### PR TITLE
Use sync client for objects submodule

### DIFF
--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -3,7 +3,7 @@ Convenience functions for creating pod templates.
 """
 from collections import namedtuple
 import copy
-from kubernetes_asyncio import client
+from kubernetes import client
 import json
 
 try:


### PR DESCRIPTION
As we do not use any of the async methods in the `objects` submodule we may not need the `kubernetes_asyncio` client.

This could be a solution for #264 as we are not creating and closing the client in an async way resulting in a warning.