### PR TITLE
expand environment variables in pod specs

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -157,6 +157,7 @@ class KubeCluster(Cluster):
 
         if not pod_template and dask.config.get('kubernetes.worker-template', None):
             d = dask.config.get('kubernetes.worker-template')
+            d = dask.config.expand_environment_variables(d)
             pod_template = make_pod_from_dict(d)
 
         if not pod_template and dask.config.get('kubernetes.worker-template-path', None):
@@ -165,6 +166,7 @@ class KubeCluster(Cluster):
             fn = fn.format(**os.environ)
             with open(fn) as f:
                 d = yaml.safe_load(f)
+            d = dask.config.expand_environment_variables(d)
             pod_template = make_pod_from_dict(d)
 
         if not pod_template:
@@ -275,6 +277,7 @@ class KubeCluster(Cluster):
             raise ImportError("PyYaml is required to use yaml functionality, please install it!")
         with open(yaml_path) as f:
             d = yaml.safe_load(f)
+            d = dask.config.expand_environment_variables(d)
             return cls.from_dict(d, **kwargs)
 
     @property


### PR DESCRIPTION
closes #92

I've taken the minimal distruption path here. Only environment variables in the pod spec are expanded. Two other ways this could be done include:

1. expand environment variables in the config.py module. This would only work for variables set in the dask configuration files, not for the worker spec yaml. This would open up the option of expanding environment variables other than the ones in the pod spec. I don't need this at the moment but it may be worth considering.
1. in the `make_pod_from_dict` function (in objects.py). This would further tie the behavior to just expanding variables to the pod spec, and nothing else.

cc @jacobtomlinson and @mrocklin 

xref: https://github.com/dask/dask/pull/3893