### PR TITLE
Bump kind action version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Install and start kind (Kubernetes in Docker)
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
 
       - name: Get kind info
         run: |


### PR DESCRIPTION
Current CI failures appear to be a result of GitHub Actions deprecating some options. This version bump should resolve that.