### PR TITLE
Add usage example to quickstart

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -61,6 +61,8 @@ Quickstart
 .. code-block:: python
 
         # Example usage
+        import distributed
+        import dask.array as da
 
         # Connect dask to the cluster
         client = distributed.Client(cluster)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -58,6 +58,17 @@ Quickstart
               cpu: "2"
               memory: 6G
 
+.. code-block:: python
+
+        # Example usage
+
+        # Connect dask to the cluster
+        client = distributed.Client(cluster)
+
+        # Create an array and calculate the mean
+        array = da.ones((1000, 1000, 1000), chunks=(100, 100, 10))
+        print(array.mean().compute())  # Should print 1.0
+
 
 Best Practices
 --------------


### PR DESCRIPTION
In response to dask/dask-kubernetes#121 I've added a quick start example for using the cluster.