### PR TITLE
Set default container name when deserializing pod template

### DIFF
--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -177,6 +177,9 @@ def make_pod_spec(
 
 
 def make_pod_from_dict(dict_):
+    containers = dict_.get("spec", {}).get("containers", [])
+    for i, container in enumerate(containers):
+        container.setdefault("name", f"dask-{i}")
     return SERIALIZATION_API_CLIENT.deserialize(dict_, client.V1Pod)
 
 

--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -117,3 +117,40 @@ def test_make_pod_from_dict():
     assert pod.spec.restart_policy == "Never"
     assert pod.spec.containers[0].security_context.privileged
     assert pod.spec.containers[0].security_context.capabilities.add == ["SYS_ADMIN"]
+
+
+def test_make_pod_from_dict_default_container_name():
+    d = {
+        "kind": "Pod",
+        "metadata": {"labels": {"app": "dask", "dask.org/component": "dask-worker"}},
+        "spec": {
+            "containers": [
+                {
+                    "args": [
+                        "dask-worker",
+                        "$(DASK_SCHEDULER_ADDRESS)",
+                        "--nthreads",
+                        "1",
+                    ],
+                    "image": "image-name",
+                    "securityContext": {
+                        "capabilities": {"add": ["SYS_ADMIN"]},
+                        "privileged": True,
+                    },
+                },
+                {
+                    "image": "image-name2",
+                    "name": "sidecar"
+                },
+                {
+                    "image": "image-name3",
+                },
+            ],
+            "restartPolicy": "Never",
+        },
+    }
+
+    pod = make_pod_from_dict(d)
+    assert pod.spec.containers[0].name == "dask-0"
+    assert pod.spec.containers[1].name == "sidecar"
+    assert pod.spec.containers[2].name == "dask-2"


### PR DESCRIPTION
Set a default name for all containers in pod templates.

Closes https://github.com/dask/dask-kubernetes/issues/59