### PR TITLE
Fix broken worker-template configuration

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -148,7 +148,6 @@ class KubeCluster(Cluster):
             env=None,
             **kwargs
     ):
-        pod_template = pod_template or dask.config.get('kubernetes.worker-template')
         name = name or dask.config.get('kubernetes.name')
         namespace = namespace or dask.config.get('kubernetes.namespace')
         n_workers = n_workers if n_workers is not None else dask.config.get('kubernetes.count.start')

--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -261,6 +261,14 @@ def test_pod_from_minimal_dict(image_name, loop, ns):
             assert result == 11
 
 
+def test_pod_template_from_conf():
+    spec = {'spec': {'containers': [{'name': 'some-name'}]}}
+
+    with dask.config.set({'kubernetes.worker-template': spec}):
+        with KubeCluster() as cluster:
+            assert cluster.pod_template.spec.containers[0].name == 'some-name'
+
+
 def test_bad_args(loop):
     with pytest.raises(TypeError) as info:
         KubeCluster('myfile.yaml')


### PR DESCRIPTION
I believe #75 broke reading pod template from `kubernetes.worker-template`.

If `kubernetes.worker-template` is set, `pod_template` becomes a truthy value (by the line I removed), and the following code will never run:
https://github.com/dask/dask-kubernetes/blob/c4728ba4ecf87c175f3b2020f3ffb0a91860b6d0/dask_kubernetes/core.py#L159-L161

Later on, since `make_pod_from_dict` was never called, the following code will raise an exception since `pod_template` at this point is still a `dict`.
https://github.com/dask/dask-kubernetes/blob/c4728ba4ecf87c175f3b2020f3ffb0a91860b6d0/dask_kubernetes/core.py#L193