### PR TITLE
Add type argument to make_pod_spec

### DIFF
--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -125,22 +125,25 @@ def make_pod_spec(
     memory_request=None,
     cpu_limit=None,
     cpu_request=None,
-    type=None
+    type=None,
 ):
     """
     Create generic pod template from input parameters
 
+
     type : str
-        Type of a dask pod. Can be "scheduler" or "worker". Defaults to "worker"
+        Type of a dask pod. Can be "scheduler" or "worker". Defaults to "worker".
+
 
     Examples
     --------
     >>> make_pod_spec(image='daskdev/dask:latest', memory_limit='4G', memory_request='4G')
     """
-
     pod_type = type
     args = None
-    if pod_type is None or pod_type == "worker":
+    if pod_type is None:
+        pod_type = "worker"
+    if pod_type == "worker":
         args = [
             "dask-worker",
             "$(DASK_SCHEDULER_ADDRESS)",
@@ -329,4 +332,3 @@ def clean_pdb_template(pdb_template):
         pdb_template.spec.selector = client.V1LabelSelector()
 
     return pdb_template
-

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -125,31 +125,44 @@ def make_pod_spec(
     memory_request=None,
     cpu_limit=None,
     cpu_request=None,
+    type=None
 ):
     """
     Create generic pod template from input parameters
+
+    type : str
+        Type of a dask pod. Can be "scheduler" or "worker". Defaults to "worker"
 
     Examples
     --------
     >>> make_pod_spec(image='daskdev/dask:latest', memory_limit='4G', memory_request='4G')
     """
-    args = [
-        "dask-worker",
-        "$(DASK_SCHEDULER_ADDRESS)",
-        "--nthreads",
-        str(threads_per_worker),
-        "--death-timeout",
-        "60",
-    ]
-    if memory_limit:
-        args.extend(["--memory-limit", str(memory_limit)])
+
+    pod_type = type
+    args = None
+    if pod_type is None or pod_type == "worker":
+        args = [
+            "dask-worker",
+            "$(DASK_SCHEDULER_ADDRESS)",
+            "--nthreads",
+            str(threads_per_worker),
+            "--death-timeout",
+            "60",
+        ]
+        if memory_limit:
+            args.extend(["--memory-limit", str(memory_limit)])
+    elif pod_type == "scheduler":
+        args = ["dask-scheduler"]
+    else:
+        raise RuntimeError("Unknown pod type %s" % pod_type)
+
     pod = client.V1Pod(
         metadata=client.V1ObjectMeta(labels=labels),
         spec=client.V1PodSpec(
             restart_policy="Never",
             containers=[
                 client.V1Container(
-                    name="dask-worker",
+                    name="dask-%s" % pod_type,
                     image=image,
                     args=args,
                     env=[client.V1EnvVar(name=k, value=v) for k, v in env.items()],
@@ -316,3 +329,4 @@ def clean_pdb_template(pdb_template):
         pdb_template.spec.selector = client.V1LabelSelector()
 
     return pdb_template
+


### PR DESCRIPTION
Added `type` argument to `make_pod_spec` function. 

I had an issue using `make_pod_spec` element as `scheduler_pod_template` in `KubeCluster` constructor. My scheduler was unable to start with `ValueError: missing port number in address '$(DASK_SCHEDULER_ADDRESS)'` because `args` list contains elements, that relate to "dask-worker" explicitly.