### PR TITLE
Make the helm command an optional dependency

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -154,8 +154,8 @@ class Scheduler(Pod):
     """
 
     def __init__(self, idle_timeout: str, service_wait_timeout_s: int = None, **kwargs):
-        self.cluster._log("Creating scheduler pod on cluster. This may take some time.")
         super().__init__(**kwargs)
+        self.cluster._log("Creating scheduler pod on cluster. This may take some time.")
         self.service = None
         self._idle_timeout = idle_timeout
         self._service_wait_timeout_s = service_wait_timeout_s

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -35,7 +35,7 @@ SCHEDULER_PORT = 8786
 
 
 class Pod(ProcessInterface):
-    """ A superclass for Kubernetes Pods
+    """A superclass for Kubernetes Pods
     See Also
     --------
     Worker
@@ -114,7 +114,7 @@ class Pod(ProcessInterface):
 
 
 class Worker(Pod):
-    """ A Remote Dask Worker controled by Kubernetes
+    """A Remote Dask Worker controled by Kubernetes
     Parameters
     ----------
     scheduler: str
@@ -140,7 +140,7 @@ class Worker(Pod):
 
 
 class Scheduler(Pod):
-    """ A Remote Dask Scheduler controled by Kubernetes
+    """A Remote Dask Scheduler controled by Kubernetes
     Parameters
     ----------
     idle_timeout: str, optional
@@ -238,7 +238,7 @@ class Scheduler(Pod):
 
 
 class KubeCluster(SpecCluster):
-    """ Launch a Dask cluster on Kubernetes
+    """Launch a Dask cluster on Kubernetes
 
     This starts a local Dask scheduler and then dynamically launches
     Dask workers on a Kubernetes cluster. The Kubernetes cluster is taken
@@ -574,7 +574,7 @@ class KubeCluster(SpecCluster):
 
     @classmethod
     def from_dict(cls, pod_spec, **kwargs):
-        """ Create cluster with worker pod spec defined by Python dictionary
+        """Create cluster with worker pod spec defined by Python dictionary
 
         Examples
         --------
@@ -602,7 +602,7 @@ class KubeCluster(SpecCluster):
 
     @classmethod
     def from_yaml(cls, yaml_path, **kwargs):
-        """ Create cluster with worker pod spec defined by a YAML file
+        """Create cluster with worker pod spec defined by a YAML file
 
         We can start a cluster with pods defined in an accompanying YAML file
         like the following:
@@ -658,7 +658,7 @@ class KubeCluster(SpecCluster):
         return super().scale(n)
 
     async def _logs(self, scheduler=True, workers=True):
-        """ Return logs for the scheduler and workers
+        """Return logs for the scheduler and workers
         Parameters
         ----------
         scheduler : boolean

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -42,8 +42,9 @@ class Pod(ProcessInterface):
     Scheduler
     """
 
-    def __init__(self, core_api, pod_template, namespace, loop=None, **kwargs):
+    def __init__(self, cluster, core_api, pod_template, namespace, loop=None, **kwargs):
         self._pod = None
+        self.cluster = cluster
         self.core_api = core_api
         self.pod_template = copy.deepcopy(pod_template)
         self.base_labels = self.pod_template.metadata.labels
@@ -153,6 +154,7 @@ class Scheduler(Pod):
     """
 
     def __init__(self, idle_timeout: str, service_wait_timeout_s: int = None, **kwargs):
+        self.cluster._log("Creating scheduler pod on cluster. This may take some time.")
         super().__init__(**kwargs)
         self.service = None
         self._idle_timeout = idle_timeout
@@ -531,6 +533,7 @@ class KubeCluster(SpecCluster):
         )
 
         common_options = {
+            "cluster": self,
             "core_api": self.core_api,
             "namespace": self._namespace,
             "loop": self.loop,

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -13,7 +13,7 @@ from .core import _namespace_default
 
 
 class HelmCluster(Cluster):
-    """ Connect to a Dask cluster deployed via the Helm Chart.
+    """Connect to a Dask cluster deployed via the Helm Chart.
 
     This cluster manager connects to an existing Dask deployment that was
     created by the Dask Helm Chart. Enabling you to perform basic cluster actions
@@ -226,13 +226,15 @@ class HelmCluster(Cluster):
         await self.apps_api.patch_namespaced_deployment(
             name=f"{self.release_name}-worker",
             namespace=self.namespace,
-            body={"spec": {"replicas": n_workers,}},
+            body={
+                "spec": {
+                    "replicas": n_workers,
+                }
+            },
         )
 
     def adapt(self, *args, **kwargs):
-        """Turn on adaptivity (Not recommended).
-
-        """
+        """Turn on adaptivity (Not recommended)."""
         raise NotImplementedError(
             "It is not recommended to run ``HelmCluster`` in adaptive mode."
             "When scaling down workers the decision on which worker to remove is left to Kubernetes, which"

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -11,13 +11,6 @@ import kubernetes_asyncio as kubernetes
 from .auth import ClusterAuth
 from .core import _namespace_default
 
-if shutil.which("helm") is None:
-    raise ImportError(
-        "Missing dependency helm. "
-        "Please install helm following the instructions for your OS. "
-        "https://helm.sh/docs/intro/install/"
-    )
-
 
 class HelmCluster(Cluster):
     """ Connect to a Dask cluster deployed via the Helm Chart.
@@ -79,6 +72,7 @@ class HelmCluster(Cluster):
     ):
         self.release_name = release_name
         self.namespace = namespace or _namespace_default()
+        self.check_helm_dependency()
         status = subprocess.run(
             ["helm", "-n", self.namespace, "status", self.release_name],
             capture_output=True,
@@ -99,6 +93,15 @@ class HelmCluster(Cluster):
         if not self.asynchronous:
             self._loop_runner.start()
             self.sync(self._start)
+
+    @staticmethod
+    def check_helm_dependency():
+        if shutil.which("helm") is None:
+            raise RuntimeError(
+                "Missing dependency helm. "
+                "Please install helm following the instructions for your OS. "
+                "https://helm.sh/docs/intro/install/"
+            )
 
     async def _start(self):
         await ClusterAuth.load_first(self.auth)

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -117,8 +117,12 @@ async def test_logs(remote_cluster):
 
     logs = await cluster.logs()
     assert len(logs) == 4
-    for _, log in logs.items()[1:]:
-        assert "distributed.scheduler" in log or "distributed.worker" in log
+    for _, log in logs.items():
+        assert (
+            "distributed.scheduler" in log
+            or "distributed.worker" in log
+            or "Creating scheduler pod" in log
+        )
 
 
 @pytest.mark.asyncio

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -116,8 +116,8 @@ async def test_logs(remote_cluster):
         assert time() < start + 20
 
     logs = await cluster.logs()
-    assert len(logs) == 3
-    for _, log in logs.items():
+    assert len(logs) == 4
+    for _, log in logs.items()[1:]:
         assert "distributed.scheduler" in log or "distributed.worker" in log
 
 


### PR DESCRIPTION
The check for the `helm` command was accidentally at the module level, so it would raise on import of `dask_kubernetes`.

Updated the check so that it happens when `HelmCluster` is instantiated.

Closes #262 