### PR TITLE
Use Cluster superclass in distributed.deploy to remove functionality

### DIFF
--- a/ci/environment-3.6.yml
+++ b/ci/environment-3.6.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - flake8
   - ipywidgets
-  - distributed=1.21.1
+  - distributed=1.21.3
   - dask=0.17.1
   - nomkl
   - pytest

--- a/ci/environment-3.6.yml
+++ b/ci/environment-3.6.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - flake8
   - ipywidgets
-  - distributed=1.21.3
   - dask=0.17.1
   - nomkl
   - pytest
@@ -12,3 +11,4 @@ dependencies:
   - pyyaml
   - pip:
     - kubernetes==4
+    - distributed==1.21.3

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -81,13 +81,15 @@ There are a few special environment variables that affect dask-kubernetes behavi
 
        cluster = KubeCluster()  # reads provided yaml file
 
-2.  ``DASK_KUBERNETES_DIAGNOSTICS_LINK``: a Python pre-formatted string that shows
+2.  ``DASK_DIAGNOSTICS_LINK``: a Python pre-formatted string that shows
     the location of Dask's dashboard.  This string will receive values for
     ``host``, ``port``, and all environment variables.  This is useful when
     using dask-kubernetes with JupyterHub and nbserverproxy to route the dashboard
     link to a proxied address as follows::
 
-       export DASK_KUBERNETES_DIANGOSTICS_LINK="{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
+       export DASK_DIANGOSTICS_LINK="{JUPYTERHUB_SERVICE_PREFIX}proxy/{port}/status"
+
+    This is inherited from general Dask behavior.
 
 3.  ``DASK_KUBERNETES_WORKER_NAME``: a Python pre-formatted string to use
     when naming dask worker pods. This string will receive values for ``user``,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 dask[distributed]
+distributed>=1.21.3
 kubernetes==4


### PR DESCRIPTION
This generalizes the widget and adapt work in dask-kubernetes to upstream

This is not yet mergable.  We'll have to wait for an upstream release.