### PR TITLE
Use new Dask docs theme

### DIFF
--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -1,3 +1,3 @@
 numpydoc
 sphinx
-dask_sphinx_theme>=1.1.0
+dask_sphinx_theme>=2

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -117,12 +117,12 @@ html_static_path = ["_static"]
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    "**": [
-        "relations.html",  # needs 'show_related': True theme option to display
-        "searchbox.html",
-    ]
-}
+# html_sidebars = {
+#     "**": [
+#         "relations.html",  # needs 'show_related': True theme option to display
+#         "searchbox.html",
+#     ]
+# }
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -96,10 +96,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 # html_theme = 'alabaster'
-import dask_sphinx_theme
-
 html_theme = "dask_sphinx_theme"
-html_theme_path = [dask_sphinx_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Bumping the minimum docs theme to use the new version. This isn't strictly necessary but I wanted to raise a PR to trigger the rtd preview and check everything looks ok.

xref dask/dask-sphinx-theme#54