### PR TITLE
Add timeout settings to wait for the remote scheduler service

### DIFF
--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -14,6 +14,8 @@ kubernetes:
   dashboard_address: ":8787"
 
   scheduler-service-type: "ClusterIP"
+  # Timeout to wait for the scheduler service to be up (in seconds)
+  scheduler-service-wait-timeout: 30
 
   scheduler-service-template:
     apiVersion: v1

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -15,6 +15,7 @@ kubernetes:
 
   scheduler-service-type: "ClusterIP"
   # Timeout to wait for the scheduler service to be up (in seconds)
+  # Set it to 0 to wait indefinitely (not recommended)
   scheduler-service-wait-timeout: 30
 
   scheduler-service-template:


### PR DESCRIPTION
When using cloud providers load balancers (in my case Azure) for the remote scheduler service it takes more than 30 secs for the service to get an IP accessible from outside the cluster.

This PR adds a new setting in the dask-kubernetes yml config file to set this timeout to a given value in seconds.

This is my first PR on the project so this will likely need some extra work.