### PR TITLE
Updated kubecluster to remove depreciated docs

### DIFF
--- a/doc/source/kubecluster.rst
+++ b/doc/source/kubecluster.rst
@@ -12,7 +12,7 @@ Quickstart
 
    from dask_kubernetes import KubeCluster
 
-   cluster = KubeCluster.from_yaml('worker-spec.yml')
+   cluster = KubeCluster('worker-spec.yml')
    cluster.scale(10)  # specify number of workers explicitly
 
    cluster.adapt(minimum=1, maximum=100)  # or dynamically scale based on current workload


### PR DESCRIPTION
Noticed that the docs showing `Deprecated, please use the KubeCluster constructor directly` [here](https://kubernetes.dask.org/en/latest/kubecluster.html#dask_kubernetes.KubeCluster.from_yaml). There might be other places where issues like this exist, I probably didn't catch them all