### PR TITLE
Transform username to lowercase when escaping

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -742,4 +742,4 @@ def _namespace_default():
 
 def escape(s):
     valid_characters = string.ascii_letters + string.digits + "-"
-    return "".join(c for c in s if c in valid_characters)
+    return "".join(c for c in s if c in valid_characters).lower()

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -619,8 +619,9 @@ async def test_repr(cluster):
 
 
 @pytest.mark.asyncio
-async def test_escape_username(pod_spec, ns, auth, monkeypatch):
-    monkeypatch.setenv("LOGNAME", "foo!._")
+@pytest.mark.parametrize("name", ["foo!._", "Foo!._"])
+async def test_escape_username(pod_spec, ns, auth, monkeypatch, name):
+    monkeypatch.setenv("LOGNAME", name)
 
     async with KubeCluster(
         pod_spec, namespace=ns, auth=auth, **cluster_kwargs

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -619,9 +619,8 @@ async def test_repr(cluster):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("name", ["foo!._", "Foo!._"])
-async def test_escape_username(pod_spec, ns, auth, monkeypatch, name):
-    monkeypatch.setenv("LOGNAME", name)
+async def test_escape_username(pod_spec, ns, auth, monkeypatch):
+    monkeypatch.setenv("LOGNAME", "Foo!._")
 
     async with KubeCluster(
         pod_spec, namespace=ns, auth=auth, **cluster_kwargs

--- a/dask_kubernetes/tests/test_sync.py
+++ b/dask_kubernetes/tests/test_sync.py
@@ -342,8 +342,9 @@ def test_repr(cluster):
         assert "workers=0" in text
 
 
-def test_escape_username(pod_spec, ns, monkeypatch):
-    monkeypatch.setenv("LOGNAME", "foo!")
+@pytest.mark.parametrize("name", ["foo!._", "Foo!._"])
+def test_escape_username(pod_spec, ns, monkeypatch, name):
+    monkeypatch.setenv("LOGNAME", name)
 
     with KubeCluster(pod_spec, namespace=ns) as cluster:
         assert "foo" in cluster.name

--- a/dask_kubernetes/tests/test_sync.py
+++ b/dask_kubernetes/tests/test_sync.py
@@ -342,9 +342,8 @@ def test_repr(cluster):
         assert "workers=0" in text
 
 
-@pytest.mark.parametrize("name", ["foo!._", "Foo!._"])
-def test_escape_username(pod_spec, ns, monkeypatch, name):
-    monkeypatch.setenv("LOGNAME", name)
+def test_escape_username(pod_spec, ns, monkeypatch):
+    monkeypatch.setenv("LOGNAME", "Foo!")
 
     with KubeCluster(pod_spec, namespace=ns) as cluster:
         assert "foo" in cluster.name


### PR DESCRIPTION
Add lower() after escaping the username.
This is a fix to #213.

Test method:
```
make test EXTRA_TEST_ARGS='-k escape'
```