### PR TITLE
Fix logs with local scheduler

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -218,6 +218,9 @@ class Scheduler(Pod):
             )
         await super().close(**kwargs)
 
+    async def get_logs(self, *args, **kwargs):
+        return await self.logs(*args, **kwargs)
+
     async def _create_service(self):
         service_template_dict = dask.config.get("kubernetes.scheduler-service-template")
         self.service_template = clean_service_template(
@@ -676,7 +679,7 @@ class KubeCluster(SpecCluster):
         logs = Logs()
 
         if scheduler:
-            logs["Scheduler"] = await self.scheduler.logs()
+            logs["Scheduler"] = await self.scheduler.get_logs()
 
         if workers:
             worker_logs = await asyncio.gather(

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -104,6 +104,7 @@ async def test_basic(cluster, client):
     assert (await total) == sum(map(lambda x: x + 1, range(10)))
     assert all((await client.has_what()).values())
 
+
 @pytest.mark.asyncio
 async def test_logs(cluster):
     cluster.scale(2)
@@ -118,6 +119,7 @@ async def test_logs(cluster):
     assert len(logs) == 3
     for _, log in logs.items():
         assert "distributed.scheduler" in log or "distributed.worker" in log
+
 
 @pytest.mark.asyncio
 async def test_remote_logs(remote_cluster):


### PR DESCRIPTION
Should fix #231.

Switched the scheduler logs method to `get_logs` and added a shim to the `Scheduler` object to ensure compatibility.

Added tests for both remote and local schedulers.