### PR TITLE
[ci] remove duplicate unit test

### DIFF
--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -69,33 +69,6 @@ def test_extra_container_config_merge(docker_image, loop):
     with KubeCluster(
         make_pod_spec(
             docker_image,
-            extra_container_config={
-                "env": [{"name": "BOO", "value": "FOO"}],
-                "args": ["last-item"],
-            },
-        ),
-        loop=loop,
-        n_workers=0,
-        env={"TEST": "HI"},
-    ) as cluster:
-
-        pod = cluster.pod_template
-
-        assert pod.spec.containers[0].env == [
-            {"name": "TEST", "value": "HI"},
-            {"name": "BOO", "value": "FOO"},
-        ]
-
-        assert pod.spec.containers[0].args[-1] == "last-item"
-
-
-def test_extra_container_config_merge(docker_image, loop):
-    """
-    Test that our container config merging process works recursively fine
-    """
-    with KubeCluster(
-        make_pod_spec(
-            docker_image,
             env={"TEST": "HI"},
             extra_container_config={
                 "env": [{"name": "BOO", "value": "FOO"}],


### PR DESCRIPTION
I've been getting familiar with `dask-kubernetes` recently and wanted to make some small contributions.

I found what looks like a duplicated unit test in `tests/test_objects.py`. There are two tests there named `test_extra_container_config_merge()`, and both seem to be testing the exact same thing.

This PR proposes removing one of the duplicate tests.

## Notes for Reviewers

I found this by running `mypy --ignore-missing-imports .`, which yielded a few warnings including the following:

> dask_kubernetes/tests/test_objects.py:92: error: Name 'test_extra_container_config_merge' already defined on line 65

I think it would be useful for maintainers here to set up `mypy` in continuous integration in the future, to catch such issues. In this case it doesn't look like there was any loss of testing coverage because these were testing the same thing. But I've seen other cases where two *different* tests have the same name. In that situation, `pytest` will only run the most-recently-defined one. This can lead to some tests silently be skipped :grimacing: 

Thanks for your time and consideration.