### PR TITLE
Pass worker resources to pod args

### DIFF
--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -117,6 +117,7 @@ def make_pod_spec(
     extra_container_config={},
     extra_pod_config={},
     memory_limit=None,
+    resources=None,
     memory_request=None,
     cpu_limit=None,
     cpu_request=None,
@@ -146,6 +147,10 @@ def make_pod_spec(
             - a float (fraction of total system memory).
             - a string (like 5GB or 5000M).
             - 'auto' for automatically computing the memory limit.  [default: auto]
+    resources : str
+        Resources for task constraints like "GPU=2 MEM=10e9". Resources are applied
+        separately to each worker process (only relevant when starting multiple
+        worker processes. Passed to the `--resources` option in ``dask-worker``.
     cpu_limit : float or str
         CPU resource limits (applied to ``spec.containers[].resources.limits.cpu``)
     cpu_requests : float or str
@@ -171,6 +176,8 @@ def make_pod_spec(
     ]
     if memory_limit:
         args.extend(["--memory-limit", str(memory_limit)])
+    if resources:
+        args.extend(["--resources", str(resources)])
     pod = client.V1Pod(
         metadata=client.V1ObjectMeta(labels=labels, annotations=annotations),
         spec=client.V1PodSpec(
@@ -226,7 +233,7 @@ def make_pdb_from_dict(dict_):
 
 
 def clean_pod_template(pod_template, match_node_purpose="prefer", pod_type="worker"):
-    """ Normalize pod template """
+    """Normalize pod template"""
     pod_template = copy.deepcopy(pod_template)
 
     # Make sure metadata / labels / env objects exist, so they can be modified
@@ -318,7 +325,7 @@ def clean_pod_template(pod_template, match_node_purpose="prefer", pod_type="work
 
 
 def clean_service_template(service_template):
-    """ Normalize service template and check for type errors """
+    """Normalize service template and check for type errors"""
 
     service_template = copy.deepcopy(service_template)
 
@@ -333,7 +340,7 @@ def clean_service_template(service_template):
 
 
 def clean_pdb_template(pdb_template):
-    """ Normalize pdb template and check for type errors """
+    """Normalize pdb template and check for type errors"""
 
     pdb_template = copy.deepcopy(pdb_template)
 

--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -87,6 +87,27 @@ def test_extra_container_config_merge(docker_image, loop):
         assert pod.spec.containers[0].args[-1] == "last-item"
 
 
+def test_worker_args(docker_image, loop):
+    """
+    Test that dask-worker arguments are added to the container args
+    """
+    with KubeCluster(
+        make_pod_spec(
+            docker_image,
+            memory_limit="5000M",
+            resources="FOO=1 BAR=2",
+        ),
+        loop=loop,
+        n_workers=0,
+    ) as cluster:
+
+        pod = cluster.pod_template
+
+        assert "--memory-limit" in pod.spec.containers[0].args
+        for arg in ["--memory-limit", "500M", "--resources", "FOO=1 BAR=2"]:
+            assert arg in pod.spec.containers[0].args
+
+
 def test_make_pod_from_dict():
     d = {
         "kind": "Pod",

--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -103,8 +103,7 @@ def test_worker_args(docker_image, loop):
 
         pod = cluster.pod_template
 
-        assert "--memory-limit" in pod.spec.containers[0].args
-        for arg in ["--memory-limit", "500M", "--resources", "FOO=1 BAR=2"]:
+        for arg in ["--memory-limit", "5000M", "--resources", "FOO=1 BAR=2"]:
             assert arg in pod.spec.containers[0].args
 
 


### PR DESCRIPTION
This adds a new keyword argument to `make_pod_spec`, facilitating passing worker resources through to the `dask-worker --resources` option.


This avoids the pattern of manipulating the pod spec after creating.

Before:

```python
pod_spec = make_pod_spec(...)
pod_spec.spec.containers[0].args.extend(["--resources", "FOO=1"])
```

Now:
```python
pod_spec = make_pod_spec(..., resources="FOO=1")
```