### PR TITLE
Cast cpus_per_worker to integer

### DIFF
--- a/dask_kubernetes/cli/utils.py
+++ b/dask_kubernetes/cli/utils.py
@@ -124,8 +124,8 @@ def get_conf(settings, args=None):
     factor = float(conf['workers']['mem_factor'])
     conf['workers']['memory_per_worker2'] = int(factor * mem_bytes(
         conf['workers']['memory_per_worker']))
-    conf['workers']['cpus_per_worker2'] = ceil(
-        float(conf['workers']['cpus_per_worker']))
+    conf['workers']['cpus_per_worker2'] = int(ceil(
+        float(conf['workers']['cpus_per_worker'])))
     return conf
 
 


### PR DESCRIPTION
The `—nthreads` parameter for the worker is passed as an integer, causing the workers not to start correctly.

This is likely the cause for #45 as well.