### PR TITLE
feat(pdb): Add support for pdb creation for remote scheduler

### DIFF
--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -35,6 +35,16 @@ kubernetes:
           port: 8787
           targetPort: 8787
 
+  scheduler-pdb-template:
+    apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    spec:
+      minAvailable: 1
+      selector:
+        matchLabels:
+          dask.org/cluster-name: "" # Cluster name will be added automatically
+          dask.org/component: scheduler
+
   worker-template-path: null
 
   scheduler-template:

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -182,6 +182,14 @@ def make_service_from_dict(dict_):
     )
 
 
+def make_pdb_from_dict(dict_):
+    # FIXME: We can't use the 'deserialize' function since
+    # that expects a response object!
+    return SERIALIZATION_API_CLIENT.deserialize(
+        _FakeResponse(data=json.dumps(dict_)), client.V1beta1PodDisruptionBudget
+    )
+
+
 def clean_pod_template(pod_template, match_node_purpose="prefer", pod_type="worker"):
     """ Normalize pod template and check for type errors """
     if isinstance(pod_template, str):
@@ -303,3 +311,20 @@ def clean_service_template(service_template):
         service_template.metadata.labels = {}
 
     return service_template
+
+
+def clean_pdb_template(pdb_template):
+    """ Normalize pdb template and check for type errors """
+
+    pdb_template = copy.deepcopy(pdb_template)
+
+    # Make sure metadata / labels objects exist, so they can be modified
+    # later without a lot of `is None` checks
+    if pdb_template.metadata is None:
+        pdb_template.metadata = client.V1ObjectMeta()
+    if pdb_template.metadata.labels is None:
+        pdb_template.metadata.labels = {}
+    if pdb_template.spec.selector is None:
+        pdb_template.spec.selector = client.V1LabelSelector()
+
+    return pdb_template

--- a/doc/source/kubecluster.rst
+++ b/doc/source/kubecluster.rst
@@ -264,7 +264,8 @@ When deploying remotely, the following k8s resources are created:
 
 - A pod with a scheduler running
 - (optional) A pod with a LoadBalancer and complimentary service (svc) to
-  expose scheduler and dashobard ports
+  expose scheduler and dashboard ports
+- A PodDisruptionBudget avoid voluntary disruptions of the scheduler pod
 
 By default, the configuration option, ``scheduler-service-type``, is
 set to ``ClusterIp``. To optionally use a LoadBalancer, change ``scheduler-service-type`` to


### PR DESCRIPTION
Adds PDB creation/deletion for the remote scheduler option within a
`KubeCluster`.

Contributes to dask/dask-kubernetes#282

Signed-off-by: Nick Groszewski <groszewn@gmail.com>