### PR TITLE
Fix label assignment for pdb_template

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -254,7 +254,7 @@ class Scheduler(Pod):
         pdb_template_dict = dask.config.get("kubernetes.scheduler-pdb-template")
         self.pdb_template = clean_pdb_template(make_pdb_from_dict(pdb_template_dict))
         self.pdb_template.metadata.name = self.cluster_name
-        self.pdb_template.spec.labels = copy.deepcopy(self.base_labels)
+        self.pdb_template.metadata.labels = copy.deepcopy(self.base_labels)
         self.pdb_template.spec.selector.match_labels[
             "dask.org/cluster-name"
         ] = self.cluster_name


### PR DESCRIPTION
The labels weren't correctly assigned for the pdb which made selecting pdbs belonging to a `KubeCluster` impossible. Functionality is the same as with `_create_service` above.