### PR TITLE
Update dockerfile to fix examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN conda install -c conda-forge nodejs
 RUN conda install -c conda-forge jupyterlab jupyter_dashboards ipywidgets \
  && jupyter labextension install @jupyter-widgets/jupyterlab-manager \
  && jupyter nbextension enable jupyter_dashboards --py --sys-prefix \
+ && jupyter nbextension enable widgetsnbextension --py --sys-prefix \
  && conda clean -tipsy
 
 RUN conda install -c bokeh bokeh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN conda install -c bokeh bokeh \
 # Optional: Install the master branch of distributed and dask
 RUN pip install git+https://github.com/dask/dask --upgrade --no-deps \
  && pip install git+https://github.com/dask/distributed --upgrade --no-deps \
- && pip install git+https://github.com/dask/gcsfs --upgrade --no-deps \
+ && pip install git+https://github.com/dask/gcsfs --upgrade \
  && pip install git+https://github.com/pydata/xarray --upgrade \
  && pip install git+https://github.com/zarr-developers/zarr --upgrade
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN conda install -c bokeh bokeh \
 # Optional: Install the master branch of distributed and dask
 RUN pip install git+https://github.com/dask/dask --upgrade --no-deps \
  && pip install git+https://github.com/dask/distributed --upgrade --no-deps \
+ && pip install git+https://github.com/dask/gcsfs --upgrade --no-deps \
  && pip install git+https://github.com/pydata/xarray --upgrade \
  && pip install git+https://github.com/zarr-developers/zarr --upgrade
 


### PR DESCRIPTION
The current image breaks when connecting to GCS (e.g. `examples/07-nyc-taxi-parquet-time-series.ipynb` cell 2). Updating to latest `dask/gcsfs` fixes it.

And the Jupyter `ipywidgets` fail to show up, so this explicitly enables them using the instructions at https://ipywidgets.readthedocs.io/en/stable/user_install.html