### PR TITLE
Delete pending pods first when manually scaling down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,24 +4,29 @@ jobs:
   build:
     machine: true
     environment:
+      MINIKUBE_WANTUPDATENOTIFICATION: false
+      MINIKUBE_WANTREPORTERRORPROMPT: false
       CHANGE_MINIKUBE_NONE_USER: true
-    environment:
       PYTHON: "3.6"
       ENV_NAME: "dask-kubernetes-test"
+
     steps:
       - checkout
       - run:
           command: |
             curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.8.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+      # Use minikube v0.25.2 as v0.26.0 requires systemd to manage the daemons which
+      # is not available in the Ubuntu 14.04 image used by Circle CI with the
+      # "machine: true" option.
       - run:
           command: |
-            curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+            curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       - run:
           command: |
-            sudo minikube start --vm-driver=none
+            sudo -E minikube start --vm-driver=none
       - run:
           command: |
-            sudo minikube update-context
+            sudo -E minikube update-context
       - run:
           command: |
             JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until sudo kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       - run:
           command: |
-            sudo -E minikube start --vm-driver=none
+            sudo -E minikube start --vm-driver=none --extra-config=kubelet.MaxPods=20
       - run:
           command: |
             sudo -E minikube update-context

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -312,69 +312,45 @@ class KubeCluster(Cluster):
         KubeCluster.scale_up
         KubeCluster.scale_down
         """
-        pods = self.pods()
+        pods = self._cleanup_succeeded_pods(self.pods())
         if n >= len(pods):
             return self.scale_up(n, pods=pods)
         else:
-            to_close = select_workers_to_close(self.scheduler, len(pods) - n)
+            n_to_delete = len(pods) - n
+            # Before trying to close running workers, check if we can cancel
+            # pending pods (in case the kubernetes cluster was too full to
+            # provision those pods in the first place).
+            running_workers = list(self.scheduler.workers.keys())
+            running_ips = set(urlparse(worker).hostname
+                              for worker in running_workers)
+            pending_pods = [p for p in pods
+                            if p.status.pod_ip not in running_ips]
+            if pending_pods:
+                pending_to_delete = pending_pods[:n_to_delete]
+                logger.debug("Deleting pending pods: %s", pending_to_delete)
+                self._delete_pods(pending_to_delete)
+                n_to_delete = n_to_delete - len(pending_to_delete)
+                if n_to_delete <= 0:
+                    return
+
+            to_close = select_workers_to_close(self.scheduler, n_to_delete)
             logger.debug("Closing workers: %s", to_close)
-            return self.scale_down(to_close)
+            if len(to_close) < len(self.scheduler.workers):
+                # Close workers cleanly to migrate any temporary results to
+                # remaining workers.
+                future = self.scheduler.retire_workers(
+                        workers=to_close, remove=True, close_workers=True)
 
-    def scale_up(self, n, pods=None, **kwargs):
-        """
-        Make sure we have n dask-workers available for this cluster
+                def callback(future):
+                    self.scale_down(to_close)
 
-        Examples
-        --------
-        >>> cluster.scale_up(20)  # ask for twenty workers
-        """
-        pods = pods or self.pods()
+                self.scheduler.loop.add_future(future, callback)
+                return
 
-        for i in range(3):
-            try:
-                out = [
-                    self.core_api.create_namespaced_pod(self.namespace, self.pod_template)
-                    for _ in range(n - len(pods))
-                ]
-                break
-            except kubernetes.client.rest.ApiException as e:
-                if e.status == 500 and 'ServerTimeout' in e.body:
-                    logger.info("Server timeout, retry #%d", i + 1)
-                    time.sleep(1)
-                    last_exception = e
-                    continue
-                else:
-                    raise
-        else:
-            raise last_exception
+            # Terminate all pods without waiting for clean worker shutdown
+            self.scale_down(to_close)
 
-        return out
-        # fixme: wait for this to be ready before returning!
-
-    def scale_down(self, workers):
-        """
-        When the worker process exits, Kubernetes leaves the pods in a completed
-        state. Kill them when we are asked to.
-
-        Parameters
-        ----------
-        workers: List[str]
-            List of addresses of workers to close
-        """
-        # Get the existing worker pods
-        pods = self.pods()
-
-        # Work out pods that we are going to delete
-        # Each worker to delete is given in the form "tcp://<worker ip>:<port>"
-        # Convert this to a set of IPs
-        ips = set(urlparse(worker).hostname for worker in workers)
-        to_delete = [
-            p for p in pods
-            # Every time we run, purge any completed pods as well as the specified ones
-            if p.status.phase == 'Succeeded' or p.status.pod_ip in ips
-        ]
-        if not to_delete:
-            return
+    def _delete_pods(self, to_delete):
         for pod in to_delete:
             try:
                 self.core_api.delete_namespaced_pod(
@@ -387,6 +363,72 @@ class KubeCluster(Cluster):
                 # If a pod has already been removed, just ignore the error
                 if e.status != 404:
                     raise
+
+    def _cleanup_succeeded_pods(self, pods):
+        terminated_pods = [p for p in pods if p.status.phase == 'Succeeded']
+        self._delete_pods(terminated_pods)
+        return [p for p in pods if p.status.phase != 'Succeeded']
+
+    def scale_up(self, n, pods=None, **kwargs):
+        """
+        Make sure we have n dask-workers available for this cluster
+
+        Examples
+        --------
+        >>> cluster.scale_up(20)  # ask for twenty workers
+        """
+        pods = pods or self._cleanup_succeeded_pods(self.pods())
+        to_create = n - len(pods)
+        new_pods = []
+        for i in range(3):
+            try:
+                for _ in range(to_create):
+                    new_pods.append(self.core_api.create_namespaced_pod(
+                        self.namespace, self.pod_template))
+                    to_create -= 1
+                break
+            except kubernetes.client.rest.ApiException as e:
+                if e.status == 500 and 'ServerTimeout' in e.body:
+                    logger.info("Server timeout, retry #%d", i + 1)
+                    time.sleep(1)
+                    last_exception = e
+                    continue
+                else:
+                    raise
+        else:
+            raise last_exception
+
+        return new_pods
+        # fixme: wait for this to be ready before returning!
+
+    def scale_down(self, workers, pods=None):
+        """ Remove the pods for the requested list of workers
+
+        When scale_down is called by the _adapt async loop, the workers are
+        assumed to have been cleanly closed first and in-memory data has been
+        migrated to the remaining workers.
+
+        Note that when the worker process exits, Kubernetes leaves the pods in
+        a 'Succeeded' state that we collect here.
+
+        If some workers have not been closed, we just delete the pods with
+        matching ip addresses.
+
+        Parameters
+        ----------
+        workers: List[str] List of addresses of workers to close
+        """
+        # Get the existing worker pods
+        pods = pods or self._cleanup_succeeded_pods(self.pods())
+
+        # Work out the list of pods that we are going to delete
+        # Each worker to delete is given in the form "tcp://<worker ip>:<port>"
+        # Convert this to a set of IPs
+        ips = set(urlparse(worker).hostname for worker in workers)
+        to_delete = [p for p in pods if p.status.pod_ip in ips]
+        if not to_delete:
+            return
+        self._delete_pods(to_delete)
 
     def __enter__(self):
         return self
@@ -440,15 +482,16 @@ def _namespace_default():
     return 'default'
 
 
-def select_workers_to_close(s, n):
-    """ Select n workers to close from scheduler s """
-    assert n <= len(s.workers)
+def select_workers_to_close(scheduler, n_to_close):
+    """ Select n workers to close from scheduler """
+    workers = list(scheduler.workers.values())
+    assert n_to_close <= len(workers)
     key = lambda ws: ws.info['memory']
-    to_close = set(sorted(s.idle, key=key)[:n])
+    to_close = set(sorted(scheduler.idle, key=key)[:n_to_close])
 
-    if len(to_close) < n:
-        rest = sorted(s.workers.values(), key=key, reverse=True)
-        while len(to_close) < n:
+    if len(to_close) < n_to_close:
+        rest = sorted(workers, key=key, reverse=True)
+        while len(to_close) < n_to_close:
             to_close.add(rest.pop())
 
     return [ws.address for ws in to_close]


### PR DESCRIPTION
When scaling down a cluster with pending pods still being provisioned in the background, one can often get an `AssertionError` in  `select_workers_to_close`. Furthermore, running workers are deleted before pending pods have a chance to get up and running when using a saturated shared kubernetes cluster. This trashes intermediate computation results for no valid reason and makes everything much slower than necessary.

This PR fixes all of that by always trying to scale down non-running pods first. Furthermore, we now explicitly scale down running pods by first scheduling `self.scheduler.retire_workers` in the event loop to make sure that we have the time to migrate intermediate results back to the remaining running workers.

I have added (stress) tests for all the above.

`test_scale_down_pending` can be quite slow when running on a cluster that allows for 20+ pods. #67 can accelerate by 30% the execution of that test (from 30s to 20s on my laptop).