### PR TITLE
Update Quickstarts docs to from_yaml()

### DIFF
--- a/doc/source/kubecluster.rst
+++ b/doc/source/kubecluster.rst
@@ -12,7 +12,7 @@ Quickstart
 
    from dask_kubernetes import KubeCluster
 
-   cluster = KubeCluster('worker-spec.yml')
+   cluster = KubeCluster.from_yaml('worker-spec.yml')
    cluster.scale(10)  # specify number of workers explicitly
 
    cluster.adapt(minimum=1, maximum=100)  # or dynamically scale based on current workload


### PR DESCRIPTION
Using the instructions as they are gives:
```
TypeError: Expected a kubernetes.client.V1Pod object, got worker-spec.ymlIf trying to pass a yaml filename then use KubeCluster.from_yaml
```