### PR TITLE
Update CI installs after upstream projects switched to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         run: |
           pip install -e .
           pip install -r requirements-test.txt
-          pip install git+https://github.com/dask/distributed@master
-          pip install git+https://github.com/dask/dask@master
+          pip install git+https://github.com/dask/distributed@main
+          pip install git+https://github.com/dask/dask@main
 
       - name: Run tests
         run: pytest

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
 FROM daskdev/dask:latest
 
 # Install latest dev builds of Dask and Distributed
-RUN pip install git+https://github.com/dask/distributed@master
-RUN pip install git+https://github.com/dask/dask@master
+RUN pip install git+https://github.com/dask/distributed@main
+RUN pip install git+https://github.com/dask/dask@main

--- a/doc/source/testing.rst
+++ b/doc/source/testing.rst
@@ -49,7 +49,7 @@ variable ``KUBECONFIG`` to point to that file, then use ``kubectl`` or ``helm`` 
 Docker image
 ------------
 
-Within the test suite there is a fixture which creates a Docker image called ``dask-kubernetes:dev`` from `this Dockerfile <https://github.com/dask/dask-kubernetes/blob/master/ci/Dockerfile>`_.
+Within the test suite there is a fixture which creates a Docker image called ``dask-kubernetes:dev`` from `this Dockerfile <https://github.com/dask/dask-kubernetes/blob/main/ci/Dockerfile>`_.
 This image will be imported into the kind cluster and then be used in all Dask clusters created.
 This is the official Dask Docker image but with the very latest trunks of ``dask`` and ``distrubuted`` installed. It is recommended that you also have the
 latest development install of those projects in your local development environment too.


### PR DESCRIPTION
Dask and distributed have renamed their default branch to `main`. Updating the CI pip installs.