### PR TITLE
Minor correction to KubeCluster docstring: deploy_mode defaults to remote

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -331,7 +331,7 @@ class KubeCluster(SpecCluster):
         Set to 0 to disable the timeout (not recommended).
     deploy_mode: str (optional)
         Run the scheduler as "local" or "remote".
-        Defaults to ``"local"``.
+        Defaults to ``"remote"``.
     **kwargs: dict
         Additional keyword arguments to pass to LocalCluster
 


### PR DESCRIPTION
Minor correction to the KubeCluster docstring, which fixes #315 