### PR TITLE
Default worker template path in /etc

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -81,6 +81,9 @@ There are a few special environment variables that affect dask-kubernetes behavi
 
        cluster = KubeCluster()  # reads provided yaml file
 
+    If ``DASK_KUBERNETES_WORKER_TEMPLATE_PATH`` is not defined, :obj:`KubeCluster`
+    it will fallback to '/etc/dask/kubernetes/worker-template.yaml' if it exists.
+
 2.  ``DASK_DIAGNOSTICS_LINK``: a Python pre-formatted string that shows
     the location of Dask's dashboard.  This string will receive values for
     ``host``, ``port``, and all environment variables.  This is useful when


### PR DESCRIPTION
I find it convenient to look up for a default location for the default worker template. That makes it possible to skip one environment variable in the helm config by default.

This PR also fixes old references to `DASKERNETES_` env variables in the docstring of `KubeCluster`.