### PR TITLE
Stop scale up from returning pods (continues #143)

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -452,7 +452,7 @@ class KubeCluster(Cluster):
         else:
             raise last_exception
 
-        return new_pods
+        return
         # fixme: wait for this to be ready before returning!
 
     def scale_down(self, workers, pods=None):

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -86,7 +86,7 @@ class KubeCluster(Cluster):
     ...                          cpu_limit=1, cpu_request=1,
     ...                          env={'EXTRA_PIP_PACKAGES': 'fastparquet git+https://github.com/dask/distributed'})
     >>> cluster = KubeCluster(pod_spec)
-    >>> cluster.scale_up(10)
+    >>> cluster.scale(10)
 
     You can also create clusters with worker pod specifications as dictionaries
     or stored in YAML files
@@ -358,6 +358,7 @@ class KubeCluster(Cluster):
         """
         pods = self._cleanup_terminated_pods(self.pods())
         if n >= len(pods):
+            self.scale_up(n, pods=pods)
             return
         else:
             n_to_delete = len(pods) - n
@@ -451,9 +452,6 @@ class KubeCluster(Cluster):
                     raise
         else:
             raise last_exception
-
-        return
-        # fixme: wait for this to be ready before returning!
 
     def scale_down(self, workers, pods=None):
         """ Remove the pods for the requested list of workers

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -358,7 +358,7 @@ class KubeCluster(Cluster):
         """
         pods = self._cleanup_terminated_pods(self.pods())
         if n >= len(pods):
-            return self.scale_up(n, pods=pods)
+            return
         else:
             n_to_delete = len(pods) - n
             # Before trying to close running workers, check if we can cancel
@@ -452,6 +452,7 @@ class KubeCluster(Cluster):
         else:
             raise last_exception
 
+        return
         # fixme: wait for this to be ready before returning!
 
     def scale_down(self, workers, pods=None):

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -452,7 +452,6 @@ class KubeCluster(Cluster):
         else:
             raise last_exception
 
-        return
         # fixme: wait for this to be ready before returning!
 
     def scale_down(self, workers, pods=None):


### PR DESCRIPTION
Fixes #140. Closes #143 

From @jacobtomlinson's PR - It seems to be unnecessary to return the list of pod objects which were created by the scale up operation. It results in a dictionary of pods being blurted into your notebook when calling scale or scale_up.

This PR just fixes a little bug in the logic for `scale_up`. 