### PR TITLE
add nodehost and nodeport kwargs to HelmCluster init

### DIFF
--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -250,7 +250,11 @@ class HelmCluster(Cluster):
         await self.apps_api.patch_namespaced_deployment(
             name=f"{self.release_name}-{self.worker_name}",
             namespace=self.namespace,
-            body={"spec": {"replicas": n_workers,}},
+            body={
+                "spec": {
+                    "replicas": n_workers,
+                }
+            },
         )
 
     def adapt(self, *args, **kwargs):

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -47,7 +47,7 @@ class HelmCluster(Cluster):
         A node address. Can be provided in case scheduler service type is
         ``NodePort`` and you want to manually specify which port to connect to.
     **kwargs: dict
-        Additional keyword arguments to pass to Cluster
+        Additional keyword arguments to pass to Cluster.
 
     Examples
     --------

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -70,16 +70,16 @@ class HelmCluster(Cluster):
     """
 
     def __init__(
-        self,
-        release_name=None,
-        auth=ClusterAuth.DEFAULT,
-        namespace=None,
-        port_forward_cluster_ip=False,
-        loop=None,
-        asynchronous=False,
-        scheduler_name="scheduler",
-        worker_name="worker",
-        **kwargs
+            self,
+            release_name=None,
+            auth=ClusterAuth.DEFAULT,
+            namespace=None,
+            port_forward_cluster_ip=False,
+            loop=None,
+            asynchronous=False,
+            scheduler_name="scheduler",
+            worker_name="worker",
+            **kwargs
     ):
         self.release_name = release_name
         self.namespace = namespace or _namespace_default()
@@ -129,7 +129,8 @@ class HelmCluster(Cluster):
         service = await self.core_api.read_namespaced_service(
             service_name, self.namespace
         )
-        [port] = [port.port for port in service.spec.ports if port.name == service_name]
+        [port] = [port.port for port in service.spec.ports if
+                  port.name == service_name]
         if service.spec.type == "LoadBalancer":
             lb = service.status.load_balancer.ingress[0]
             host = lb.hostname or lb.ip
@@ -162,7 +163,8 @@ class HelmCluster(Cluster):
         while True:
             n_workers = len(self.scheduler_info["workers"])
             deployment = await self.apps_api.read_namespaced_deployment(
-                name=f"{self.release_name}-{self.worker_name}", namespace=self.namespace
+                name=f"{self.release_name}-{self.worker_name}",
+                namespace=self.namespace
             )
             deployment_replicas = deployment.spec.replicas
             if n_workers == deployment_replicas:

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -109,9 +109,8 @@ class HelmCluster(Cluster):
         self.worker_name = worker_name
         self.node_host = node_host
         self.node_port = node_port
-        self.kwargs = kwargs
 
-        super().__init__(asynchronous=asynchronous)
+        super().__init__(asynchronous=asynchronous, **kwargs)
         if not self.asynchronous:
             self._loop_runner.start()
             self.sync(self._start)
@@ -251,11 +250,7 @@ class HelmCluster(Cluster):
         await self.apps_api.patch_namespaced_deployment(
             name=f"{self.release_name}-{self.worker_name}",
             namespace=self.namespace,
-            body={
-                "spec": {
-                    "replicas": n_workers,
-                }
-            },
+            body={"spec": {"replicas": n_workers,}},
         )
 
     def adapt(self, *args, **kwargs):

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -70,16 +70,16 @@ class HelmCluster(Cluster):
     """
 
     def __init__(
-            self,
-            release_name=None,
-            auth=ClusterAuth.DEFAULT,
-            namespace=None,
-            port_forward_cluster_ip=False,
-            loop=None,
-            asynchronous=False,
-            scheduler_name="scheduler",
-            worker_name="worker",
-            **kwargs
+        self,
+        release_name=None,
+        auth=ClusterAuth.DEFAULT,
+        namespace=None,
+        port_forward_cluster_ip=False,
+        loop=None,
+        asynchronous=False,
+        scheduler_name="scheduler",
+        worker_name="worker",
+        **kwargs,
     ):
         self.release_name = release_name
         self.namespace = namespace or _namespace_default()
@@ -129,20 +129,19 @@ class HelmCluster(Cluster):
         service = await self.core_api.read_namespaced_service(
             service_name, self.namespace
         )
-        [port] = [port.port for port in service.spec.ports if
-                  port.name == service_name]
+        [port] = [port.port for port in service.spec.ports if port.name == service_name]
         if service.spec.type == "LoadBalancer":
             lb = service.status.load_balancer.ingress[0]
             host = lb.hostname or lb.ip
             return f"tcp://{host}:{port}"
         elif service.spec.type == "NodePort":
-            nodeport_host = self.kwargs.get('nodeport_host')
+            nodeport_host = self.kwargs.get("nodeport_host")
             if nodeport_host:
                 host = nodeport_host
             else:
                 nodes = await self.core_api.list_node()
                 host = nodes.items[0].status.addresses[0].address
-            port = self.kwargs.get('node_port') or port
+            port = self.kwargs.get("node_port") or port
             return f"tcp://{host}:{port}"
         elif service.spec.type == "ClusterIP":
             if self.port_forward_cluster_ip:
@@ -163,8 +162,7 @@ class HelmCluster(Cluster):
         while True:
             n_workers = len(self.scheduler_info["workers"])
             deployment = await self.apps_api.read_namespaced_deployment(
-                name=f"{self.release_name}-{self.worker_name}",
-                namespace=self.namespace
+                name=f"{self.release_name}-{self.worker_name}", namespace=self.namespace
             )
             deployment_replicas = deployment.spec.replicas
             if n_workers == deployment_replicas:


### PR DESCRIPTION
This is a small PullRequest to allow user side parametrization of dask scheduler service when NodePort is chosen as its type.



As this is a very minor change, do you require any additional testing and/or documentation? Manually I have been able to connect without an issue with this change.