### PR TITLE
Add flag to block until scaling finishes

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -333,7 +333,7 @@ class KubeCluster(Cluster):
         return self.core_api.read_namespaced_pod_log(pod.metadata.name,
                                                      pod.metadata.namespace)
 
-    def scale(self, n):
+    def scale(self, n, wait=False):
         """ Scale cluster to n workers
 
         Parameters
@@ -341,9 +341,13 @@ class KubeCluster(Cluster):
         n: int
             Target number of workers
 
+        wait: bool
+            Flag to wait for the scaling to happen before returning
+
         Example
         -------
         >>> cluster.scale(10)  # scale cluster to ten workers
+        >>> cluster.scale(10, wait=True)  # scale and block until workers are connected
 
         See Also
         --------
@@ -387,6 +391,10 @@ class KubeCluster(Cluster):
 
             # Terminate all pods without waiting for clean worker shutdown
             self.scale_down(to_close)
+
+        if wait:
+            while len(self.scheduler.workers) != n:
+                time.sleep(0.1)
 
     def _delete_pods(self, to_delete):
         for pod in to_delete:

--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -414,6 +414,13 @@ def test_scale_down_pending(cluster, client):
         assert time() < start + 60
 
 
+def test_scale_wait(cluster, client):
+    cluster.scale(3, wait=True)
+    assert len(cluster.scheduler.workers) == 3
+
+    cluster.scale(2, wait=True)
+    assert len(cluster.scheduler.workers) == 2
+
 def test_automatic_startup(image_name, loop, ns):
     test_yaml = {
         "kind": "Pod",


### PR DESCRIPTION
Sometimes I've found that I want to create a cluster but wait for it to scale to the desired size before starting to execute work on it.

This PR adds a `wait` flag which allows users to tell the `KubeCluster.scale()` method to block until scaling completes.