### PR TITLE
Property Name Fixes

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -447,6 +447,9 @@ class KubeCluster(SpecCluster):
         self.kwargs = kwargs
         super().__init__(**self.kwargs)
 
+        # overwrite cluster name with pod template generated name
+        self.name = self.pod_template.metadata.generate_name
+
     def _get_pod_template(self, pod_template, pod_type):
         if not pod_template and dask.config.get(
             "kubernetes.{}-template".format(pod_type), None
@@ -677,10 +680,6 @@ class KubeCluster(SpecCluster):
     @property
     def namespace(self):
         return self.pod_template.metadata.namespace
-
-    @property
-    def name(self):
-        return self.pod_template.metadata.generate_name
 
     def scale(self, n):
         # A shim to maintain backward compatibility


### PR DESCRIPTION
PR resolves #299

This is a little hacky in that we are overwriting the name rather than instantiating a cluster with the generated name.  It's not entirely clear to me how to do this as dask-kubernetes does not directly use Cluster but rather worker/scheduler specs