### PR TITLE
docs(rbac): Add PDB RBAC permissions to documentation

### DIFF
--- a/doc/source/kubecluster.rst
+++ b/doc/source/kubecluster.rst
@@ -187,6 +187,16 @@ following Role to that ServiceAccount via a RoleBinding:
       - "watch"
       - "create"
       - "delete"
+    - apiGroups:
+      - "policy"  # indicates the policy API group
+      resources:
+      - "poddisruptionbudgets"
+      verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "create"
+      - "delete"
 
 
 Docker Images


### PR DESCRIPTION
Add PDB resource RBAC permissions to the documented permissions for `KubeCluster` management.

Contributes to #313

Signed-off-by: Nick Groszewski <nicholas.groszewski@capitalone.com>