### PR TITLE
remove unnecessary statement in HelmCluster constructor

### DIFF
--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -106,7 +106,6 @@ class HelmCluster(Cluster):
         if status.returncode != 0:
             raise RuntimeError(f"No such helm release {self.release_name}.")
         self.auth = auth
-        self.namespace
         self.core_api = None
         self.scheduler_comm = None
         self.port_forward_cluster_ip = port_forward_cluster_ip


### PR DESCRIPTION
This PR proposes removing a statement in the `HelmCluster` constructor which seems to not do anything.

I found this by running `pylint dask_kubernetes/`, which produces the following:

> dask_kubernetes/helm.py:109:8: W0104: Statement seems to have no effect (pointless-statement)

Thanks for your time and consideration.