### PR TITLE
Add maximum number of workers limit

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -381,6 +381,8 @@ class KubeCluster(Cluster):
         --------
         >>> cluster.scale_up(20)  # ask for twenty workers
         """
+        if 'kubernetes-maximum-workers' in config:
+            n = min(n, config['kubernetes-maximum-workers'])
         pods = pods or self._cleanup_succeeded_pods(self.pods())
         to_create = n - len(pods)
         new_pods = []

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -382,7 +382,10 @@ class KubeCluster(Cluster):
         >>> cluster.scale_up(20)  # ask for twenty workers
         """
         if 'kubernetes-maximum-workers' in config:
-            n = min(n, config['kubernetes-maximum-workers'])
+            mx = config['kubernetes-maximum-workers']
+            if mx < n:
+                logger.info("Tried to scale beyond maximum number of workers: %d", n)
+                n = mx
         pods = pods or self._cleanup_succeeded_pods(self.pods())
         to_create = n - len(pods)
         new_pods = []

--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -439,6 +439,19 @@ def test_automatic_startup(image_name, loop, ns):
                 assert cluster.pod_template.metadata.labels['foo'] == 'bar'
 
 
+def test_maximum(cluster):
+    with set_config(**{'kubernetes-maximum-workers': 1}):
+        cluster.scale(10)
+
+        start = time()
+        while len(cluster.scheduler.workers) <= 0:
+            sleep(0.1)
+            assert time() < start + 60
+
+        sleep(0.5)
+        assert len(cluster.scheduler.workers) == 1
+
+
 def test_repr(cluster):
     for text in [repr(cluster), str(cluster)]:
         assert 'Box' not in text


### PR DESCRIPTION
This allows the maximum number of workers to be controled with the following
environment variable

    export DASK_KUBERNETES_MAXIMUM_WORKERS=20

or the following config value

    kubernetes-maximum-workers: 20

@TomAugspurger this may interest you