### PR TITLE
allow imports like 'from dask_kubernetes import *'

### DIFF
--- a/dask_kubernetes/__init__.py
+++ b/dask_kubernetes/__init__.py
@@ -11,7 +11,7 @@ from .core import KubeCluster
 from .helm import HelmCluster
 from .objects import make_pod_spec, make_pod_from_dict, clean_pod_template
 
-__all__ = [KubeCluster, HelmCluster]
+__all__ = ["HelmCluster", "KubeCluster"]
 
 from ._version import get_versions
 


### PR DESCRIPTION
### Short Description

Because `__all__` in `__init__.py` is not a list of strings, using `from dask_kubernetes import *` results in an error. This PR changes `__all__` to a list of strings.

### Longer Description

I've been getting more familiar with `dask-kubernetes`, and looking for small opportunities to contribute.

Running `pylint dask_kubernetes`, I saw the following significant warning.

```text
dask_kubernetes/__init__.py:14:11: E0604: Invalid object 'KubeCluster' in __all__, must contain only strings (invalid-all-object)
dask_kubernetes/__init__.py:14:24: E0604: Invalid object 'HelmCluster' in __all__, must contain only strings (invalid-all-object)
```

This one is fairly serious. On `main`, running the following

```shell
python setup.py install
python -c 'from dask_kubernetes import *; print(dir())'
```

results in this error:

> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1037, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 1033, in _handle_fromlist
TypeError: Item in dask_kubernetes.__all__ must be str, not type

As of this PR, the same code is successful and demonstrates that only `HelmCluster` and `KubeCluster` are imported with `from dask_kubernetes import *`.

> ['HelmCluster', 'KubeCluster', '__annotations__', '__builtins__', '__doc__', '__loader__', '__name__', '__package__', '__spec__']

While I'm touching that line anyway, this PR also proposes switching the order of the elements in `__all__` so they are in alphabetical order. I've found that this makes that list easier to manage if, in the future, additional elements are added.

### References

Python docs on `__all__`: https://docs.python.org/3/tutorial/modules.html#importing-from-a-package