### PR TITLE
Default affinity

### DIFF
--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -180,7 +180,7 @@ def make_pod_from_dict(dict_):
     )
 
 
-def clean_pod_template(pod_template):
+def clean_pod_template(pod_template, match_node_purpose='prefer'):
     """ Normalize pod template and check for type errors """
     if isinstance(pod_template, str):
         msg = ('Expected a kubernetes.client.V1Pod object, got %s'
@@ -229,26 +229,56 @@ def clean_pod_template(pod_template):
     else:
         pod_template.spec.tolerations.extend(tolerations)
 
-    affinity = client.V1PreferredSchedulingTerm(
-        weight=100,
-        preference=client.V1NodeSelectorTerm(
+    # add default node affinity to k8s.dask.org/node-purpose=worker
+    if match_node_purpose is not "ignore":
+        # for readability
+        affinity = pod_template.spec.affinity
+
+        if affinity is None:
+            affinity = client.V1Affinity()
+        if affinity.node_affinity is None:
+            affinity.node_affinity = client.V1NodeAffinity()
+
+        # a common object for both a preferred and a required node affinity
+        node_selector_term = client.V1NodeSelectorTerm(
             match_expressions=[
                 client.V1NodeSelectorRequirement(
-                    key='k8s.dask.org/node-purpose',
-                    operator='In',
-                    values=['worker']
+                    key="k8s.dask.org/node-purpose", operator="In", values=["worker"]
                 )
             ]
         )
-    )
-    
-    if pod_template.spec.affinity is None:
-        pod_template.spec.affinity = client.V1Affinity(
-                node_affinity=client.V1PodAntiAffinity(
-                    preferred_during_scheduling_ignored_during_execution=[affinity]
+
+        if match_node_purpose == "require":
+            if (
+                affinity.node_affinity.required_during_scheduling_ignored_during_execution
+                is None
+            ):
+                affinity.node_affinity.required_during_scheduling_ignored_during_execution = client.V1NodeSelector(
+                    node_selector_terms=[]
                 )
+            affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms.append(
+                node_selector_term
             )
-    else:
-        print('TODO: need to handle the various partial states here')
+        elif match_node_purpose == "prefer":
+            if (
+                affinity.node_affinity.preferred_during_scheduling_ignored_during_execution
+                is None
+            ):
+                affinity.node_affinity.preferred_during_scheduling_ignored_during_execution = (
+                    []
+                )
+            preferred_scheduling_terms = [
+                client.V1PreferredSchedulingTerm(
+                    preference=node_selector_term, weight=100
+                )
+            ]
+            affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.extend(
+                preferred_scheduling_terms
+            )
+        else:
+            raise ValueError(
+                'Attribute must be one of "ignore", "prefer", or "require".'
+            )
+        pod_template.spec.affinity = affinity
 
     return pod_template

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -230,7 +230,7 @@ def clean_pod_template(pod_template):
         pod_template.spec.tolerations.extend(tolerations)
 
     affinity = client.V1PreferredSchedulingTerm(
-        weight=1,
+        weight=100,
         preference=client.V1NodeSelectorTerm(
             match_expressions=[
                 client.V1NodeSelectorRequirement(

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -229,4 +229,22 @@ def clean_pod_template(pod_template):
     else:
         pod_template.spec.tolerations.extend(tolerations)
 
+    pod_template.spec.affinity = client.V1Affinity(
+        pod_affinity=client.V1PodAntiAffinity(
+            preferred_during_scheduling_ignored_during_execution=[
+                client.V1WeightedPodAffinityTerm(
+                    weight=1,
+                    pod_affinity_term=client.V1PodAffinityTerm(
+                        topology_key="k8s.dask.org/node-purpose",
+                        label_selector=client.V1LabelSelector(
+                            match_labels=dict(
+                                component='worker'
+                            )
+                        )
+                    )
+                )
+            ]
+        )
+    )
+
     return pod_template

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -229,25 +229,26 @@ def clean_pod_template(pod_template):
     else:
         pod_template.spec.tolerations.extend(tolerations)
 
-    affinity = client.V1WeightedPodAffinityTerm(
+    affinity = client.V1PreferredSchedulingTerm(
         weight=1,
-        pod_affinity_term=client.V1PodAffinityTerm(
-            topology_key="k8s.dask.org/node-purpose",
-            label_selector=client.V1LabelSelector(
-                match_labels=dict(
-                    component='worker'
+        preference=client.V1NodeSelectorTerm(
+            match_expressions=[
+                client.V1NodeSelectorRequirement(
+                    key='k8s.dask.org/node-purpose',
+                    operator='In',
+                    values=['worker']
                 )
-            )
+            ]
         )
     )
-
+    
     if pod_template.spec.affinity is None:
         pod_template.spec.affinity = client.V1Affinity(
-            pod_affinity=client.V1PodAntiAffinity(
-                preferred_during_scheduling_ignored_during_execution=[affinity]
+                node_affinity=client.V1PodAntiAffinity(
+                    preferred_during_scheduling_ignored_during_execution=[affinity]
+                )
             )
-        )
     else:
-        pod_template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.append(affinity)
+        print('TODO: need to handle the various partial states here')
 
     return pod_template

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -229,22 +229,25 @@ def clean_pod_template(pod_template):
     else:
         pod_template.spec.tolerations.extend(tolerations)
 
-    pod_template.spec.affinity = client.V1Affinity(
-        pod_affinity=client.V1PodAntiAffinity(
-            preferred_during_scheduling_ignored_during_execution=[
-                client.V1WeightedPodAffinityTerm(
-                    weight=1,
-                    pod_affinity_term=client.V1PodAffinityTerm(
-                        topology_key="k8s.dask.org/node-purpose",
-                        label_selector=client.V1LabelSelector(
-                            match_labels=dict(
-                                component='worker'
-                            )
-                        )
-                    )
+    affinity = client.V1WeightedPodAffinityTerm(
+        weight=1,
+        pod_affinity_term=client.V1PodAffinityTerm(
+            topology_key="k8s.dask.org/node-purpose",
+            label_selector=client.V1LabelSelector(
+                match_labels=dict(
+                    component='worker'
                 )
-            ]
+            )
         )
     )
+
+    if pod_template.spec.affinity is None:
+        pod_template.spec.affinity = client.V1Affinity(
+            pod_affinity=client.V1PodAntiAffinity(
+                preferred_during_scheduling_ignored_during_execution=[affinity]
+            )
+        )
+    else:
+        pod_template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution.append(affinity)
 
     return pod_template

--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -628,20 +628,15 @@ def test_default_toleration_preserved(image_name):
 
 def test_default_affinity(clean_pod_spec):
     affinity = clean_pod_spec.to_dict()['spec']['affinity']
+
     assert {
-        'preferred_during_scheduling_ignored_during_execution': [{
-            'preference': {
-                'match_expressions': [{
-                    'key': 'k8s.dask.org/node-purpose',
-                    'operator': 'In',
-                    'values': ['worker']
-                }],
-                'match_fields': None
-            },
-            'weight': 100
-        }],
-        'required_during_scheduling_ignored_during_execution': None
-    } in affinity['node_affinity']
+        'key': 'k8s.dask.org/node-purpose',
+        'operator': 'In',
+        'values': ['worker']
+    } in affinity['node_affinity']['preferred_during_scheduling_ignored_during_execution'][0]['preference']['match_expressions']
+    assert affinity['node_affinity']['preferred_during_scheduling_ignored_during_execution'][0]['weight'] == 100
+    assert affinity['node_affinity']['required_during_scheduling_ignored_during_execution'] is None
+    assert affinity['pod_affinity'] is None
 
 
 def test_auth_missing(pod_spec, ns, loop):

--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -626,6 +626,24 @@ def test_default_toleration_preserved(image_name):
     } in tolerations
 
 
+def test_default_affinity(clean_pod_spec):
+    affinity = clean_pod_spec.to_dict()['spec']['affinity']
+    assert {
+        'preferred_during_scheduling_ignored_during_execution': [{
+            'preference': {
+                'match_expressions': [{
+                    'key': 'k8s.dask.org/node-purpose',
+                    'operator': 'In',
+                    'values': ['worker']
+                }],
+                'match_fields': None
+            },
+            'weight': 100
+        }],
+        'required_during_scheduling_ignored_during_execution': None
+    } in affinity['node_affinity']
+
+
 def test_auth_missing(pod_spec, ns, loop):
     with pytest.raises(kubernetes.config.ConfigException) as info:
         KubeCluster(pod_spec, auth=[], loop=loop, namespace=ns)


### PR DESCRIPTION
At this point, this is for illustration purposes only. It builds on #145 and gives #146 a try. By default, this now creates dask-worker pods with the following affinity and tolerations:

```yaml
spec:
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - preference:
          matchExpressions:
          - key: k8s.dask.org/node-purpose
            operator: In
            values:
            - worker
        weight: 100
  tolerations:
  - effect: NoSchedule
    key: k8s.dask.org/dedicated
    operator: Equal
    value: worker
  - effect: NoSchedule
    key: k8s.dask.org_dedicated
    operator: Equal
    value: worker
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
```

If my understanding is correct: A kubernetes cluster / node-pool with the following labels/taints should attract and accept dask-workers with this spec.

labels:
 - `k8s.dask.org/node-purpose : worker`

taints:
- `k8s.dask.org/dedicated=worker`
- `k8s.dask.org_dedicated=worker`

I should note that I have a node-pool with these options set and my dask-workers are not landing in the desired place yet so I'm probably still missing at least one piece of the puzzle. 