### PR TITLE
[CLOSE] Add default node affinity (Duplicate of #147)

### DIFF
--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -180,7 +180,7 @@ def make_pod_from_dict(dict_):
     )
 
 
-def clean_pod_template(pod_template):
+def clean_pod_template(pod_template, match_node_purpose="prefer"):
     """ Normalize pod template and check for type errors """
     if isinstance(pod_template, str):
         msg = ('Expected a kubernetes.client.V1Pod object, got %s'
@@ -228,5 +228,42 @@ def clean_pod_template(pod_template):
         pod_template.spec.tolerations = tolerations
     else:
         pod_template.spec.tolerations.extend(tolerations)
+
+    # add default node affinity to k8s.dask.org/node-purpose=worker
+    if match_node_purpose is not "ignore":
+        # for readability
+        affinity = pod_template.spec.affinity
+
+        if affinity is None:
+            affinity = client.V1Affinity()
+        if affinity.node_affinity is None:
+            affinity.node_affinity = client.V1NodeAffinity()
+
+        # a common object for both a preferred and a required node affinity
+        node_selector_term = client.V1NodeSelectorTerm(
+            match_expressions=[client.V1NodeSelectorRequirement(
+                key="k8s.dask.org/node-purpose",
+                operator="Equal",
+                values=["worker"],
+            )]
+        )
+
+        if match_node_purpose == "require":
+            if affinity.node_affinity.required_during_scheduling_ignored_during_execution is None:
+                affinity.node_affinity.required_during_scheduling_ignored_during_execution = client.V1NodeSelector(
+                    node_selector_terms=[]
+                )
+            affinity.node_affinity.required_during_scheduling_ignored_during_execution.node_selector_terms.append(node_selector_term)
+        elif match_node_purpose == "prefer":
+            if affinity.node_affinity.preferred_during_scheduling_ignored_during_execution is None:
+                affinity.node_affinity.preferred_during_scheduling_ignored_during_execution = []
+            preferred_scheduling_terms = [client.V1PreferredSchedulingTerm(
+                preference=node_selector_term,
+                weight=100,
+            )]
+            affinity.node_affinity.preferred_during_scheduling_ignored_during_execution.extend(preferred_scheduling_terms)
+        else:
+            raise ValueError('Attribute must be one of "ignore", "prefer", or "require".')
+        pod_template.spec.affinity = affinity
 
     return pod_template


### PR DESCRIPTION
## UPDATE
I failed to notice the PR #147 attempting the same thing when I got working on this. Feel free to straight up close or copy/paste/edit parts.

---

This PR is meant to close #146 by adding a default preference for nodes with a `k8s.dask.org/node-purpose=worker` label, and optionally make the worker pods require scheduling there.

I struggled with getting my tests to run locally, so I figured I'll start by submitting this PR as a WIP.

/cc: @jhamman 