### PR TITLE
Do not pull daskdev/dask image for each test

### DIFF
--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -34,7 +34,10 @@ def ns():
 
 @pytest.fixture
 def pod_spec(image_name):
-    yield make_pod_spec(image=image_name)
+    yield make_pod_spec(
+        image=image_name,
+        extra_container_config={'imagePullPolicy': 'IfNotPresent'}
+    )
 
 
 @pytest.fixture
@@ -166,6 +169,7 @@ def test_pod_from_yaml(image_name, loop, ns):
                     "1"
                 ],
                 "image": image_name,
+                'imagePullPolicy': 'IfNotPresent',
                 "name": "dask-worker"
             }]
         }
@@ -205,6 +209,7 @@ def test_pod_from_dict(image_name, loop, ns):
                          '--death-timeout', '60'],
                 'command': None,
                 'image': image_name,
+                'imagePullPolicy': 'IfNotPresent',
                 'name': 'dask-worker',
             }]
         }
@@ -236,6 +241,7 @@ def test_pod_from_minimal_dict(image_name, loop, ns):
                          '--death-timeout', '60'],
                 'command': None,
                 'image': image_name,
+                'imagePullPolicy': 'IfNotPresent',
                 'name': 'worker'
             }]
         }

--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -31,7 +31,7 @@ def test_extra_container_config(image_name, loop):
         make_pod_spec(
             image_name,
             extra_container_config={
-                'imagePullPolicy': 'IfNotReady',
+                'imagePullPolicy': 'IfNotPresent',
                 'securityContext': {
                     'runAsUser': 0
                 }
@@ -43,7 +43,7 @@ def test_extra_container_config(image_name, loop):
 
     pod = cluster.pod_template
 
-    assert pod.spec.containers[0].image_pull_policy == 'IfNotReady'
+    assert pod.spec.containers[0].image_pull_policy == 'IfNotPresent'
     assert pod.spec.containers[0].security_context == {
         'runAsUser': 0
     }

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -36,6 +36,7 @@ Quickstart
         restartPolicy: Never
         containers:
         - image: daskdev/dask:latest
+          imagePullPolicy: IfNotPresent
           args: [dask-worker, --nthreads, '2', --no-bokeh, --memory-limit, 6GB, --death-timeout, '60']
           name: dask
           env:


### PR DESCRIPTION
The following PR tries to use `'imagePullPolicy': 'IfNotPresent'` as much as possible in the pod specs used in the tests (only those that actually spawn worker pods) so as to accelerate the speed of the tests (both on the CI and on the local machine).