### PR TITLE
Set the name of each worker to allow tracking worker removals.

### DIFF
--- a/ci/environment-3.7.yml
+++ b/ci/environment-3.7.yml
@@ -25,7 +25,6 @@ dependencies:
   - six
   - sortedcontainers !=2.0.0,!=2.0.1
   - tblib
-  - tornado >=5
   - zict >=0.1.3
   - pip:
       - pytest-asyncio

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -24,8 +24,6 @@ from distributed.comm.utils import offload
 from distributed.utils import Log, Logs
 import kubernetes_asyncio as kubernetes
 from kubernetes_asyncio.client.rest import ApiException
-from tornado import gen
-from tornado.gen import TimeoutError
 
 from .objects import (
     make_pod_from_dict,
@@ -181,7 +179,7 @@ class Scheduler(Pod):
                     self._service_wait_timeout_s > 0
                     and time.time() > start + self._service_wait_timeout_s
                 ):
-                    raise TimeoutError(
+                    raise asyncio.TimeoutError(
                         "Timed out waiting for Load Balancer to be provisioned."
                     )
                 self.service = await self.core_api.read_namespaced_service(

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -112,9 +112,11 @@ class Worker(Pod):
     ----------
     scheduler: str
         The address of the scheduler
+    name (optional):
+        The name passed to the dask-worker CLI at creation time.
     """
 
-    def __init__(self, scheduler: str, **kwargs):
+    def __init__(self, scheduler: str, name=None, **kwargs):
         super().__init__(**kwargs)
 
         self.scheduler = scheduler
@@ -125,6 +127,9 @@ class Worker(Pod):
                 name="DASK_SCHEDULER_ADDRESS", value=self.scheduler
             )
         )
+        if name is not None:
+            worker_name_args = ["--name", str(name)]
+            self.pod_template.spec.containers[0].args += worker_name_args
 
 
 class Scheduler(Pod):

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -440,11 +440,18 @@ async def test_reject_evicted_workers(cluster):
         ),
     )
 
-    # Wait until pod is evicted
+    # Wait until worker removal has been picked up by scheduler
     start = time()
     while len(cluster.scheduler_info["workers"]) != 0:
-        await gen.sleep(0.1)
-        assert time() < start + 60
+        delta = time() - start 
+        assert delta < 60, f"Scheduler failed to remove worker in {delta:.0f}s"
+        await asyncio.sleep(0.1)
+
+    # Wait until worker removal has been handled by cluster
+    while len(cluster.workers) != 0:
+        delta = time() - start 
+        assert delta < 60, f"Cluster failed to remove worker in {delta:.0f}s"
+        await asyncio.sleep(0.1)
 
 
 @pytest.mark.asyncio

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import base64
 import getpass
 import os
@@ -9,7 +10,6 @@ import yaml
 
 import kubernetes_asyncio as kubernetes
 import pytest
-from tornado import gen
 
 import dask
 from dask.distributed import Client, wait
@@ -113,7 +113,7 @@ async def test_basic(cluster, client):
     assert result == 11
 
     while len(cluster.scheduler_info["workers"]) < 2:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
 
     # Ensure that inter-worker communication works well
     futures = client.map(lambda x: x + 1, range(10))
@@ -130,7 +130,7 @@ async def test_logs(remote_cluster):
 
     start = time()
     while len(cluster.scheduler_info["workers"]) < 2:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 20
 
     logs = await cluster.logs()
@@ -169,7 +169,7 @@ async def test_namespace(pod_spec, ns):
 
             cluster2.scale(1)
             while len(await cluster2.pods()) != 1:
-                await gen.sleep(0.1)
+                await asyncio.sleep(0.1)
 
 
 @pytest.mark.asyncio
@@ -182,7 +182,7 @@ async def test_adapt(cluster):
 
     start = time()
     while cluster.scheduler_info["workers"]:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 20
 
 
@@ -201,7 +201,7 @@ async def test_ipython_display(cluster):
     start = time()
     while "<td>1</td>" not in str(box):  # one worker in a table
         assert time() < start + 20
-        await gen.sleep(0.5)
+        await asyncio.sleep(0.5)
 
 
 @pytest.mark.asyncio
@@ -213,7 +213,7 @@ async def test_env(pod_spec, ns):
         await cluster
         async with Client(cluster, asynchronous=True) as client:
             while not cluster.scheduler_info["workers"]:
-                await gen.sleep(0.1)
+                await asyncio.sleep(0.1)
             env = await client.run(lambda: dict(os.environ))
             assert all(v["ABC"] == "DEF" for v in env.values())
 
@@ -256,7 +256,7 @@ async def test_pod_from_yaml(image_name, ns):
 
                 start = time()
                 while len(cluster.scheduler_info["workers"]) < 2:
-                    await gen.sleep(0.1)
+                    await asyncio.sleep(0.1)
                     assert time() < start + 20, "timeout"
 
                 # Ensure that inter-worker communication works well
@@ -339,7 +339,7 @@ async def test_pod_from_dict(image_name, ns):
             assert result == 11
 
             while len(cluster.scheduler_info["workers"]) < 2:
-                await gen.sleep(0.1)
+                await asyncio.sleep(0.1)
 
             # Ensure that inter-worker communication works well
             futures = client.map(lambda x: x + 1, range(10))
@@ -426,7 +426,7 @@ async def test_reject_evicted_workers(cluster):
 
     start = time()
     while len(cluster.scheduler_info["workers"]) != 1:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 60
 
     # Evict worker
@@ -462,7 +462,7 @@ async def test_scale_up_down(cluster, client):
 
     start = time()
     while len(cluster.scheduler_info["workers"]) != 2:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 20
 
     a, b = list(cluster.scheduler_info["workers"])
@@ -476,7 +476,7 @@ async def test_scale_up_down(cluster, client):
 
     start = time()
     while len(cluster.scheduler_info["workers"]) != 1:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 20
 
     # assert set(cluster.scheduler_info["workers"]) == {b}
@@ -492,7 +492,7 @@ async def test_scale_up_down_fast(cluster, client):
 
     start = time()
     while len(cluster.scheduler_info["workers"]) != 1:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 20
 
     worker = next(iter(cluster.scheduler_info["workers"].values()))
@@ -507,13 +507,13 @@ async def test_scale_up_down_fast(cluster, client):
     # with the temporary result.
     for i in range(10):
         await cluster._scale_up(4)
-        await gen.sleep(random.random() / 2)
+        await asyncio.sleep(random.random() / 2)
         cluster.scale(1)
-        await gen.sleep(random.random() / 2)
+        await asyncio.sleep(random.random() / 2)
 
     start = time()
     while len(cluster.scheduler_info["workers"]) != 1:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 20
 
     # The original task result is still stored on the original worker: this pod
@@ -539,7 +539,7 @@ async def test_scale_down_pending(cluster, client, cleanup_namespaces):
 
     start = time()
     while len(cluster.scheduler_info["workers"]) < 2:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         # Wait a bit because the kubernetes cluster can take time to provision
         # the requested pods as we requested a large number of pods.
         assert time() < start + 60
@@ -572,7 +572,7 @@ async def test_scale_down_pending(cluster, client, cleanup_namespaces):
                 "Expected %d running pods but got %r"
                 % (len(running_workers), pod_statuses)
             )
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         pod_statuses = [p.status.phase for p in await cluster.pods()]
 
     assert pod_statuses == ["Running"] * len(running_workers)
@@ -583,7 +583,7 @@ async def test_scale_down_pending(cluster, client, cleanup_namespaces):
 
     start = time()
     while len(cluster.scheduler_info["workers"]) > 0:
-        await gen.sleep(0.1)
+        await asyncio.sleep(0.1)
         assert time() < start + 60
 
 
@@ -653,9 +653,9 @@ async def test_maximum(cluster):
 
             start = time()
             while len(cluster.scheduler_info["workers"]) <= 0:
-                await gen.sleep(0.1)
+                await asyncio.sleep(0.1)
                 assert time() < start + 60
-            await gen.sleep(0.5)
+            await asyncio.sleep(0.5)
             assert len(cluster.scheduler_info["workers"]) == 1
 
         result = logger.getvalue()
@@ -792,4 +792,4 @@ async def test_start_with_workers(pod_spec, ns):
     ) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             while len(cluster.scheduler_info["workers"]) != 2:
-                await gen.sleep(0.1)
+                await asyncio.sleep(0.1)

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -89,7 +89,6 @@ async def client(cluster):
         yield client
 
 
-@pytest.mark.skip  # Waiting on https://github.com/dask/distributed/pull/3064
 @pytest.mark.asyncio
 async def test_versions(client):
     await client.get_versions(check=True)

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -41,7 +41,7 @@ def pod_spec(image_name):
     )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def event_loop(request):
     """Override function-scoped fixture in pytest-asyncio."""
     loop = asyncio.new_event_loop()
@@ -442,13 +442,13 @@ async def test_reject_evicted_workers(cluster):
     # Wait until worker removal has been picked up by scheduler
     start = time()
     while len(cluster.scheduler_info["workers"]) != 0:
-        delta = time() - start 
+        delta = time() - start
         assert delta < 60, f"Scheduler failed to remove worker in {delta:.0f}s"
         await asyncio.sleep(0.1)
 
     # Wait until worker removal has been handled by cluster
     while len(cluster.workers) != 0:
-        delta = time() - start 
+        delta = time() - start
         assert delta < 60, f"Cluster failed to remove worker in {delta:.0f}s"
         await asyncio.sleep(0.1)
 

--- a/dask_kubernetes/tests/test_sync.py
+++ b/dask_kubernetes/tests/test_sync.py
@@ -37,22 +37,20 @@ except kubernetes.config.ConfigException:
 asyncio.get_event_loop().run_until_complete(ClusterAuth.load_first())
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def api():
     return kubernetes.client.CoreV1Api()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def ns(api):
     name = "test-dask-kubernetes" + str(uuid.uuid4())[:10]
     ns = kubernetes.client.V1Namespace(
         metadata=kubernetes.client.V1ObjectMeta(name=name)
     )
     api.create_namespace(ns)
-    try:
-        yield name
-    finally:
-        api.delete_namespace(name)
+    yield name
+    api.delete_namespace(name)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR allows the `KubeCluster` to maintain the number of worker pods in adaptive mode, even if pods are lost/deleted externally.

This PR fixes https://github.com/dask/dask-kubernetes/issues/216

## Before this change
`KubeCluster._update_worker_status` was not working correctly. The name found in `KubeCluster.scheduler_info` defaulted to worker address, and was thus different from the corresponding key in `KubeCluster.workers`.

## After this change
The auto-generated worker name is handled correctly by the `Worker` and is appended to `args` in the Pod spec.

### Other improvements
- increas scope of slow test fixtures for faster tests
- remove `tornado` dependency in favour af native `asyncio` as not needed with `python>=3.5`