### PR TITLE
Refactor fixtures

### DIFF
--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -1,6 +1,7 @@
 import pytest
 
 import asyncio
+from contextlib import asynccontextmanager
 import pathlib
 import os.path
 
@@ -10,34 +11,33 @@ DIR = pathlib.Path(__file__).parent.absolute()
 
 
 @pytest.fixture()
-async def operator(k8s_cluster):
-    with KopfRunner(["run", "-m", "dask_kubernetes.operator", "--verbose"]) as runner:
-        yield runner
-
-    # Check operator completed successfully
-    assert runner.exit_code == 0
-    assert runner.exception is None
+async def kopf_runner(k8s_cluster):
+    yield KopfRunner(["run", "-m", "dask_kubernetes.operator", "--verbose"])
 
 
 @pytest.fixture()
-async def simplecluster(k8s_cluster, operator):
-    cluster_path = os.path.join(DIR, "resources", "simplecluster.yaml")
-    cluster_name = "simple-cluster"
+async def gen_cluster(k8s_cluster):
+    """Yields an instantiated context manager for creating/deleting a simple cluster."""
 
-    # Create cluster resource
-    k8s_cluster.kubectl("apply", "-f", cluster_path)
-    while cluster_name not in k8s_cluster.kubectl("get", "daskclusters"):
-        await asyncio.sleep(1)
+    @asynccontextmanager
+    async def cm():
+        cluster_path = os.path.join(DIR, "resources", "simplecluster.yaml")
+        cluster_name = "simple-cluster"
 
-    yield cluster_name
+        # Create cluster resource
+        k8s_cluster.kubectl("apply", "-f", cluster_path)
+        while cluster_name not in k8s_cluster.kubectl("get", "daskclusters"):
+            await asyncio.sleep(0.1)
 
-    # Delete cluster resource
-    k8s_cluster.kubectl("delete", "-f", cluster_path)
-    while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
-        await asyncio.sleep(1)
+        try:
+            yield cluster_name
+        finally:
+            # Delete cluster resource
+            k8s_cluster.kubectl("delete", "-f", cluster_path)
+            while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
+                await asyncio.sleep(0.1)
 
-    # FIXME stdout may not have triggered or flushed by this point but we should check that this was successful
-    # assert "A DaskCluster has been created" in operator.stdout
+    yield cm
 
 
 def test_customresources(k8s_cluster):
@@ -45,8 +45,21 @@ def test_customresources(k8s_cluster):
     assert "daskworkergroups.kubernetes.dask.org" in k8s_cluster.kubectl("get", "crd")
 
 
+def test_operator_runs(kopf_runner):
+    with kopf_runner as runner:
+        pass
+
+    assert runner.exit_code == 0
+    assert runner.exception is None
+
+
 @pytest.mark.timeout(60)
 @pytest.mark.asyncio
-async def test_simplecluster(simplecluster):
-    # If we get to this point then all fixtures worked ok and we can actually test some things
-    assert simplecluster
+async def test_simplecluster(kopf_runner, gen_cluster):
+    with kopf_runner as runner:
+        async with gen_cluster() as cluster_name:
+            # TODO test our cluster here
+            assert cluster_name
+
+    assert "A DaskCluster has been created" in runner.stdout
+    # TODO test that the cluster has been cleaned up


### PR DESCRIPTION
Moving the runner and cluster creation into fixtures made it tricky to make assertions after those things have stopped/been deleted

For the runner I've removed the `with` statement and just instantiated the running with the necessary arguments. That means in the test we need to do the `with` each time.

```python
def test_operator_runs(kopf_runner):
    # Do stuff before the operator starts
    with kopf_runner as runner:
        # Do stuff while the operator is running
    # Do stuff after the operator has exited
```

I've then applied that same pattern to the `simplecluster` fixture so now instead of applying and deleting the resource during the fixture it yields an async context manager that we can use in a `async with` statement to trigger the applying and deleting when we want to.

```python
@pytest.mark.asyncio
async def test_simplecluster(gen_cluster):
    # Do stuff before the cluster is applied
    async with gen_cluster() as cluster_name:
        # Do stuff while the cluster has been applied
    # Do stuff after the cluster has been deleted
```