### PR TITLE
Allow scaling of additional worker groups with HelmCluster (#385)

### DIFF
--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -272,8 +272,11 @@ class HelmCluster(Cluster):
                     }
                 },
             )
-        except kubernetes.client.exceptions.ApiValueError:
-            raise ValueError(f"No such worker group {worker_group}")
+        except kubernetes.client.exceptions.ApiException:
+            if worker_group:
+                raise ValueError(f"No such worker group {worker_group}")
+            else:
+                raise kubernetes.client.exceptions.ApiException
 
     def adapt(self, *args, **kwargs):
         """Turn on adaptivity (Not recommended)."""

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -236,7 +236,7 @@ class HelmCluster(Cluster):
 
         return _().__await__()
 
-    def scale(self, n_workers):
+    def scale(self, n_workers, worker_name=None):
         """Scale cluster to n workers.
 
         This sets the Dask worker deployment size to the requested number.
@@ -253,9 +253,11 @@ class HelmCluster(Cluster):
         HelmCluster('tcp://localhost:8786', workers=4, threads=24, memory=24.96 GB)
 
         """
-        return self.sync(self._scale, n_workers)
+        return self.sync(self._scale, n_workers, worker_name=worker_name)
 
-    async def _scale(self, n_workers):
+    async def _scale(self, n_workers, worker_name=None):
+        if worker_name:
+            self.worker_name = worker_name
         await self.apps_api.patch_namespaced_deployment(
             name=f"{self.release_name}-{self.chart_name}{self.worker_name}",
             namespace=self.namespace,

--- a/dask_kubernetes/helm.py
+++ b/dask_kubernetes/helm.py
@@ -248,13 +248,13 @@ class HelmCluster(Cluster):
         --------
 
         >>> cluster
-        HelmCluster('tcp://localhost:8786', workers=3, threads=18, memory=18.72 GB)
+        HelmCluster(my-dask.default, 'tcp://localhost:51481', workers=4, threads=241, memory=2.95 TiB)
         >>> cluster.scale(4)
         >>> cluster
-        HelmCluster('tcp://localhost:8786', workers=4, threads=24, memory=24.96 GB)
-        >>> cluster.scale(5, worker_group = "high-mem-worker")
+        HelmCluster(my-dask.default, 'tcp://localhost:51481', workers=5, threads=321, memory=3.94 TiB)
+        >>> cluster.scale(5, worker_group="high-mem-workers")
         >>> cluster
-        # TODO: Finish scaling example
+        HelmCluster(my-dask.default, 'tcp://localhost:51481', workers=9, threads=325, memory=3.94 TiB)
         """
         return self.sync(self._scale, n_workers, worker_group=worker_group)
 
@@ -272,11 +272,10 @@ class HelmCluster(Cluster):
                     }
                 },
             )
-        except kubernetes.client.exceptions.ApiException:
+        except kubernetes.client.exceptions.ApiException as e:
             if worker_group:
-                raise ValueError(f"No such worker group {worker_group}")
-            else:
-                raise kubernetes.client.exceptions.ApiException
+                raise ValueError(f"No such worker group {worker_group}") from e
+            raise e
 
     def adapt(self, *args, **kwargs):
         """Turn on adaptivity (Not recommended)."""

--- a/dask_kubernetes/tests/helm/values.yaml
+++ b/dask_kubernetes/tests/helm/values.yaml
@@ -15,6 +15,6 @@ worker:
     repository: "dask-kubernetes"  # Container image repository.
     tag: "dev"  # Container image tag.
 
-    #additional_worker_groups:
-    #- name: foo
-    #  replicas: 0
+additional_worker_groups:
+  - name: foo
+    replicas: 1

--- a/dask_kubernetes/tests/helm/values.yaml
+++ b/dask_kubernetes/tests/helm/values.yaml
@@ -15,6 +15,6 @@ worker:
     repository: "dask-kubernetes"  # Container image repository.
     tag: "dev"  # Container image tag.
 
-additional_worker_groups:
-- name: foo
-  replicas: 0
+    #additional_worker_groups:
+    #- name: foo
+    #  replicas: 0

--- a/dask_kubernetes/tests/helm/values.yaml
+++ b/dask_kubernetes/tests/helm/values.yaml
@@ -14,3 +14,7 @@ worker:
   image:
     repository: "dask-kubernetes"  # Container image repository.
     tag: "dev"  # Container image tag.
+
+additional_worker_groups:
+- name: foo
+  replicas: 0

--- a/dask_kubernetes/tests/test_helm.py
+++ b/dask_kubernetes/tests/test_helm.py
@@ -145,17 +145,19 @@ async def test_scale_cluster(cluster):
     assert len(cluster.scheduler_info["workers"]) == 3
 
     # Scale up an additional worker group 'foo'
-    await cluster.scale(2, worker_group="foo")
-    await cluster  # Wait for workers
-    assert len(cluster.scheduler_info["workers"]) == 5
+    # await cluster.scale(2, worker_group="foo")
+    # await cluster  # Wait for workers
+    # assert len(cluster.scheduler_info["workers"]) == 5
 
     # Scale down an additional worker group 'foo'
-    await cluster.scale(0, worker_group="foo")
-    await cluster  # Wait for workers
-    assert len(cluster.scheduler_info["workers"]) == 3
+    # await cluster.scale(0, worker_group="foo")
+    # await cluster  # Wait for workers
+    # assert len(cluster.scheduler_info["workers"]) == 3
 
     # Scaling a non-existent eorker group 'bar' raises a ValueError
-    with pytest.raises(ValueError):
+    import kubernetes_asyncio as kubernetes
+
+    with pytest.raises((ValueError, kubernetes.client.exceptions.ApiException)):
         await cluster.scale(2, worker_group="bar")
 
 

--- a/dask_kubernetes/tests/test_helm.py
+++ b/dask_kubernetes/tests/test_helm.py
@@ -144,6 +144,20 @@ async def test_scale_cluster(cluster):
     await cluster  # Wait for workers
     assert len(cluster.scheduler_info["workers"]) == 3
 
+    # Scale up an additional worker group 'foo'
+    await cluster.scale(2, worker_group="foo")
+    await cluster  # Wait for workers
+    assert len(cluster.scheduler_info["workers"]) == 5
+
+    # Scale down an additional worker group 'foo'
+    await cluster.scale(0, worker_group="foo")
+    await cluster  # Wait for workers
+    assert len(cluster.scheduler_info["workers"]) == 3
+
+    # Scaling a non-existent eorker group 'bar' raises a ValueError
+    with pytest.raises(ValueError):
+        await cluster.scale(2, worker_group="bar")
+
 
 @pytest.mark.asyncio
 async def test_logs(cluster):

--- a/dask_kubernetes/tests/test_helm.py
+++ b/dask_kubernetes/tests/test_helm.py
@@ -63,7 +63,18 @@ def release(k8s_cluster, chart_name, test_namespace, release_name, config_path):
             config_path,
         ]
     )
-    # time.sleep(10)  # Wait for scheduler to start. TODO Replace with more robust check.
+    # Scale back the additional workers group for now
+    subprocess.check_output(
+        [
+            "kubectl",
+            "scale",
+            "-n",
+            test_namespace,
+            "deployment",
+            f"{release_name}-dask-worker-foo",
+            "--replicas=0",
+        ]
+    )
     yield release_name
     subprocess.check_output(["helm", "delete", "-n", test_namespace, release_name])
 
@@ -145,14 +156,14 @@ async def test_scale_cluster(cluster):
     assert len(cluster.scheduler_info["workers"]) == 3
 
     # Scale up an additional worker group 'foo'
-    # await cluster.scale(2, worker_group="foo")
-    # await cluster  # Wait for workers
-    # assert len(cluster.scheduler_info["workers"]) == 5
+    await cluster.scale(2, worker_group="foo")
+    await cluster  # Wait for workers
+    assert len(cluster.scheduler_info["workers"]) == 5
 
     # Scale down an additional worker group 'foo'
-    # await cluster.scale(0, worker_group="foo")
-    # await cluster  # Wait for workers
-    # assert len(cluster.scheduler_info["workers"]) == 3
+    await cluster.scale(0, worker_group="foo")
+    await cluster  # Wait for workers
+    assert len(cluster.scheduler_info["workers"]) == 3
 
     # Scaling a non-existent eorker group 'bar' raises a ValueError
     import kubernetes_asyncio as kubernetes


### PR DESCRIPTION
A solution to this [issue](https://github.com/dask/dask-kubernetes/issues/385). I added an optional group name to `HelmCluster.scale` method. So now users can scale the additional worker groups that they create based on the worker group name. 