### PR TITLE
Adds option to use preemptible instances

### DIFF
--- a/dask_kubernetes/cli/defaults.yaml
+++ b/dask_kubernetes/cli/defaults.yaml
@@ -6,6 +6,7 @@ cluster:
   autoscaling: False
   min_nodes: 2
   max_nodes: 32
+  preemptible: False
 jupyter:
   memory: 4096Mi
   cpus: 1

--- a/dask_kubernetes/cli/main.py
+++ b/dask_kubernetes/cli/main.py
@@ -72,12 +72,17 @@ def create(ctx, name, settings_file, set, nowait):
                 max=conf['cluster']['max_nodes']))
     else:
         autoscaling = ''
+    if conf['cluster']['preemptible']:
+        preemptible = '--preemptible'
+    else:
+        preemptible = ''
     call("gcloud container clusters create {0} --num-nodes {1} --machine-type"
-         " {2} --no-async --disk-size {3} {autoscaling} --tags=dask --scopes "
+         " {2} --no-async --disk-size {3} {autoscaling} {preemptible} --tags=dask --scopes "
          "https://www.googleapis.com/auth/cloud-platform".format(
             name, conf['cluster']['num_nodes'], conf['cluster']['machine_type'],
             conf['cluster']['disk_size'],
-            autoscaling=autoscaling))
+            autoscaling=autoscaling,
+            preemptible=preemptible))
     get_credentials(name)
     context = get_context_from_cluster(name)
     # specify label for notebook and scheduler


### PR DESCRIPTION
See #55 

This PR is a very simple fix. There's no handling of the event that an instance is pre-empted. So using this option is of course on the user's own risk. But I think it's OK, since people who know about preemptible VMs also knows the risks.