### PR TITLE
Explicitly set a host when using NodePort Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ credentials.csv
 *.pub
 *.rdp
 *_rsa
+
+# IDE settings
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,3 @@ credentials.csv
 *.pub
 *.rdp
 *_rsa
-
-# IDE settings
-.idea

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -152,7 +152,7 @@ class Worker(Pod):
 
 
 class Scheduler(Pod):
-    """A Remote Dask Scheduler controled by Kubernetes
+    """A Remote Dask Scheduler controlled by Kubernetes
     Parameters
     ----------
     idle_timeout: str, optional
@@ -198,7 +198,7 @@ class Scheduler(Pod):
             port=SCHEDULER_PORT,
         )
         self.external_address = await get_external_address_for_scheduler_service(
-            self.core_api, self.service
+            self.core_api, self.service, host=self.kwargs["host"]
         )
 
         self.pdb = await self._create_pdb()
@@ -578,6 +578,7 @@ class KubeCluster(SpecCluster):
                     "idle_timeout": self._idle_timeout,
                     "service_wait_timeout_s": self._scheduler_service_wait_timeout,
                     "pod_template": self.scheduler_pod_template,
+                    "host": self.host,
                     **common_options,
                 },
             }

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -351,8 +351,7 @@ class KubeCluster(SpecCluster):
     >>> pod_spec = make_pod_spec(image='daskdev/dask:latest',
     ...                          memory_limit='4G', memory_request='4G',
     ...                          cpu_limit=1, cpu_request=1,
-    ...                          env={'EXTRA_PIP_PACKAGES': 'fastparquet
-    git+https://github.com/dask/distributed'})
+    ...                          env={'EXTRA_PIP_PACKAGES': 'fastparquet git+https://github.com/dask/distributed'})
     >>> cluster = KubeCluster(pod_spec)
     >>> cluster.scale(10)
 

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -425,7 +425,7 @@ class KubeCluster(SpecCluster):
         security=None,
         scheduler_service_wait_timeout=None,
         scheduler_pod_template=None,
-        scheduler_service_type="ClusterIP",
+        scheduler_service_type=None,
         nodeport_host=None,
         **kwargs
     ):

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -321,8 +321,8 @@ class KubeCluster(SpecCluster):
         Listen address for local scheduler. Only used when deploy_mode == "local". Defaults to
         0.0.0.0
     nodeport_host: str
-        When scheduler_service_type == ``"NodePort"``, override KubeCluster's default behaviour
-        of listing nodes by specifying a nodeport_host.
+        When scheduler_service_type == ``"NodePort"``, select a specific node IP to connect to.
+        When this is not set the node IP will be autodetected.
     port: int
         Port of local scheduler
     auth: List[ClusterAuth] (optional)

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -14,6 +14,7 @@ kubernetes:
   dashboard_address: ":8787"
 
   scheduler-service-type: "ClusterIP"
+  scheduler-nodeport-host: null
   # Timeout to wait for the scheduler service to be up (in seconds)
   # Set it to 0 to wait indefinitely (not recommended)
   scheduler-service-wait-timeout: 30

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -23,7 +23,6 @@ from dask_kubernetes import (
 from distributed.utils import tmpfile
 from distributed.utils_test import captured_logger
 
-
 TEST_DIR = os.path.abspath(os.path.join(__file__, ".."))
 CONFIG_DEMO = os.path.join(TEST_DIR, "config-demo.yaml")
 FAKE_CERT = os.path.join(TEST_DIR, "fake-cert-file")
@@ -388,6 +387,15 @@ async def test_constructor_parameters(k8s_cluster, pod_spec):
         assert var and var[0].value == "1"
 
         assert pod.metadata.generate_name == "myname"
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="Can't communicate with kind nodes")
+async def test_passing_host_to_nodeport_service(k8s_cluster, pod_spec):
+    with dask.config.set({"kubernetes.scheduler-service-type": "NodePort"}):
+        async with KubeCluster(pod_spec, host="127.0.0.1", **cluster_kwargs) as cluster:
+            assert cluster.scheduler.service_template.spec.type == "NodePort"
+            assert cluster.scheduler.external_address == "127.0.0.1"
 
 
 @pytest.mark.asyncio

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -129,9 +129,9 @@ async def test_logs(remote_cluster):
     assert len(logs) == 4
     for _, log in logs.items():
         assert (
-                "distributed.scheduler" in log
-                or "distributed.worker" in log
-                or "Creating scheduler pod" in log
+            "distributed.scheduler" in log
+            or "distributed.worker" in log
+            or "Creating scheduler pod" in log
         )
 
 
@@ -150,7 +150,7 @@ async def test_diagnostics_link_env_variable(k8s_cluster, pod_spec, user_env):
             port = cluster.scheduler_info["services"]["dashboard"]
 
             assert (
-                    "foo-" + getpass.getuser() + "-" + str(port) in cluster.dashboard_link
+                "foo-" + getpass.getuser() + "-" + str(port) in cluster.dashboard_link
             )
 
 
@@ -378,7 +378,7 @@ async def test_pod_template_from_conf(docker_image):
 async def test_constructor_parameters(k8s_cluster, pod_spec):
     env = {"FOO": "BAR", "A": 1}
     async with KubeCluster(
-            pod_spec, name="myname", env=env, **cluster_kwargs
+        pod_spec, name="myname", env=env, **cluster_kwargs
     ) as cluster:
         pod = cluster.pod_template
         assert pod.metadata.namespace == "default"
@@ -394,7 +394,7 @@ async def test_constructor_parameters(k8s_cluster, pod_spec):
 
 @pytest.mark.asyncio
 async def test_passing_nodeport_host_to_scheduler_will_set_correct_host(
-        k8s_cluster, pod_spec
+    k8s_cluster, pod_spec
 ):
     cluster = KubeCluster(
         pod_template=pod_spec,
@@ -412,8 +412,11 @@ async def test_passing_nodeport_host_to_scheduler_will_set_correct_host(
         pod_template=cluster.scheduler_pod_template, pod_type="scheduler"
     )
     await ClusterAuth.load_first(cluster.auth)
-    cluster._generate_name = escape(cluster._generate_name.format(user=getpass.getuser(),
-                                                                  uuid=str(uuid.uuid4())[:10]))
+    cluster._generate_name = escape(
+        cluster._generate_name.format(
+            user=getpass.getuser(), uuid=str(uuid.uuid4())[:10]
+        )
+    )
     cluster.scheduler_pod_template = cluster._fill_pod_templates(
         cluster.scheduler_pod_template, pod_type="scheduler"
     )
@@ -431,7 +434,9 @@ async def test_passing_nodeport_host_to_scheduler_will_set_correct_host(
         loop=cluster.loop,
     )
 
-    scheduler.service = await scheduler._create_service(scheduler.kwargs["scheduler_service_type"])
+    scheduler.service = await scheduler._create_service(
+        scheduler.kwargs["scheduler_service_type"]
+    )
 
     external_address = await get_external_address_for_scheduler_service(
         scheduler.core_api,
@@ -644,8 +649,8 @@ async def test_repr(cluster):
     for text in [repr(cluster), str(cluster)]:
         assert "Box" not in text
         assert (
-                cluster.scheduler.address in text
-                or cluster.scheduler.external_address in text
+            cluster.scheduler.address in text
+            or cluster.scheduler.external_address in text
         )
 
 
@@ -688,19 +693,19 @@ async def test_maximum(cluster):
 def test_default_toleration(pod_spec):
     tolerations = pod_spec.to_dict()["spec"]["tolerations"]
     assert {
-               "key": "k8s.dask.org/dedicated",
-               "operator": "Equal",
-               "value": "worker",
-               "effect": "NoSchedule",
-               "toleration_seconds": None,
-           } in tolerations
+        "key": "k8s.dask.org/dedicated",
+        "operator": "Equal",
+        "value": "worker",
+        "effect": "NoSchedule",
+        "toleration_seconds": None,
+    } in tolerations
     assert {
-               "key": "k8s.dask.org_dedicated",
-               "operator": "Equal",
-               "value": "worker",
-               "effect": "NoSchedule",
-               "toleration_seconds": None,
-           } in tolerations
+        "key": "k8s.dask.org_dedicated",
+        "operator": "Equal",
+        "value": "worker",
+        "effect": "NoSchedule",
+        "toleration_seconds": None,
+    } in tolerations
 
 
 def test_default_toleration_preserved(docker_image):
@@ -720,24 +725,24 @@ def test_default_toleration_preserved(docker_image):
     )
     tolerations = pod_spec.to_dict()["spec"]["tolerations"]
     assert {
-               "key": "k8s.dask.org/dedicated",
-               "operator": "Equal",
-               "value": "worker",
-               "effect": "NoSchedule",
-               "toleration_seconds": None,
-           } in tolerations
+        "key": "k8s.dask.org/dedicated",
+        "operator": "Equal",
+        "value": "worker",
+        "effect": "NoSchedule",
+        "toleration_seconds": None,
+    } in tolerations
     assert {
-               "key": "k8s.dask.org_dedicated",
-               "operator": "Equal",
-               "value": "worker",
-               "effect": "NoSchedule",
-               "toleration_seconds": None,
-           } in tolerations
+        "key": "k8s.dask.org_dedicated",
+        "operator": "Equal",
+        "value": "worker",
+        "effect": "NoSchedule",
+        "toleration_seconds": None,
+    } in tolerations
     assert {
-               "key": "example.org/toleration",
-               "operator": "Exists",
-               "effect": "NoSchedule",
-           } in tolerations
+        "key": "example.org/toleration",
+        "operator": "Exists",
+        "effect": "NoSchedule",
+    } in tolerations
 
 
 @pytest.mark.asyncio

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -3,6 +3,7 @@ import base64
 import getpass
 import os
 import random
+import uuid
 from time import time
 
 import dask
@@ -23,7 +24,7 @@ from dask_kubernetes import (
     KubeAuth,
 )
 from dask_kubernetes.core import Scheduler
-from dask_kubernetes.utils import get_external_address_for_scheduler_service
+from dask_kubernetes.utils import get_external_address_for_scheduler_service, escape
 
 TEST_DIR = os.path.abspath(os.path.join(__file__, ".."))
 CONFIG_DEMO = os.path.join(TEST_DIR, "config-demo.yaml")
@@ -128,9 +129,9 @@ async def test_logs(remote_cluster):
     assert len(logs) == 4
     for _, log in logs.items():
         assert (
-            "distributed.scheduler" in log
-            or "distributed.worker" in log
-            or "Creating scheduler pod" in log
+                "distributed.scheduler" in log
+                or "distributed.worker" in log
+                or "Creating scheduler pod" in log
         )
 
 
@@ -149,7 +150,7 @@ async def test_diagnostics_link_env_variable(k8s_cluster, pod_spec, user_env):
             port = cluster.scheduler_info["services"]["dashboard"]
 
             assert (
-                "foo-" + getpass.getuser() + "-" + str(port) in cluster.dashboard_link
+                    "foo-" + getpass.getuser() + "-" + str(port) in cluster.dashboard_link
             )
 
 
@@ -377,7 +378,7 @@ async def test_pod_template_from_conf(docker_image):
 async def test_constructor_parameters(k8s_cluster, pod_spec):
     env = {"FOO": "BAR", "A": 1}
     async with KubeCluster(
-        pod_spec, name="myname", env=env, **cluster_kwargs
+            pod_spec, name="myname", env=env, **cluster_kwargs
     ) as cluster:
         pod = cluster.pod_template
         assert pod.metadata.namespace == "default"
@@ -393,7 +394,7 @@ async def test_constructor_parameters(k8s_cluster, pod_spec):
 
 @pytest.mark.asyncio
 async def test_passing_nodeport_host_to_scheduler_will_set_correct_host(
-    k8s_cluster, pod_spec
+        k8s_cluster, pod_spec
 ):
     cluster = KubeCluster(
         pod_template=pod_spec,
@@ -403,20 +404,24 @@ async def test_passing_nodeport_host_to_scheduler_will_set_correct_host(
         **cluster_kwargs,
     )
 
-    scheduler_pod_template = cluster._get_pod_template(
+    cluster.scheduler_pod_template = cluster._get_pod_template(
         cluster.pod_template, pod_type="scheduler"
     )
-    scheduler_pod_template = clean_pod_template(
-        pod_template=scheduler_pod_template, pod_type="scheduler"
+    cluster.scheduler_pod_template.spec.containers[0].args = ["dask-scheduler"]
+    cluster.scheduler_pod_template = clean_pod_template(
+        pod_template=cluster.scheduler_pod_template, pod_type="scheduler"
     )
-    scheduler_pod_template = cluster._fill_pod_templates(
-        scheduler_pod_template, pod_type="scheduler"
+    await ClusterAuth.load_first(cluster.auth)
+    cluster._generate_name = escape(cluster._generate_name.format(user=getpass.getuser(),
+                                                                  uuid=str(uuid.uuid4())[:10]))
+    cluster.scheduler_pod_template = cluster._fill_pod_templates(
+        cluster.scheduler_pod_template, pod_type="scheduler"
     )
 
     scheduler = Scheduler(
         idle_timeout=cluster._idle_timeout,
         service_wait_timeout_s=cluster._scheduler_service_wait_timeout,
-        pod_template=scheduler_pod_template,
+        pod_template=cluster.scheduler_pod_template,
         nodeport_host=cluster.nodeport_host,
         scheduler_service_type=cluster._scheduler_service_type,
         cluster=cluster,
@@ -426,14 +431,15 @@ async def test_passing_nodeport_host_to_scheduler_will_set_correct_host(
         loop=cluster.loop,
     )
 
-    await scheduler._create_service(scheduler.kwargs["scheduler_service_type"])
+    scheduler.service = await scheduler._create_service(scheduler.kwargs["scheduler_service_type"])
 
     external_address = await get_external_address_for_scheduler_service(
         scheduler.core_api,
         scheduler.service,
         nodeport_host=scheduler.kwargs["nodeport_host"],
     )
-    assert external_address == "10.10.10.10"
+    assert external_address == "tcp://10.10.10.10:8786"
+    assert scheduler.service.spec.type == "NodePort"
 
 
 @pytest.mark.asyncio
@@ -638,8 +644,8 @@ async def test_repr(cluster):
     for text in [repr(cluster), str(cluster)]:
         assert "Box" not in text
         assert (
-            cluster.scheduler.address in text
-            or cluster.scheduler.external_address in text
+                cluster.scheduler.address in text
+                or cluster.scheduler.external_address in text
         )
 
 
@@ -682,19 +688,19 @@ async def test_maximum(cluster):
 def test_default_toleration(pod_spec):
     tolerations = pod_spec.to_dict()["spec"]["tolerations"]
     assert {
-        "key": "k8s.dask.org/dedicated",
-        "operator": "Equal",
-        "value": "worker",
-        "effect": "NoSchedule",
-        "toleration_seconds": None,
-    } in tolerations
+               "key": "k8s.dask.org/dedicated",
+               "operator": "Equal",
+               "value": "worker",
+               "effect": "NoSchedule",
+               "toleration_seconds": None,
+           } in tolerations
     assert {
-        "key": "k8s.dask.org_dedicated",
-        "operator": "Equal",
-        "value": "worker",
-        "effect": "NoSchedule",
-        "toleration_seconds": None,
-    } in tolerations
+               "key": "k8s.dask.org_dedicated",
+               "operator": "Equal",
+               "value": "worker",
+               "effect": "NoSchedule",
+               "toleration_seconds": None,
+           } in tolerations
 
 
 def test_default_toleration_preserved(docker_image):
@@ -714,24 +720,24 @@ def test_default_toleration_preserved(docker_image):
     )
     tolerations = pod_spec.to_dict()["spec"]["tolerations"]
     assert {
-        "key": "k8s.dask.org/dedicated",
-        "operator": "Equal",
-        "value": "worker",
-        "effect": "NoSchedule",
-        "toleration_seconds": None,
-    } in tolerations
+               "key": "k8s.dask.org/dedicated",
+               "operator": "Equal",
+               "value": "worker",
+               "effect": "NoSchedule",
+               "toleration_seconds": None,
+           } in tolerations
     assert {
-        "key": "k8s.dask.org_dedicated",
-        "operator": "Equal",
-        "value": "worker",
-        "effect": "NoSchedule",
-        "toleration_seconds": None,
-    } in tolerations
+               "key": "k8s.dask.org_dedicated",
+               "operator": "Equal",
+               "value": "worker",
+               "effect": "NoSchedule",
+               "toleration_seconds": None,
+           } in tolerations
     assert {
-        "key": "example.org/toleration",
-        "operator": "Exists",
-        "effect": "NoSchedule",
-    } in tolerations
+               "key": "example.org/toleration",
+               "operator": "Exists",
+               "effect": "NoSchedule",
+           } in tolerations
 
 
 @pytest.mark.asyncio

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -3,7 +3,6 @@ import base64
 import getpass
 import os
 import random
-import uuid
 from time import time
 
 import dask
@@ -23,8 +22,7 @@ from dask_kubernetes import (
     KubeConfig,
     KubeAuth,
 )
-from dask_kubernetes.core import Scheduler
-from dask_kubernetes.utils import get_external_address_for_scheduler_service, escape
+from dask_kubernetes.utils import get_external_address_for_scheduler_service
 
 TEST_DIR = os.path.abspath(os.path.join(__file__, ".."))
 CONFIG_DEMO = os.path.join(TEST_DIR, "config-demo.yaml")
@@ -397,11 +395,15 @@ async def test_passing_nodeport_host_to_scheduler_will_set_correct_host(
     k8s_cluster, pod_spec
 ):
     from dask_kubernetes.objects import make_service_from_dict
-    
-    service = make_service_from_dict({"spec": {"ports": [{"port": 8786, "name": "comm"}], "type": "NodePort"}})
-    
+
+    service = make_service_from_dict(
+        {"spec": {"ports": [{"port": 8786, "name": "comm"}], "type": "NodePort"}}
+    )
+
     external_address = await get_external_address_for_scheduler_service(
-        None, service, nodeport_host="10.10.10.10",
+        None,
+        service,
+        nodeport_host="10.10.10.10",
     )
     assert external_address == "tcp://10.10.10.10:8786"
 

--- a/dask_kubernetes/utils.py
+++ b/dask_kubernetes/utils.py
@@ -53,8 +53,9 @@ async def get_external_address_for_scheduler_service(
         lb = service.status.load_balancer.ingress[0]
         host = lb.hostname or lb.ip
     elif service.spec.type == "NodePort":
-        host = nodeport_host
-        if host is None:
+        if nodeport_host is not None:
+            host = nodeport_host
+        else:
             nodes = await core_api.list_node()
             host = nodes.items[0].status.addresses[0].address
     elif service.spec.type == "ClusterIP":

--- a/dask_kubernetes/utils.py
+++ b/dask_kubernetes/utils.py
@@ -41,7 +41,7 @@ def namespace_default():
 
 
 async def get_external_address_for_scheduler_service(
-    core_api, service, port_forward_cluster_ip=None
+    core_api, service, port_forward_cluster_ip=None, host=None
 ):
     """Take a service object and return the scheduler address."""
     [port] = [
@@ -53,8 +53,9 @@ async def get_external_address_for_scheduler_service(
         lb = service.status.load_balancer.ingress[0]
         host = lb.hostname or lb.ip
     elif service.spec.type == "NodePort":
-        nodes = await core_api.list_node()
-        host = nodes.items[0].status.addresses[0].address
+        if host is None:
+            nodes = await core_api.list_node()
+            host = nodes.items[0].status.addresses[0].address
     elif service.spec.type == "ClusterIP":
         try:
             # Try to resolve the service name. If we are inside the cluster this should succeeed.

--- a/dask_kubernetes/utils.py
+++ b/dask_kubernetes/utils.py
@@ -41,7 +41,7 @@ def namespace_default():
 
 
 async def get_external_address_for_scheduler_service(
-    core_api, service, port_forward_cluster_ip=None, host=None
+    core_api, service, port_forward_cluster_ip=None, nodeport_host=None
 ):
     """Take a service object and return the scheduler address."""
     [port] = [
@@ -53,6 +53,7 @@ async def get_external_address_for_scheduler_service(
         lb = service.status.load_balancer.ingress[0]
         host = lb.hostname or lb.ip
     elif service.spec.type == "NodePort":
+        host = nodeport_host
         if host is None:
             nodes = await core_api.list_node()
             host = nodes.items[0].status.addresses[0].address


### PR DESCRIPTION
Previously, if the service type was a NodePort, KubeCluster would attempt to discover the IP address by listing nodes. This is a set of permissions that not all users will have, so this PR adds the ability to explicitly set a known host.

Closes #348 