### PR TITLE
Switch to fork of pytest-kind

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,5 @@ black>=18.9b0
 dask-ctl>=2021.3.0
 pytest>=5.3
 pytest-asyncio>=0.10.0
-pytest-kind>=21.1.3
+git+https://codeberg.org/jacobtomlinson/pytest-kind.git@kind-1.11  # Until https://codeberg.org/hjacobs/pytest-kind/pulls/17 is merged and released
 pytest-timeout


### PR DESCRIPTION
The `pytest-kind` package is currently broken on GitHub Actions due to using `kind==0.10.0`. This PR moves us over onto my fork of `pytest-kind`.

I've opened a [PR upstream](https://codeberg.org/hjacobs/pytest-kind/pulls/17) so hopefully we can switch back at a later date.