### PR TITLE
adding gcc to EXTRA_APT_PACKAGES to fix error

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -45,13 +45,11 @@ Quickstart
         containers:
         - image: daskdev/dask:latest
           imagePullPolicy: IfNotPresent
-          args: [dask-worker, --nthreads, '2', --no-bokeh, --memory-limit, 6GB, --death-timeout, '60']
+          args: [dask-worker, $(DASK_SCHEDULER_ADDRESS), --nthreads, '2', --no-dashboard, --memory-limit, 6GB, --death-timeout, '60']
           name: dask
           env:
             - name: EXTRA_PIP_PACKAGES
-              value: fastparquet git+https://github.com/dask/distributed
-            - name: EXTRA_APT_PACKAGES
-              value: gcc
+              value: git+https://github.com/dask/distributed
           resources:
             limits:
               cpu: "2"
@@ -188,6 +186,10 @@ are available on https://hub.docker.com/r/daskdev .
 More information about these images is available at the
 `Dask documentation <https://docs.dask.org/en/latest/setup/docker.html>`_.
 
+Note that these images can be further customized with extra packages using
+``EXTRA_PIP_PACKAGES``, ``EXTRA_APT_PACKAGES``, and ``EXTRA_CONDA_PACKAGES``
+as described in the
+`Extensibility section <https://docs.dask.org/en/latest/setup/docker.html#extensibility>`_.
 
 Deployment Details
 ------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -50,6 +50,8 @@ Quickstart
           env:
             - name: EXTRA_PIP_PACKAGES
               value: fastparquet git+https://github.com/dask/distributed
+            - name: EXTRA_APT_PACKAGES
+              value: gcc
           resources:
             limits:
               cpu: "2"

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -45,7 +45,7 @@ Quickstart
         containers:
         - image: daskdev/dask:latest
           imagePullPolicy: IfNotPresent
-          args: [dask-worker, $(DASK_SCHEDULER_ADDRESS), --nthreads, '2', --no-dashboard, --memory-limit, 6GB, --death-timeout, '60']
+          args: [dask-worker, --nthreads, '2', --no-dashboard, --memory-limit, 6GB, --death-timeout, '60']
           name: dask
           env:
             - name: EXTRA_PIP_PACKAGES


### PR DESCRIPTION
This pull request fixes a bug in the documentation. It seems the fastparquet packet requires gcc, so without `gcc` in `EXTRA_APT_PACKAGES` this error will occur:
```
  copying fastparquet/test/test_util.py -> build/lib.linux-x86_64-3.7/fastparquet/test
  copying fastparquet/test/test_with_n.py -> build/lib.linux-x86_64-3.7/fastparquet/test
  .....
  building 'fastparquet.speedups' extension
  creating build/temp.linux-x86_64-3.7
  creating build/temp.linux-x86_64-3.7/fastparquet
  gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/conda/include/python3.7m -I/opt/conda/lib/python3.7/site-packages/numpy/core/include -c fastparquet/speedups.c -o build/temp.linux-x86_64-3.7/fastparquet/speedups.o
  unable to execute 'gcc': No such file or directory
  error: command 'gcc' failed with exit status 1
```

It appears that gcc is not in the base image specified in this example:
```
$ docker run -i -t daskdev/dask-notebook /bin/bash
jovyan@d011bb568da8:~$ gcc
bash: gcc: command not found
```

Adding gcc` in `EXTRA_APT_PACKAGES` fixes this documentation bug
