### PR TITLE
WIP: change scheduler_timeout to idle_timeout

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -141,10 +141,7 @@ class Scheduler(Pod):
         self.pod_template.metadata.labels["dask.org/component"] = "scheduler"
         cli_args = ["dask-scheduler"]
         if self._idle_timeout is not None:
-            cli_args += [
-                "--idle-timeout",
-                self.__idle_timeout
-            ]
+            cli_args += ["--idle-timeout", self.__idle_timeout]
         self.pod_template.spec.containers[0].args = cli_args
 
     async def start(self, **kwargs):
@@ -489,10 +486,7 @@ class KubeCluster(SpecCluster):
         elif self._deploy_mode == "remote":
             self.scheduler_spec = {
                 "cls": Scheduler,
-                "options": {
-                    "idle_timeout": self._idle_timeout,
-                    **common_options,
-                },
+                "options": {"idle_timeout": self._idle_timeout, **common_options,},
             }
         else:
             raise RuntimeError("Unknown deploy mode %s" % self._deploy_mode)

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -139,11 +139,13 @@ class Scheduler(Pod):
         self._idle_timeout = idle_timeout
 
         self.pod_template.metadata.labels["dask.org/component"] = "scheduler"
-        self.pod_template.spec.containers[0].args = [
-            "dask-scheduler",
-            "--idle-timeout",
-            self._idle_timeout,
-        ]
+        cli_args = ["dask-scheduler"]
+        if self._idle_timeout is not None:
+            cli_args += [
+                "--idle-timeout",
+                self.__idle_timeout
+            ]
+        self.pod_template.spec.containers[0].args = cli_args
 
     async def start(self, **kwargs):
         await super().start(**kwargs)

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -383,7 +383,7 @@ class KubeCluster(SpecCluster):
         self._generate_name = self._generate_name or dask.config.get("kubernetes.name")
         self._namespace = self._namespace or dask.config.get("kubernetes.namespace")
         self._idle_timeout = self._idle_timeout or dask.config.get(
-            "kubernetes.idle-timeout"
+            "distributed.scheduler.idle-timeout"
         )
         self._deploy_mode = self._deploy_mode or dask.config.get(
             "kubernetes.deploy-mode"

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -385,7 +385,7 @@ class KubeCluster(SpecCluster):
         self._generate_name = self._generate_name or dask.config.get("kubernetes.name")
         self._namespace = self._namespace or dask.config.get("kubernetes.namespace")
         self._idle_timeout = self._idle_timeout or dask.config.get(
-            "distributed.scheduler.idle-timeout"
+            "kubernetes.idle-timeout"
         )
         self._deploy_mode = self._deploy_mode or dask.config.get(
             "kubernetes.deploy-mode"

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -127,22 +127,22 @@ class Scheduler(Pod):
     """ A Remote Dask Scheduler controled by Kubernetes
     Parameters
     ----------
-    scheduler_timeout: str
+    idle_timeout: str, optional
         The scheduler task will exit after this amount of time
-        if there are no clients connected.
-        Defaults to ``5 minutes``.
+        if there are no requests from the client. Default is to 
+        never timeout.
     """
 
-    def __init__(self, scheduler_timeout: str, **kwargs):
+    def __init__(self, idle_timeout: str, **kwargs):
         super().__init__(**kwargs)
         self.service = None
-        self._scheduler_timeout = scheduler_timeout
+        self._idle_timeout = idle_timeout
 
         self.pod_template.metadata.labels["dask.org/component"] = "scheduler"
         self.pod_template.spec.containers[0].args = [
             "dask-scheduler",
             "--idle-timeout",
-            self._scheduler_timeout,
+            self._idle_timeout,
         ]
 
     async def start(self, **kwargs):
@@ -264,10 +264,10 @@ class KubeCluster(SpecCluster):
     auth: List[ClusterAuth] (optional)
         Configuration methods to attempt in order.  Defaults to
         ``[InCluster(), KubeConfig()]``.
-    scheduler_timeout: str (optional)
+    idle_timeout: str (optional)
         The scheduler task will exit after this amount of time
-        if there are no clients connected.
-        Defaults to ``5 minutes``.
+        if there are no requests from the client. Default is to 
+        never timeout.
     deploy_mode: str (optional)
         Run the scheduler as "local" or "remote".
         Defaults to ``"local"``.
@@ -348,7 +348,7 @@ class KubeCluster(SpecCluster):
         port=None,
         env=None,
         auth=ClusterAuth.DEFAULT,
-        scheduler_timeout=None,
+        idle_timeout=None,
         deploy_mode=None,
         interface=None,
         protocol=None,
@@ -360,7 +360,7 @@ class KubeCluster(SpecCluster):
         self._generate_name = name
         self._namespace = namespace
         self._n_workers = n_workers
-        self._scheduler_timeout = scheduler_timeout
+        self._idle_timeout = idle_timeout
         self._deploy_mode = deploy_mode
         self._protocol = protocol
         self._interface = interface
@@ -382,8 +382,8 @@ class KubeCluster(SpecCluster):
     async def _start(self):
         self._generate_name = self._generate_name or dask.config.get("kubernetes.name")
         self._namespace = self._namespace or dask.config.get("kubernetes.namespace")
-        self._scheduler_timeout = self._scheduler_timeout or dask.config.get(
-            "kubernetes.scheduler-timeout"
+        self._idle_timeout = self._idle_timeout or dask.config.get(
+            "kubernetes.idle-timeout"
         )
         self._deploy_mode = self._deploy_mode or dask.config.get(
             "kubernetes.deploy-mode"
@@ -488,7 +488,7 @@ class KubeCluster(SpecCluster):
             self.scheduler_spec = {
                 "cls": Scheduler,
                 "options": {
-                    "scheduler_timeout": self._scheduler_timeout,
+                    "idle_timeout": self._idle_timeout,
                     **common_options,
                 },
             }

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -486,7 +486,7 @@ class KubeCluster(SpecCluster):
         elif self._deploy_mode == "remote":
             self.scheduler_spec = {
                 "cls": Scheduler,
-                "options": {"idle_timeout": self._idle_timeout, **common_options,},
+                "options": {"idle_timeout": self._idle_timeout, **common_options},
             }
         else:
             raise RuntimeError("Unknown deploy mode %s" % self._deploy_mode)

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -7,7 +7,7 @@ kubernetes:
   host: "0.0.0.0"
   port: 0
   env: {}
-  scheduler-timeout: "5 minutes" # Length of inactivity to wait before closing the cluster
+  idle-timeout: null # Length of inactivity to wait before closing the cluster
   deploy-mode: "local"
   interface: null
   protocol: "tcp://"

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -7,7 +7,6 @@ kubernetes:
   host: "0.0.0.0"
   port: 0
   env: {}
-  idle-timeout: null # Length of inactivity to wait before closing the cluster
   deploy-mode: "local"
   interface: null
   protocol: "tcp://"

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -7,6 +7,7 @@ kubernetes:
   host: "0.0.0.0"
   port: 0
   env: {}
+  idle-timeout: null
   deploy-mode: "local"
   interface: null
   protocol: "tcp://"


### PR DESCRIPTION
(partially) fixes #206 

- changes the kwarg `scheduler_timeout` to `idle_timeout` to match the actual behavior of this kwarg
- passes the configuration of this setting to `distributed.yaml`, rather than having a separate value in `kubernetes.yaml`

The question still remains of whether there should be an implementation of the original intended behavior of `scheduler_timeout` (i.e. to timeout after a certain amount of time not having been connected to a client). And, if so, should the pod containing the scheduler also be killed if the scheduler dies.