### PR TITLE
Pass port to local scheduler

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -479,6 +479,7 @@ class KubeCluster(SpecCluster):
                     "protocol": self._protocol,
                     "interface": self._interface,
                     "host": self.host,
+                    "port": self.port,
                     "dashboard_address": self._dashboard_address,
                     "security": self.security,
                 },

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -328,10 +328,12 @@ async def test_pod_from_dict(image_name, ns):
         },
     }
 
-    async with KubeCluster.from_dict(spec, namespace=ns, port=32000, **cluster_kwargs) as cluster:
+    async with KubeCluster.from_dict(
+        spec, namespace=ns, port=32000, **cluster_kwargs
+    ) as cluster:
         cluster.scale(2)
         await cluster
-        assert '32000' in cluster.scheduler_address
+        assert "32000" in cluster.scheduler_address
         async with Client(cluster, asynchronous=True) as client:
             future = client.submit(lambda x: x + 1, 10)
             result = await future

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -328,9 +328,10 @@ async def test_pod_from_dict(image_name, ns):
         },
     }
 
-    async with KubeCluster.from_dict(spec, namespace=ns, **cluster_kwargs) as cluster:
+    async with KubeCluster.from_dict(spec, namespace=ns, port=32000, **cluster_kwargs) as cluster:
         cluster.scale(2)
         await cluster
+        assert '32000' in cluster.scheduler_address
         async with Client(cluster, asynchronous=True) as client:
             future = client.submit(lambda x: x + 1, 10)
             result = await future


### PR DESCRIPTION
Looks like we lost the ability to specify the scheduler port as part of the #162 rewrite.

This PR reinstates that option and tests for it.

Fixes #195 