### PR TITLE
Docs improvements

### DIFF
--- a/doc/source/helmcluster.rst
+++ b/doc/source/helmcluster.rst
@@ -3,10 +3,16 @@
 HelmCluster
 ===========
 
+:doc:`helmcluster` is for managing an existing Dask cluster which has been deployed using
+`Helm <https://helm.sh>`_.
+
 Quickstart
 ----------
 
 .. currentmodule:: dask_kubernetes
+
+First you must install the `Dask Helm chart <https://helm.dask.org/>`_ with ``helm``
+and have the cluster running.
 
 .. code-block:: bash
 
@@ -15,12 +21,31 @@ Quickstart
 
    helm install myrelease dask/dask
 
+You can then create a :class:`HelmCluster` object in Python to manage scaling the cluster and retrieve logs.
+
 .. code-block:: python
 
    from dask_kubernetes import HelmCluster
 
    cluster = HelmCluster(release_name="myrelease")
    cluster.scale(10)  # specify number of workers explicitly
+
+With this cluster object you can conveniently connect a Dask :class:`dask.distributed.Client` object to the cluster
+and perform your work. Provided you have API access to Kubernetes and can run the ``kubectl`` command then
+connectivity to the Dask cluster is handled automatically for you via services or port forwarding.
+
+.. code-block:: python
+
+    # Example usage
+    from dask.distributed import Client
+    import dask.array as da
+
+    # Connect Dask to the cluster
+    client = Client(cluster)
+
+    # Create a large array and calculate the mean
+    array = da.ones((1000, 1000, 1000))
+    print(array.mean().compute())  # Should print 1.0
 
 For more information see the :class:`HelmCluster` API reference.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,16 +3,37 @@ Dask Kubernetes
 
 .. currentmodule:: dask_kubernetes
 
-Dask Kubernetes provides cluster managers for Kubernetes.
+Welcome to the documentation for ``dask-kubernetes``.
 
-:class:`KubeCluster` deploys Dask clusters on Kubernetes clusters using native
+.. note::
+
+   If you are looking for general documentation on deploying
+   Dask on Kubernetes new users should head to the
+   `Dask documentation page on Kubernetes <https://docs.dask.org/en/latest/deploying-kubernetes.html>`_.
+
+The package ``dask-kubernetes`` provides cluster managers for Kubernetes.
+
+:doc:`kubecluster` deploys Dask clusters on Kubernetes clusters using native
 Kubernetes APIs.  It is designed to dynamically launch ad-hoc deployments.
 
-:class:`HelmCluster` is for managing an existing Dask cluster which has been deployed using
+.. code-block:: python
+
+    from dask_kubernetes import KubeCluster, make_pod_spec
+
+    pod_spec = make_pod_spec(image='daskdev/dask:latest')
+    cluster = KubeCluster(pod_spec)
+    cluster.scale(10)
+
+:doc:`helmcluster` is for managing an existing Dask cluster which has been deployed using
 `Helm <https://helm.sh>`_. You must have already installed the `Dask Helm chart <https://helm.dask.org/>`_
 and have the cluster running. You can then use it to manage scaling and retrieve logs.
 
-For more general information on running Dask on Kubernetes see `this page <https://docs.dask.org/en/latest/setup/kubernetes.html>`_.
+.. code-block:: python
+
+   from dask_kubernetes import HelmCluster
+
+   cluster = HelmCluster(release_name="myrelease")
+   cluster.scale(10)
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,6 +13,9 @@ Welcome to the documentation for ``dask-kubernetes``.
 
 The package ``dask-kubernetes`` provides cluster managers for Kubernetes.
 
+KubeCluster
+-----------
+
 :doc:`kubecluster` deploys Dask clusters on Kubernetes clusters using native
 Kubernetes APIs.  It is designed to dynamically launch ad-hoc deployments.
 
@@ -23,6 +26,9 @@ Kubernetes APIs.  It is designed to dynamically launch ad-hoc deployments.
     pod_spec = make_pod_spec(image='daskdev/dask:latest')
     cluster = KubeCluster(pod_spec)
     cluster.scale(10)
+
+HelmCluster
+-----------
 
 :doc:`helmcluster` is for managing an existing Dask cluster which has been deployed using
 `Helm <https://helm.sh>`_. You must have already installed the `Dask Helm chart <https://helm.dask.org/>`_


### PR DESCRIPTION
These changes include:
- Directing new users to the main [Dask on Kubernetes](https://docs.dask.org/en/latest/deploying-kubernetes.html) page earlier.
- Adding code examples to the index.
- Simplifying the `KubeCluster` quickstart example.
- Make better use of `:doc:` and `:class:` directives.