### PR TITLE
Pass through return value from close

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -485,10 +485,10 @@ class KubeCluster(Cluster):
     def __enter__(self):
         return self
 
-    def close(self):
+    def close(self, **kwargs):
         """ Close this cluster """
         self.scale_down(self.cluster.scheduler.workers)
-        self.cluster.close()
+        return self.cluster.close(**kwargs)
 
     def __exit__(self, type, value, traceback):
         _cleanup_pods(self.namespace, self.pod_template.metadata.labels)


### PR DESCRIPTION
This enables dask_kubernetes to close clusters asynchronously

    await cluster.close()

This follows on to https://github.com/dask/distributed/pull/2437