### PR TITLE
skip if no ipywidgets

### DIFF
--- a/dask_kubernetes/tests/test_core.py
+++ b/dask_kubernetes/tests/test_core.py
@@ -132,6 +132,7 @@ def test_dask_worker_name_env_variable(pod_spec, loop, ns):
 
 def test_diagnostics_link_env_variable(pod_spec, loop, ns):
     pytest.importorskip("bokeh")
+    pytest.importorskip("ipywidgets")
     with dask.config.set({"distributed.dashboard.link": "foo-{USER}-{port}"}):
         with KubeCluster(pod_spec, loop=loop, namespace=ns) as cluster:
             port = cluster.scheduler.services["bokeh"].port


### PR DESCRIPTION
Failed locally with 

```pytb
======================================================================== FAILURES =========================================================================___________________________________________________________ test_diagnostics_link_env_variable ____________________________________________________________
pod_spec = {'api_version': None,
 'kind': None,
 'metadata': {'annotations': None,
              'cluster_name': None,
          ...  'termination_grace_period_seconds': None,
          'tolerations': None,
          'volumes': None},
 'status': None}
loop = <tornado.platform.asyncio.AsyncIOLoop object at 0x1196e86a0>, ns = 'test-dask-kubernetesae2a0756-1'

    def test_diagnostics_link_env_variable(pod_spec, loop, ns):
        pytest.importorskip("bokeh")
        with dask.config.set({"distributed.dashboard.link": "foo-{USER}-{port}"}):
            with KubeCluster(pod_spec, loop=loop, namespace=ns) as cluster:
                port = cluster.scheduler.services["bokeh"].port
>               cluster._ipython_display_()

dask_kubernetes/tests/test_core.py:138:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _../../miniconda3/envs/dask-kubernetes-dev/lib/python3.7/site-packages/distributed/deploy/cluster.py:217: in _ipython_display_
    return self._widget()._ipython_display_(**kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = KubeCluster("tcp://192.168.7.20:60847", workers=0)

    def _widget(self):
        """ Create IPython widget for display within a notebook """
        try:
            return self._cached_widget
        except AttributeError:
            pass

>       from ipywidgets import Layout, VBox, HBox, IntText, Button, HTML, Accordion
E       ModuleNotFoundError: No module named 'ipywidgets'

../../miniconda3/envs/dask-kubernetes-dev/lib/python3.7/site-packages/distributed/deploy/cluster.py:153: ModuleNotFoundError
```

before installing ipywidgets.