### PR TITLE
Exclude failed pods from list of pods

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -395,7 +395,12 @@ class KubeCluster(Cluster):
                     self.namespace,
                     kubernetes.client.V1DeleteOptions()
                 )
-                logger.info('Deleted pod: %s', pod.metadata.name)
+                pod_info = pod.metadata.name
+                if pod.status.reason:
+                    pod_info += ' [{}]'.format(pod.status.reason)
+                if pod.status.message:
+                    pod_info += ' {}'.format(pod.status.message)
+                logger.info('Deleted pod: %s', pod_info)
             except kubernetes.client.rest.ApiException as e:
                 # If a pod has already been removed, just ignore the error
                 if e.status != 404:


### PR DESCRIPTION
Digging a bit deeper into #90, I think I found the issue.

So I started 6 workers, one of them got evicted, and then my logs got flooded with
```
2018-08-03 08:24:50 [INFO] distributed.deploy.adaptive: CPU limit exceeded [132485 occupancy / 5 cores]
2018-08-03 08:24:50 [INFO] distributed.deploy.adaptive: Scaling up to 6 workers
```
This is the status of my evicted pod: 
```
"status": {
    "message": "The node was low on resource: memory.",
    "phase": "Failed",
    "reason": "Evicted",
    "startTime": "2018-08-05T11:29:55Z"
}
```
It seems to be that failed pods are not excluded in the podlist, only Successful pods are. So `to_create` in `scale_up` ends up being 0.

The simple fix is the one attached, but maybe more changes should be made.
- Should we cleanup failed pods?
- Should `_cleanup_succeeded_pods` be renamed?
- Do you have some other fix in mind?