### PR TITLE
ensure Pod.close() succeeds when pod has already been removed

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -87,8 +87,8 @@ class Pod(ProcessInterface):
                     raise e
 
     async def close(self, **kwargs):
-        name, namespace = self._pod.metadata.name, self.namespace
         if self._pod:
+            name, namespace = self._pod.metadata.name, self.namespace
             try:
                 await self.core_api.delete_namespaced_pod(name, namespace)
             except ApiException as e:


### PR DESCRIPTION
Thanks very much for this project!

I've started getting familiar with `dask-kubernetes` recently, and found what I believe is a small bug. The teardown method `dask_kubernetes.core.Pod.close()` tries to access details of `self._pod` before checking whether or not `self._pod` is `None`. As a result, if you tear down a `Pod` object that is already empty, you'll get the following error:

> AttributeError: 'NoneType' object has no attribute 'metadata'

This PR proposes a fix to avoid that.