### PR TITLE
remove unused import 'yaml'

### DIFF
--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -8,11 +8,6 @@ import json
 
 from kubernetes.client.configuration import Configuration
 
-try:
-    import yaml
-except ImportError:
-    yaml = False
-
 _FakeResponse = namedtuple("_FakeResponse", ["data"])
 
 
@@ -98,7 +93,7 @@ def merge_dictionaries(a, b, path=None, update=True):
             elif a[key] == b[key]:
                 pass  # same leaf value
             elif isinstance(a[key], list) and isinstance(b[key], list):
-                for idx, val in enumerate(b[key]):
+                for idx, _ in enumerate(b[key]):
                     a[key][idx] = merge_dictionaries(
                         a[key][idx],
                         b[key][idx],


### PR DESCRIPTION
I ran `pylint dask_kubernetes` today to see if there were any small things I could contribute fixes for, and I think I found some!

This PR proposes changes to fix these two warnings raised by `pylint`.

```text
dask_kubernetes/objects.py:101:25: W0612: Unused variable 'val' (unused-variable)
dask_kubernetes/objects.py:12:4: W0611: Unused import yaml (unused-import)
```

Thanks for your time and consideration.