### PR TITLE
Add widgets for logs

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -21,6 +21,7 @@ from tornado import gen
 
 from .objects import make_pod_from_dict, clean_pod_template
 from .auth import ClusterAuth
+from .logs import Log, Logs
 
 logger = logging.getLogger(__name__)
 
@@ -334,10 +335,10 @@ class KubeCluster(Cluster):
         Client.get_worker_logs
         """
         if pod is None:
-            return {pod.status.pod_ip: self.logs(pod) for pod in self.pods()}
+            return Logs({pod.status.pod_ip: self.logs(pod) for pod in self.pods()})
 
-        return self.core_api.read_namespaced_pod_log(pod.metadata.name,
-                                                     pod.metadata.namespace)
+        return Log(self.core_api.read_namespaced_pod_log(pod.metadata.name,
+                                                         pod.metadata.namespace))
 
     def scale(self, n):
         """ Scale cluster to n workers

--- a/dask_kubernetes/logs.py
+++ b/dask_kubernetes/logs.py
@@ -1,0 +1,28 @@
+class Log(str):
+    """A container for logs."""
+
+    def _widget(self):
+        from ipywidgets import HTML
+        return HTML(
+            value="<pre><code>{logs}</code></pre>".format(logs=self)
+        )
+
+    def _ipython_display_(self, **kwargs):
+        return self._widget()._ipython_display_(**kwargs)
+
+
+class Logs(dict):
+    """A container for multiple logs."""
+
+    def _widget(self):
+        from ipywidgets import Accordion
+        accordion = Accordion(children=[log._widget() for log in self.values()])
+        [accordion.set_title(i, title) for i, title in enumerate(self.keys())]
+        return accordion
+
+    def _ipython_display_(self, **kwargs):
+        return self._widget()._ipython_display_(**kwargs)
+
+
+
+


### PR DESCRIPTION
Add a couple of new log classes which extend `str` and `dict` to add some ipywidgets. This is aimed to make viewing logs easier.

Each log is a string which is rendered as a `<code>` block in an `HTML` widget. Then all logs are a dictionary of the log strings wrapped in an accordion view.

### Before
![image](https://user-images.githubusercontent.com/1610850/56971476-36637c00-6b61-11e9-82c0-ca547a4ab74f.png)

### After
![image](https://user-images.githubusercontent.com/1610850/56971497-44190180-6b61-11e9-85e9-0c3d9279f8f1.png)

Would appreciate some pointers on testing ipywidgets stuff.