### PR TITLE
Update logs to make specifying a pod optional

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -327,7 +327,7 @@ class KubeCluster(Cluster):
         Client.get_worker_logs
         """
         if pod is None:
-            return [self.logs(pod for pod in self.pods())]
+            return {pod.status.pod_ip: self.logs(pod) for pod in self.pods()}
 
         return self.core_api.read_namespaced_pod_log(pod.metadata.name,
                                                      pod.metadata.namespace)

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -29,7 +29,7 @@ class KubeCluster(Cluster):
 
     This starts a local Dask scheduler and then dynamically launches
     Dask workers on a Kubernetes cluster. The Kubernetes cluster is taken
-    to be either the current one on which this code is running, or as a 
+    to be either the current one on which this code is running, or as a
     fallback, the default one configured in a kubeconfig file.
 
     **Environments**
@@ -308,10 +308,13 @@ class KubeCluster(Cluster):
             label_selector=format_labels(self.pod_template.metadata.labels)
         ).items
 
-    def logs(self, pod):
+    def logs(self, pod=None):
         """ Logs from a worker pod
 
         You can get this pod object from the ``pods`` method.
+
+        If no pod is specified all pod logs will be returned. On large clusters
+        this could end up being rather large.
 
         Parameters
         ----------
@@ -323,6 +326,9 @@ class KubeCluster(Cluster):
         KubeCluster.pods
         Client.get_worker_logs
         """
+        if pod is None:
+            return [self.logs(pod for pod in self.pods())]
+
         return self.core_api.read_namespaced_pod_log(pod.metadata.name,
                                                      pod.metadata.namespace)
 

--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -85,6 +85,11 @@ def test_logs(cluster):
     logs = cluster.logs(a)
     assert 'distributed.worker' in logs
 
+    logs = cluster.logs()
+    assert len(logs) == 2
+    for pod in logs:
+        assert 'distributed.worker' in logs[pod]
+
 
 def test_ipython_display(cluster):
     ipywidgets = pytest.importorskip('ipywidgets')


### PR DESCRIPTION
Partially addresses #56.

This PR updated the `KubeCluster.logs()` method to make the `pod` kwarg optional. Now if you omit the kwarg it will return you a dictionary of logs by pod IP.