### PR TITLE
Add kubectl cluster discovery

### DIFF
--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -288,9 +288,11 @@ class HelmCluster(Cluster):
         )
 
     @classmethod
-    def from_name(cls, name):
+    def from_name(cls, name, asynchronous=False):
         release_name, namespace = name.split(".")
-        return cls(release_name=release_name, namespace=namespace)
+        return cls(
+            release_name=release_name, namespace=namespace, asynchronous=asynchronous
+        )
 
 
 async def discover(
@@ -302,7 +304,8 @@ async def discover(
         core_api = kubernetes.client.CoreV1Api(api)
         namespace = namespace or namespace_default()
         try:
-            pods = await core_api.list_pod_for_all_namespaces(
+            pods = await core_api.list_namespaced_pod(
+                namespace,
                 label_selector="app=dask,component=scheduler",
             )
             for pod in pods.items:

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -202,6 +202,8 @@ def clean_pod_template(pod_template, match_node_purpose="prefer", pod_type="work
     # later without a lot of `is None` checks
     if pod_template.metadata is None:
         pod_template.metadata = client.V1ObjectMeta()
+    if isinstance(pod_template.metadata, dict):
+        pod_template.metadata = client.V1ObjectMeta(**pod_template.metadata)
     if pod_template.metadata.labels is None:
         pod_template.metadata.labels = {}
 

--- a/dask_kubernetes/tests/test_utils.py
+++ b/dask_kubernetes/tests/test_utils.py
@@ -1,0 +1,12 @@
+from dask_kubernetes.utils import b64_dump, b64_load
+
+
+def test_b64():
+    for obj in [
+        "hello",
+        1,
+        True,
+        {"Hello": "world"},
+        [1, 2, 3, 4],
+    ]:
+        assert b64_load(b64_dump(obj)) == obj

--- a/dask_kubernetes/utils.py
+++ b/dask_kubernetes/utils.py
@@ -7,6 +7,8 @@ import subprocess
 import string
 import time
 from weakref import finalize
+import json
+import base64
 
 from dask.distributed import Client
 
@@ -77,7 +79,9 @@ async def port_forward_service(service_name, remote_port, local_port=None):
             "port-forward",
             f"service/{service_name}",
             f"{local_port}:{remote_port}",
-        ]
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
     time.sleep(1)
     finalize(kproc, kproc.kill)
@@ -104,3 +108,21 @@ def check_dependency(dependency):
             f"Missing dependency {dependency}. "
             f"Please install {dependency} following the instructions for your OS. "
         )
+
+
+def b64_dump(obj):
+    """Dump an object to a base64 endoded JSON."""
+    s = json.dumps(obj)
+    s_bytes = s.encode("ascii")
+    b64_bytes = base64.b64encode(s_bytes)
+    b64 = b64_bytes.decode("ascii")
+    return b64
+
+
+def b64_load(b64):
+    """Load an object from base64 endoded JSON."""
+    b64_bytes = b64.encode("ascii")
+    s_bytes = base64.b64decode(b64_bytes)
+    s = s_bytes.decode("ascii")
+    obj = json.loads(s)
+    return obj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask>=2021.02.0
-distributed>=2021.02.0
+dask>=2021.03.0
+distributed>=2021.03.0
 kubernetes>=9
 kubernetes-asyncio>=9

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(
     entry_points="""
         [dask_cluster_discovery]
         helmcluster=dask_kubernetes.helm:discover
+        kubecluster=dask_kubernetes.core:discover
       """,
 )


### PR DESCRIPTION
Adds a `discovery` method for `KubeCluster` objects and also the `from_name` method required to reconstruct a `KubeCluster` object.

This PR works by serializing the `KubeCluster` object into a Kubernetes `Secret` resource, allowing it to be recreated at a later time.

This may not be an ideal approach, but opening this anyway as a reference.

```python
from dask_kubernetes import KubeCluster

cluster = KubeCluster(shutdown_on_close=True)  # Minimal pod spec stored in config
cluster.scale(5)

del cluster
```

```console
$ daskctl cluster list
NAME                        ADDRESS                TYPE         WORKERS  THREADS  MEMORY   CREATED   STATUS
dask-jtomlinson-bffca7fc-7  tcp://localhost:65125  KubeCluster        5        5  5.20 GB  Just now  Running
```

```python
from dask_ctl import get_cluster

cluster = get_cluster("dask-jtomlinson-bffca7fc-7")
```

_Note the address is `localhost` as I used port forwarding in my config. This port will randomly change every time we run `get_cluster` (which is used within `daskctl`). For clusters using a LoadBalancer or NodePort this address will be consistent._