### PR TITLE
Stop scale up from returning pods

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -452,7 +452,7 @@ class KubeCluster(Cluster):
         else:
             raise last_exception
 
-        return new_pods
+        return
         # fixme: wait for this to be ready before returning!
 
     def scale_down(self, workers, pods=None):

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -358,7 +358,7 @@ class KubeCluster(Cluster):
         """
         pods = self._cleanup_terminated_pods(self.pods())
         if n >= len(pods):
-            return self.scale_up(n, pods=pods)
+            return
         else:
             n_to_delete = len(pods) - n
             # Before trying to close running workers, check if we can cancel
@@ -452,6 +452,7 @@ class KubeCluster(Cluster):
         else:
             raise last_exception
 
+        return
         # fixme: wait for this to be ready before returning!
 
     def scale_down(self, workers, pods=None):

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -452,7 +452,6 @@ class KubeCluster(Cluster):
         else:
             raise last_exception
 
-        return
         # fixme: wait for this to be ready before returning!
 
     def scale_down(self, workers, pods=None):


### PR DESCRIPTION
Fixes #140.

It seems to be unnecessary to return the list of pod objects which were created by the scale up operation. It results in a dictionary of pods being blurted into your notebook when calling `scale` or `scale_up`.