### PR TITLE
Remove _ from valid characters

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -723,5 +723,5 @@ def _namespace_default():
 
 
 def escape(s):
-    valid_characters = string.ascii_letters + string.digits + "_-."
+    valid_characters = string.ascii_letters + string.digits + "-."
     return "".join(c for c in s if c in valid_characters)


### PR DESCRIPTION
Fixes #213 

It seems like `_` is not a valid character for a pod name. As we are already escaping the name we can just drop this character from our list of valid characters.