### PR TITLE
Add Scaling to the Dask Operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,5 +32,6 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        run: pytest
+        # run: pytest
         # run: pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
+        run: pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,5 +32,5 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        # run: pytest
-        run: pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
+        run: pytest
+        # run: pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,4 @@ jobs:
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
         # run: pytest
-        run: pytest ../../dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
+        run: pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,9 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        # run: pytest
+        run: |
+          pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster
+          pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
+        # pytest
         # run: pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
-        run: pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster
+        # run: pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,4 +32,5 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        run: pytest
+        # run: pytest
+        run: pytest ../../dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,4 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        # run: pytest
-        # run: pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
-        run: pytest dask_kubernetes/operator/tests/test_operator.py -m asyncio
+        run: pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,6 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
-        run: |
-          pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster
-          pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
-        # pytest
+        # run: pytest
         # run: pytest dask_kubernetes/operator/tests/test_operator.py::test_scalesimplecluster
-        # run: pytest dask_kubernetes/operator/tests/test_operator.py::test_simplecluster
+        run: pytest dask_kubernetes/operator/tests/test_operator.py -m asyncio

--- a/dask_kubernetes/operator/customresources/daskcluster.yaml
+++ b/dask_kubernetes/operator/customresources/daskcluster.yaml
@@ -28,5 +28,5 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
       subresources:
         scale:
-          specReplicasPath: .spec.workers.replicas
+          specReplicasPath: .spec.replicas
           statusReplicasPath: .status.replicas

--- a/dask_kubernetes/operator/customresources/daskcluster.yaml
+++ b/dask_kubernetes/operator/customresources/daskcluster.yaml
@@ -26,3 +26,7 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.workers.replicas
+          statusReplicasPath: .status.replicas

--- a/dask_kubernetes/operator/customresources/daskworkergroup.yaml
+++ b/dask_kubernetes/operator/customresources/daskworkergroup.yaml
@@ -25,3 +25,7 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.workers.replicas
+          statusReplicasPath: .status.replicas

--- a/dask_kubernetes/operator/customresources/daskworkergroup.yaml
+++ b/dask_kubernetes/operator/customresources/daskworkergroup.yaml
@@ -27,5 +27,5 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
       subresources:
         scale:
-          specReplicasPath: .spec.workers.replicas
+          specReplicasPath: .spec.replicas
           statusReplicasPath: .status.replicas

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -235,7 +235,7 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
         label_selector=f"dask.org/workergroup-name={name}",
     )
     current_workers = len(workers.items)
-    desired_workers = spec["workers"]["replicas"]
+    desired_workers = spec["replicas"]
     workers_needed = desired_workers - current_workers
     if workers_needed > 0:
         for i in range(current_workers + 1, desired_workers + 1):

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -173,7 +173,7 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         spec.get("resources"),
         spec.get("env"),
     )
-    # kopf.adopt(data) # Unecessary if we can get worker groups adopted by the cluster
+    kopf.adopt(data)  # Unecessary if we can get worker groups adopted by the cluster
     api = kubernetes.client.CustomObjectsApi()
     worker_pods = api.create_namespaced_custom_object(
         group="kubernetes.dask.org",
@@ -256,15 +256,15 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
         logger.info(f"Scaled worker group {name} down to {spec['replicas']} workers.")
 
 
-# @kopf.on.delete("daskcluster")
-# async def daskcluster_delete(spec, name, namespace, logger, **kwargs):
-#     api = kubernetes.client.CustomObjectsApi()
-#     workergroups = api.list_cluster_custom_object(
-#         group="kubernetes.dask.org", version="v1", plural="daskworkergroups"
-#     )
-#     workergroups = api.delete_collection_namespaced_custom_object(
-#         group="kubernetes.dask.org",
-#         version="v1",
-#         plural="daskworkergroups",
-#         namespace=namespace,
-#     )
+@kopf.on.delete("daskcluster")
+async def daskcluster_delete(spec, name, namespace, logger, **kwargs):
+    api = kubernetes.client.CustomObjectsApi()
+    workergroups = api.list_cluster_custom_object(
+        group="kubernetes.dask.org", version="v1", plural="daskworkergroups"
+    )
+    workergroups = api.delete_collection_namespaced_custom_object(
+        group="kubernetes.dask.org",
+        version="v1",
+        plural="daskworkergroups",
+        namespace=namespace,
+    )

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -173,7 +173,8 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         spec.get("resources"),
         spec.get("env"),
     )
-    kopf.adopt(data)  # Unecessary if we can get worker groups adopted by the cluster
+    # TODO: Next line is not needed if we can get worker groups adopted by the cluster
+    kopf.adopt(data)
     api = kubernetes.client.CustomObjectsApi()
     worker_pods = api.create_namespaced_custom_object(
         group="kubernetes.dask.org",
@@ -196,18 +197,6 @@ async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
         group="kubernetes.dask.org", version="v1", plural="daskclusters"
     )
     scheduler_name = cluster["items"][0]["metadata"]["name"]
-    # scheduler_spec = scheduler["items"][0]["spec"]
-    # scheduler_data = build_scheduler_pod_spec(
-    #     name=scheduler_name, image=scheduler_spec.get("image")
-    # )
-    # data = build_worker_group_spec(
-    #     name.split('-')[0],
-    #     spec.get("image"),
-    #     spec.get("replicas"),
-    #     spec.get("resources"),
-    #     spec.get("env"),
-    # )
-    # kopf.adopt(data, owner = cluster["items"][0])
     num_workers = spec["replicas"]
     for i in range(1, num_workers + 1):
         data = build_worker_pod_spec(

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -239,7 +239,7 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
     if workers_needed < 0:
         for i in range(current_workers, desired_workers, -1):
             worker_pod = api.delete_namespaced_pod(
-                name=f"{name}-worker-{i}",
+                name=f"{scheduler_name}-{name}-worker-{i}",
                 namespace=namespace,
             )
         logger.info(f"Scaled worker group {name} down to {spec['replicas']} workers.")

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -87,7 +87,7 @@ def build_worker_pod_spec(name, namespace, image, n, scheduler_name):
         "apiVersion": "v1",
         "kind": "Pod",
         "metadata": {
-            "name": f"{name}-worker-{n}",
+            "name": f"{scheduler_name}-{name}-worker-{n}",
             "labels": {
                 "dask.org/cluster-name": scheduler_name,
                 "dask.org/workergroup-name": name,
@@ -257,3 +257,4 @@ async def daskcluster_delete(spec, name, namespace, logger, **kwargs):
         plural="daskworkergroups",
         namespace=namespace,
     )
+    # TODO: We would prefer to use adoptions rather than a delete handler

--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -256,15 +256,15 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
         logger.info(f"Scaled worker group {name} down to {spec['replicas']} workers.")
 
 
-@kopf.on.delete("daskcluster")
-async def daskcluster_delete(spec, name, namespace, logger, **kwargs):
-    api = kubernetes.client.CustomObjectsApi()
-    workergroups = api.list_cluster_custom_object(
-        group="kubernetes.dask.org", version="v1", plural="daskworkergroups"
-    )
-    workergroups = api.delete_collection_namespaced_custom_object(
-        group="kubernetes.dask.org",
-        version="v1",
-        plural="daskworkergroups",
-        namespace=namespace,
-    )
+# @kopf.on.delete("daskcluster")
+# async def daskcluster_delete(spec, name, namespace, logger, **kwargs):
+#     api = kubernetes.client.CustomObjectsApi()
+#     workergroups = api.list_cluster_custom_object(
+#         group="kubernetes.dask.org", version="v1", plural="daskworkergroups"
+#     )
+#     workergroups = api.delete_collection_namespaced_custom_object(
+#         group="kubernetes.dask.org",
+#         version="v1",
+#         plural="daskworkergroups",
+#         namespace=namespace,
+#     )

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -16,9 +16,8 @@ spec:
     # affinity: null
     # tolerations: null
     # serviceAccountName: null
-  workers:
-    replicas: 3
-    resources: {}
-    env: {}
+  replicas: 3
+  resources: {}
+  env: {}
 status:
   replicas: 3

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -19,5 +19,3 @@ spec:
   replicas: 3
   resources: {}
   env: {}
-status:
-  replicas: 3

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -20,3 +20,5 @@ spec:
     replicas: 3
     resources: {}
     env: {}
+status:
+  replicas: 3

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -15,3 +15,5 @@ spec:
     # affinity: null
     # tolerations: null
     # serviceAccountName: null
+status:
+  replicas: 2

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -6,14 +6,13 @@ spec:
   imagePullSecrets: null
   image: "daskdev/dask:latest"
   imagePullPolicy: "IfNotPresent"
-  workers:
-    replicas: 2
-    resources: {}
-    env: {}
-    # nodeSelector: null
-    # securityContext: null
-    # affinity: null
-    # tolerations: null
-    # serviceAccountName: null
+  replicas: 2
+  resources: {}
+  env: {}
+  # nodeSelector: null
+  # securityContext: null
+  # affinity: null
+  # tolerations: null
+  # serviceAccountName: null
 status:
   replicas: 2

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -14,5 +14,3 @@ spec:
   # affinity: null
   # tolerations: null
   # serviceAccountName: null
-status:
-  replicas: 2

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-# @pytest.mark.timeout(120)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -77,7 +77,13 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
-                    await client.wait_for_workers(2)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=6",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
                     # Ensure that inter-worker communication works well
                     futures = client.map(lambda x: x + 1, range(10))
                     total = client.submit(sum, futures)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -74,7 +74,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
+                    f"{cluster_name}:{port}", asynchronous=True
                 ) as client:
                     await client.wait_for_workers(2)
                     # Ensure that inter-worker communication works well

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+# @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -77,13 +77,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=6",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
+                    await client.wait_for_workers(2)
                     # Ensure that inter-worker communication works well
                     futures = client.map(lambda x: x + 1, range(10))
                     total = client.submit(sum, futures)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -103,20 +103,20 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     # TODO test that the cluster has been cleaned up
 
 
-# @pytest.mark.asyncio
-# async def test_scale(k8s_cluster):
-#     async with Client() as client:
-#         k8s_cluster.kubectl(
-#             "scale",
-#             "--replicas=5",
-#             "daskworkergroup",
-#             "default-worker-group",
-#         )
-#         await client.wait_for_workers(5)
-#         k8s_cluster.kubectl(
-#             "scale",
-#             "--replicas=3",
-#             "daskworkergroup",
-#             "default-worker-group",
-#         )
-#         await client.wait_for_workers(3)
+@pytest.mark.asyncio
+async def test_scale(k8s_cluster):
+    async with Client("simple-cluster-scheduler") as client:
+        k8s_cluster.kubectl(
+            "scale",
+            "--replicas=5",
+            "daskworkergroup",
+            "default-worker-group",
+        )
+        await client.wait_for_workers(5)
+        k8s_cluster.kubectl(
+            "scale",
+            "--replicas=3",
+            "daskworkergroup",
+            "default-worker-group",
+        )
+        await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -42,6 +42,10 @@ async def gen_cluster(k8s_cluster):
             scheduler_pod_name = "simple-cluster-scheduler"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
+            while "Running" in k8s_cluster.kubectl("get", "pods", scheduler_pod_name):
+                await asyncio.sleep(0.1)
+            while cluster_name in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
 
     yield cm
 

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -35,7 +35,7 @@ async def gen_cluster(k8s_cluster):
             yield cluster_name
         finally:
             # Delete cluster resource
-            k8s_cluster.kubectl("delete", "dsk", "--all")
+            k8s_cluster.kubectl("delete", "-f", cluster_path)
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
 

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -101,9 +101,10 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout
     # TODO test that the cluster has been cleaned up
+    asyncio.sleep(60)
 
 
-@pytest.mark.timeout(120)
+# @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-# @pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -35,7 +35,6 @@ async def gen_cluster(k8s_cluster):
             yield cluster_name
         finally:
             # Delete cluster resource
-            # k8s_cluster.kubectl("delete", "-f", cluster_path)
             k8s_cluster.kubectl("delete", "dsk", "--all")
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
@@ -89,10 +88,6 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             worker_pod_name = "default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-                # while "Running" not in k8s_cluster.kubectl(
-                #     "get", "pods", scheduler_pod_name
-                # ):
-                # await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
@@ -109,7 +104,6 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     assert (await total) == sum(map(lambda x: x + 1, range(10)))
             assert cluster_name
 
-    # TODO test that the cluster has been cleaned up
     assert "A DaskCluster has been created" in runner.stdout
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -7,8 +7,6 @@ import os.path
 
 from kopf.testing import KopfRunner
 
-from dask.distributed import Client
-
 DIR = pathlib.Path(__file__).parent.absolute()
 
 
@@ -55,13 +53,13 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(60)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "simple-cluster-worker-1"
+            # scheduler_service_name = "simple-cluster"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             while "Running" not in k8s_cluster.kubectl(
@@ -85,5 +83,5 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
     assert "A DaskCluster has been created" in runner.stdout
     assert "A scheduler pod has been created" in runner.stdout
-    assert "A worker group has been created" in runner.stdout
+    assert "A scheduler service has been created" in runner.stdout
     # TODO test that the cluster has been cleaned up

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -104,19 +104,20 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
 
 @pytest.mark.asyncio
-async def test_scale(k8s_cluster):
-    async with Client(asynchronous=True) as client:
-        k8s_cluster.kubectl(
-            "scale",
-            "--replicas=5",
-            "daskworkergroup",
-            "default-worker-group",
-        )
-        await client.wait_for_workers(5)
-        k8s_cluster.kubectl(
-            "scale",
-            "--replicas=3",
-            "daskworkergroup",
-            "default-worker-group",
-        )
-        await client.wait_for_workers(3)
+async def test_scale(kopf_runner, k8s_cluster):
+    with kopf_runner as runner:
+        async with Client(asynchronous=True) as client:
+            k8s_cluster.kubectl(
+                "scale",
+                "--replicas=5",
+                "daskworkergroup",
+                "default-worker-group",
+            )
+            await client.wait_for_workers(5)
+            k8s_cluster.kubectl(
+                "scale",
+                "--replicas=3",
+                "daskworkergroup",
+                "default-worker-group",
+            )
+            await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-# @pytest.mark.timeout(180)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+# @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -101,7 +101,8 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout
     # TODO test that the cluster has been cleaned up
-    asyncio.sleep(60)
+    while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
+        await asyncio.sleep(0.1)
 
 
 # @pytest.mark.timeout(120)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -105,7 +105,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
 @pytest.mark.asyncio
 async def test_scale(k8s_cluster):
-    async with Client("simple-cluster-scheduler") as client:
+    async with Client("simple-cluster-scheduler", asynchronous=True) as client:
         k8s_cluster.kubectl(
             "scale",
             "--replicas=5",

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -103,11 +103,11 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     # TODO test that the cluster has been cleaned up
 
 
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
-            asyncio.sleep(120)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -35,8 +35,8 @@ async def gen_cluster(k8s_cluster):
             yield cluster_name
         finally:
             # Delete cluster resource
-            k8s_cluster.kubectl("delete", "-f", cluster_path)
-            # k8s_cluster.kubectl("delete", "dsk", "--all")
+            # k8s_cluster.kubectl("delete", "-f", cluster_path)
+            k8s_cluster.kubectl("delete", "dsk", "--all")
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
 

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -89,10 +89,10 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             worker_pod_name = "default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-                # while "Running" not in k8s_cluster.kubectl(
-                #     "get", "pods", scheduler_pod_name
-                # ):
-                # await asyncio.sleep(0.1)
+                while "Running" not in k8s_cluster.kubectl(
+                    "get", "pods", scheduler_pod_name
+                ):
+                    await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -115,6 +115,8 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 "get", "pods", scheduler_pod_name
             ):
                 asyncio.wait(0.1)
+            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -56,6 +56,30 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
+@pytest.mark.asyncio
+async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+    with kopf_runner as runner:
+        async with gen_cluster() as cluster_name:
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+                async with Client(
+                    f"tcp://localhost:{port}", asynchronous=True
+                ) as client:
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=3",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(3)
+
+
 # @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
@@ -102,45 +126,3 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     assert "A DaskCluster has been created" in runner.stdout
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout
-
-
-# @pytest.mark.timeout(120)
-@pytest.mark.asyncio
-async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-    scheduler_pod_name = "simple-cluster-scheduler"
-    while scheduler_pod_name in k8s_cluster.kubectl("get", "pods"):
-        await asyncio.sleep(0.1)
-    while "Running" in k8s_cluster.kubectl("get", "pods", scheduler_pod_name):
-        await asyncio.sleep(0.1)
-    with kopf_runner as runner:
-        async with gen_cluster() as cluster_name:
-            scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "default-worker-group-worker-1"
-            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
-            while "Running" not in k8s_cluster.kubectl(
-                "get", "pods", scheduler_pod_name
-            ):
-                await asyncio.sleep(0.1)
-            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-                await asyncio.sleep(0.1)
-            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-                async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
-                ) as client:
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=5",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=3",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -104,20 +104,25 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
 
 @pytest.mark.asyncio
-async def test_scale(kopf_runner, k8s_cluster):
+async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
-        async with Client(asynchronous=True) as client:
-            k8s_cluster.kubectl(
-                "scale",
-                "--replicas=5",
-                "daskworkergroup",
-                "default-worker-group",
-            )
-            await client.wait_for_workers(5)
-            k8s_cluster.kubectl(
-                "scale",
-                "--replicas=3",
-                "daskworkergroup",
-                "default-worker-group",
-            )
-            await client.wait_for_workers(3)
+        async with gen_cluster() as cluster_name:
+            asyncio.sleep(60)
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+                async with Client(
+                    f"tcp://localhost:{port}", asynchronous=True
+                ) as client:
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=3",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(150)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -56,6 +56,30 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
+@pytest.mark.asyncio
+async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+    with kopf_runner as runner:
+        async with gen_cluster() as cluster_name:
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+                async with Client(
+                    f"tcp://localhost:{port}", asynchronous=True
+                ) as client:
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=3",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(3)
+
+
 @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
@@ -102,27 +126,3 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     assert "A DaskCluster has been created" in runner.stdout
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout
-
-
-@pytest.mark.asyncio
-async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-    with kopf_runner as runner:
-        async with gen_cluster() as cluster_name:
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-                async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
-                ) as client:
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=5",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=3",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -97,12 +97,12 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     # await client.wait_for_workers(3)
             assert cluster_name
 
-    assert "A DaskCluster has been created" in runner.stdout
-    assert "A scheduler pod has been created" in runner.stdout
-    assert "A worker group has been created" in runner.stdout
     # TODO test that the cluster has been cleaned up
     while "simple-cluster" in k8s_cluster.kubectl("get", "daskclusters"):
         await asyncio.sleep(0.1)
+    assert "A DaskCluster has been created" in runner.stdout
+    assert "A scheduler pod has been created" in runner.stdout
+    assert "A worker group has been created" in runner.stdout
 
 
 # @pytest.mark.timeout(120)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -89,9 +89,9 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             worker_pod_name = "default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-            while "Running" not in k8s_cluster.kubectl(
-                "get", "pods", scheduler_pod_name
-            ):
+                # while "Running" not in k8s_cluster.kubectl(
+                #     "get", "pods", scheduler_pod_name
+                # ):
                 await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
                 await asyncio.sleep(0.1)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -103,20 +103,20 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     # TODO test that the cluster has been cleaned up
 
 
-@pytest.mark.asyncio
-async def test_scale(k8s_cluster):
-    async with Client() as client:
-        k8s_cluster.kubectl(
-            "scale",
-            "--replicas=5",
-            "daskworkergroup",
-            "default-worker-group",
-        )
-        await client.wait_for_workers(5)
-        k8s_cluster.kubectl(
-            "scale",
-            "--replicas=3",
-            "daskworkergroup",
-            "default-worker-group",
-        )
-        await client.wait_for_workers(3)
+# @pytest.mark.asyncio
+# async def test_scale(k8s_cluster):
+#     async with Client() as client:
+#         k8s_cluster.kubectl(
+#             "scale",
+#             "--replicas=5",
+#             "daskworkergroup",
+#             "default-worker-group",
+#         )
+#         await client.wait_for_workers(5)
+#         k8s_cluster.kubectl(
+#             "scale",
+#             "--replicas=3",
+#             "daskworkergroup",
+#             "default-worker-group",
+#         )
+#         await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -83,11 +83,18 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "daskworkergroup",
                         "default-worker-group",
                     )
-                    await client.wait_for_workers(2)
+                    await client.wait_for_workers(5)
                     # Ensure that inter-worker communication works well
                     futures = client.map(lambda x: x + 1, range(10))
                     total = client.submit(sum, futures)
                     assert (await total) == sum(map(lambda x: x + 1, range(10)))
+                    # k8s_cluster.port_forward(
+                    #     "scale",
+                    #     "--replicas=3",
+                    #     "daskworkergroup",
+                    #     "default-worker-group",
+                    # )
+                    # await client.wait_for_workers(3)
             assert cluster_name
 
     assert "A DaskCluster has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -116,6 +116,18 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
+            scheduler_pod_name = "simple-cluster-scheduler"
+            worker_pod_name = "default-worker-group-worker-1"
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+            while "Running" not in k8s_cluster.kubectl(
+                "get", "pods", scheduler_pod_name
+            ):
+                await asyncio.sleep(0.1)
+            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -35,8 +35,8 @@ async def gen_cluster(k8s_cluster):
             yield cluster_name
         finally:
             # Delete cluster resource
-            k8s_cluster.kubectl("delete", "-f", cluster_path)
-            # k8s_cluster.kubectl("delete", "dsk", "--all")
+            # k8s_cluster.kubectl("delete", "-f", cluster_path)
+            k8s_cluster.kubectl("delete", "dsk", "--all")
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
 
@@ -89,10 +89,10 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             worker_pod_name = "default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-                while "Running" not in k8s_cluster.kubectl(
-                    "get", "pods", scheduler_pod_name
-                ):
-                    await asyncio.sleep(0.1)
+                # while "Running" not in k8s_cluster.kubectl(
+                #     "get", "pods", scheduler_pod_name
+                # ):
+                # await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -103,7 +103,44 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     # TODO test that the cluster has been cleaned up
 
 
-# @pytest.mark.timeout(120)
+# # @pytest.mark.timeout(120)
+# @pytest.mark.asyncio
+# async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+#     with kopf_runner as runner:
+#         async with gen_cluster() as cluster_name:
+#             scheduler_pod_name = "simple-cluster-scheduler"
+#             worker_pod_name = "default-worker-group-worker-1"
+#             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+#                 await asyncio.sleep(0.1)
+#             while "Running" not in k8s_cluster.kubectl(
+#                 "get", "pods", scheduler_pod_name
+#             ):
+#                 await asyncio.sleep(0.1)
+#             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+#                 await asyncio.sleep(0.1)
+#             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+#                 await asyncio.sleep(0.1)
+#             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+#                 async with Client(
+#                     f"tcp://localhost:{port}", asynchronous=True
+#                 ) as client:
+#                     k8s_cluster.kubectl(
+#                         "scale",
+#                         "--replicas=5",
+#                         "daskworkergroup",
+#                         "default-worker-group",
+#                     )
+#                     await client.wait_for_workers(5)
+#                     k8s_cluster.kubectl(
+#                         "scale",
+#                         "--replicas=3",
+#                         "daskworkergroup",
+#                         "default-worker-group",
+#                     )
+#                     await client.wait_for_workers(3)
+
+
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -120,6 +157,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
+
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
@@ -131,6 +169,10 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "default-worker-group",
                     )
                     await client.wait_for_workers(5)
+                    # Ensure that inter-worker communication works well
+                    futures = client.map(lambda x: x + 1, range(10))
+                    total = client.submit(sum, futures)
+                    assert (await total) == sum(map(lambda x: x + 1, range(10)))
                     k8s_cluster.kubectl(
                         "scale",
                         "--replicas=3",
@@ -138,3 +180,9 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "default-worker-group",
                     )
                     await client.wait_for_workers(3)
+            assert cluster_name
+
+    assert "A DaskCluster has been created" in runner.stdout
+    assert "A scheduler pod has been created" in runner.stdout
+    assert "A worker group has been created" in runner.stdout
+    # TODO test that the cluster has been cleaned up

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -59,6 +59,15 @@ def test_operator_runs(kopf_runner):
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
+            scheduler_pod_name = "simple-cluster-scheduler"
+            worker_pod_name = "default-worker-group-worker-1"
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
+
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -140,7 +140,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 #                     await client.wait_for_workers(3)
 
 
-@pytest.mark.timeout(120)
+# @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -105,7 +105,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
 @pytest.mark.asyncio
 async def test_scale(k8s_cluster):
-    async with Client("simple-cluster-scheduler", asynchronous=True) as client:
+    async with Client(asynchronous=True) as client:
         k8s_cluster.kubectl(
             "scale",
             "--replicas=5",

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -158,6 +158,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
 
+            asyncio.sleep(60)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+# @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -77,6 +77,12 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
+                    k8s_cluster.port_forward(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
                     await client.wait_for_workers(2)
                     # Ensure that inter-worker communication works well
                     futures = client.map(lambda x: x + 1, range(10))

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -106,25 +106,25 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
 
 # @pytest.mark.timeout(120)
-# @pytest.mark.asyncio
-# async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-#     with kopf_runner as runner:
-#         async with gen_cluster() as cluster_name:
-#             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-#                 async with Client(
-#                     f"tcp://localhost:{port}", asynchronous=True
-#                 ) as client:
-#                     k8s_cluster.kubectl(
-#                         "scale",
-#                         "--replicas=5",
-#                         "daskworkergroup",
-#                         "default-worker-group",
-#                     )
-#                     await client.wait_for_workers(5)
-#                     k8s_cluster.kubectl(
-#                         "scale",
-#                         "--replicas=3",
-#                         "daskworkergroup",
-#                         "default-worker-group",
-#                     )
-#                     await client.wait_for_workers(3)
+@pytest.mark.asyncio
+async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+    with kopf_runner as runner:
+        async with gen_cluster() as cluster_name:
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+                async with Client(
+                    f"tcp://localhost:{port}", asynchronous=True
+                ) as client:
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=3",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -60,7 +60,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "default-worker-group-worker-1"
+            worker_pod_name = "simple-cluster-default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
@@ -94,7 +94,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "default-worker-group-worker-1"
+            worker_pod_name = "simple-cluster-default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -36,7 +36,11 @@ async def gen_cluster(k8s_cluster):
         finally:
             # Delete cluster resource
             k8s_cluster.kubectl("delete", "-f", cluster_path)
+            # k8s_cluster.kubectl("delete", "dsk", "--all")
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
+                await asyncio.sleep(0.1)
+            scheduler_pod_name = "simple-cluster-scheduler"
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
 
     yield cm
@@ -98,8 +102,6 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             assert cluster_name
 
     # TODO test that the cluster has been cleaned up
-    while "simple-cluster" in k8s_cluster.kubectl("get", "daskclusters"):
-        await asyncio.sleep(0.1)
     assert "A DaskCluster has been created" in runner.stdout
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -140,50 +140,20 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 #                     await client.wait_for_workers(3)
 
 
-# @pytest.mark.timeout(120)
 @pytest.mark.asyncio
-async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-    with kopf_runner as runner:
-        async with gen_cluster() as cluster_name:
-            scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "default-worker-group-worker-1"
-            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
-            while "Running" not in k8s_cluster.kubectl(
-                "get", "pods", scheduler_pod_name
-            ):
-                await asyncio.sleep(0.1)
-            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-                await asyncio.sleep(0.1)
-            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
-
-            asyncio.sleep(60)
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-                async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
-                ) as client:
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=5",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
-                    # Ensure that inter-worker communication works well
-                    futures = client.map(lambda x: x + 1, range(10))
-                    total = client.submit(sum, futures)
-                    assert (await total) == sum(map(lambda x: x + 1, range(10)))
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=3",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(3)
-            assert cluster_name
-
-    assert "A DaskCluster has been created" in runner.stdout
-    assert "A scheduler pod has been created" in runner.stdout
-    assert "A worker group has been created" in runner.stdout
-    # TODO test that the cluster has been cleaned up
+async def test_scalesimplecluster(k8s_cluster):
+    async with Client() as client:
+        k8s_cluster.kubectl(
+            "scale",
+            "--replicas=5",
+            "daskworkergroup",
+            "default-worker-group",
+        )
+        await client.wait_for_workers(5)
+        k8s_cluster.kubectl(
+            "scale",
+            "--replicas=3",
+            "daskworkergroup",
+            "default-worker-group",
+        )
+        await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -109,13 +109,16 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             scheduler_pod_name = "simple-cluster-scheduler"
+            worker_pod_name = "default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             while "Running" not in k8s_cluster.kubectl(
                 "get", "pods", scheduler_pod_name
             ):
-                asyncio.wait(0.1)
+                await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -107,7 +107,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
-            asyncio.sleep(60)
+            asyncio.sleep(120)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -103,45 +103,8 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     # TODO test that the cluster has been cleaned up
 
 
-# # @pytest.mark.timeout(120)
-# @pytest.mark.asyncio
-# async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-#     with kopf_runner as runner:
-#         async with gen_cluster() as cluster_name:
-#             scheduler_pod_name = "simple-cluster-scheduler"
-#             worker_pod_name = "default-worker-group-worker-1"
-#             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-#                 await asyncio.sleep(0.1)
-#             while "Running" not in k8s_cluster.kubectl(
-#                 "get", "pods", scheduler_pod_name
-#             ):
-#                 await asyncio.sleep(0.1)
-#             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-#                 await asyncio.sleep(0.1)
-#             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-#                 await asyncio.sleep(0.1)
-#             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-#                 async with Client(
-#                     f"tcp://localhost:{port}", asynchronous=True
-#                 ) as client:
-#                     k8s_cluster.kubectl(
-#                         "scale",
-#                         "--replicas=5",
-#                         "daskworkergroup",
-#                         "default-worker-group",
-#                     )
-#                     await client.wait_for_workers(5)
-#                     k8s_cluster.kubectl(
-#                         "scale",
-#                         "--replicas=3",
-#                         "daskworkergroup",
-#                         "default-worker-group",
-#                     )
-#                     await client.wait_for_workers(3)
-
-
 @pytest.mark.asyncio
-async def test_scalesimplecluster(k8s_cluster):
+async def test_scale(k8s_cluster):
     async with Client() as client:
         k8s_cluster.kubectl(
             "scale",

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -79,9 +79,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 ) as client:
                     k8s_cluster.port_forward(
                         "scale",
-                        "--replicas=5",
-                        "daskworkergroup",
-                        "default-worker-group",
+                        "--replicas=5 daskworkergroup default-worker-group",
                     )
                     await client.wait_for_workers(5)
                     # Ensure that inter-worker communication works well
@@ -90,9 +88,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     assert (await total) == sum(map(lambda x: x + 1, range(10)))
                     # k8s_cluster.port_forward(
                     #     "scale",
-                    #     "--replicas=3",
-                    #     "daskworkergroup",
-                    #     "default-worker-group",
+                    #     "--replicas=3 daskworkergroup default-worker-group"
                     # )
                     # await client.wait_for_workers(3)
             assert cluster_name

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(180)
+# @pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -56,31 +56,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.asyncio
-async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-    with kopf_runner as runner:
-        async with gen_cluster() as cluster_name:
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-                async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
-                ) as client:
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=5",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=3",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(3)
-
-
-# @pytest.mark.timeout(120)
+@pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
@@ -126,3 +102,27 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     assert "A DaskCluster has been created" in runner.stdout
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout
+
+
+@pytest.mark.asyncio
+async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+    with kopf_runner as runner:
+        async with gen_cluster() as cluster_name:
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+                async with Client(
+                    f"tcp://localhost:{port}", asynchronous=True
+                ) as client:
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=3",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -109,6 +109,8 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             scheduler_pod_name = "simple-cluster-scheduler"
+            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
+                await asyncio.sleep(0.1)
             while "Running" not in k8s_cluster.kubectl(
                 "get", "pods", scheduler_pod_name
             ):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -101,6 +101,8 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout
     # TODO test that the cluster has been cleaned up
+    while "simple-cluster" in k8s_cluster.kubectl("get", "daskclusters"):
+        await asyncio.sleep(0.1)
 
 
 # @pytest.mark.timeout(120)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -61,7 +61,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "simple-cluster-worker-1"
+            worker_pod_name = "default-worker-group-worker-1"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             while "Running" not in k8s_cluster.kubectl(

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -101,30 +101,28 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     assert "A scheduler pod has been created" in runner.stdout
     assert "A worker group has been created" in runner.stdout
     # TODO test that the cluster has been cleaned up
-    while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
-        await asyncio.sleep(0.1)
 
 
 # @pytest.mark.timeout(120)
-@pytest.mark.asyncio
-async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-    with kopf_runner as runner:
-        async with gen_cluster() as cluster_name:
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-                async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
-                ) as client:
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=5",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=3",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(3)
+# @pytest.mark.asyncio
+# async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+#     with kopf_runner as runner:
+#         async with gen_cluster() as cluster_name:
+#             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+#                 async with Client(
+#                     f"tcp://localhost:{port}", asynchronous=True
+#                 ) as client:
+#                     k8s_cluster.kubectl(
+#                         "scale",
+#                         "--replicas=5",
+#                         "daskworkergroup",
+#                         "default-worker-group",
+#                     )
+#                     await client.wait_for_workers(5)
+#                     k8s_cluster.kubectl(
+#                         "scale",
+#                         "--replicas=3",
+#                         "daskworkergroup",
+#                         "default-worker-group",
+#                     )
+#                     await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -77,13 +77,13 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
-                    # k8s_cluster.port_forward(
-                    #     "scale",
-                    #     "--replicas=5",
-                    #     "daskworkergroup",
-                    #     "default-worker-group",
-                    # )
-                    await client.wait_for_workers(2)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
                     # Ensure that inter-worker communication works well
                     futures = client.map(lambda x: x + 1, range(10))
                     total = client.submit(sum, futures)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -55,7 +55,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -88,13 +88,13 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     futures = client.map(lambda x: x + 1, range(10))
                     total = client.submit(sum, futures)
                     assert (await total) == sum(map(lambda x: x + 1, range(10)))
-                    # k8s_cluster.port_forward(
-                    #     "scale",
-                    #     "--replicas=3",
-                    #     "daskworkergroup",
-                    #     "default-worker-group",
-                    # )
-                    # await client.wait_for_workers(3)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=3",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(3)
             assert cluster_name
 
     assert "A DaskCluster has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -56,28 +56,28 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-@pytest.mark.asyncio
-async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
-    with kopf_runner as runner:
-        async with gen_cluster() as cluster_name:
-            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
-                async with Client(
-                    f"tcp://localhost:{port}", asynchronous=True
-                ) as client:
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=5",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
-                    k8s_cluster.kubectl(
-                        "scale",
-                        "--replicas=3",
-                        "daskworkergroup",
-                        "default-worker-group",
-                    )
-                    await client.wait_for_workers(3)
+# @pytest.mark.asyncio
+# async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+#     with kopf_runner as runner:
+#         async with gen_cluster() as cluster_name:
+#             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+#                 async with Client(
+#                     f"tcp://localhost:{port}", asynchronous=True
+#                 ) as client:
+#                     k8s_cluster.kubectl(
+#                         "scale",
+#                         "--replicas=5",
+#                         "daskworkergroup",
+#                         "default-worker-group",
+#                     )
+#                     await client.wait_for_workers(5)
+#                     k8s_cluster.kubectl(
+#                         "scale",
+#                         "--replicas=3",
+#                         "daskworkergroup",
+#                         "default-worker-group",
+#                     )
+#                     await client.wait_for_workers(3)
 
 
 @pytest.mark.timeout(120)
@@ -120,9 +120,33 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     #     "default-worker-group",
                     # )
                     # await client.wait_for_workers(3)
-            assert cluster_name
+    #         assert cluster_name
 
-    # TODO test that the cluster has been cleaned up
-    assert "A DaskCluster has been created" in runner.stdout
-    assert "A scheduler pod has been created" in runner.stdout
-    assert "A worker group has been created" in runner.stdout
+    # # TODO test that the cluster has been cleaned up
+    # assert "A DaskCluster has been created" in runner.stdout
+    # assert "A scheduler pod has been created" in runner.stdout
+    # assert "A worker group has been created" in runner.stdout
+
+
+@pytest.mark.asyncio
+async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+    with kopf_runner as runner:
+        async with gen_cluster() as cluster_name:
+            with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
+                async with Client(
+                    f"tcp://localhost:{port}", asynchronous=True
+                ) as client:
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=5",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(5)
+                    k8s_cluster.kubectl(
+                        "scale",
+                        "--replicas=3",
+                        "daskworkergroup",
+                        "default-worker-group",
+                    )
+                    await client.wait_for_workers(3)

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -39,13 +39,6 @@ async def gen_cluster(k8s_cluster):
             # k8s_cluster.kubectl("delete", "dsk", "--all")
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
-            scheduler_pod_name = "simple-cluster-scheduler"
-            while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
-            while "Running" in k8s_cluster.kubectl("get", "pods", scheduler_pod_name):
-                await asyncio.sleep(0.1)
-            while cluster_name in k8s_cluster.kubectl("get", "svc"):
-                await asyncio.sleep(0.1)
 
     yield cm
 
@@ -114,6 +107,11 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 # @pytest.mark.timeout(120)
 @pytest.mark.asyncio
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+    scheduler_pod_name = "simple-cluster-scheduler"
+    while scheduler_pod_name in k8s_cluster.kubectl("get", "pods"):
+        await asyncio.sleep(0.1)
+    while "Running" in k8s_cluster.kubectl("get", "pods", scheduler_pod_name):
+        await asyncio.sleep(0.1)
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
             scheduler_pod_name = "simple-cluster-scheduler"

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -77,18 +77,22 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
-                    k8s_cluster.port_forward(
-                        "scale",
-                        "--replicas=5 daskworkergroup default-worker-group",
-                    )
-                    await client.wait_for_workers(5)
+                    # k8s_cluster.port_forward(
+                    #     "scale",
+                    #     "--replicas=5",
+                    #     "daskworkergroup",
+                    #     "default-worker-group",
+                    # )
+                    await client.wait_for_workers(2)
                     # Ensure that inter-worker communication works well
                     futures = client.map(lambda x: x + 1, range(10))
                     total = client.submit(sum, futures)
                     assert (await total) == sum(map(lambda x: x + 1, range(10)))
                     # k8s_cluster.port_forward(
                     #     "scale",
-                    #     "--replicas=3 daskworkergroup default-worker-group"
+                    #     "--replicas=3",
+                    #     "daskworkergroup",
+                    #     "default-worker-group",
                     # )
                     # await client.wait_for_workers(3)
             assert cluster_name


### PR DESCRIPTION
As a part of https://github.com/dask/dask-kubernetes/pull/392, the Dask Operator needs to scale workers on Kubernetes whenever we create our DaskWorkerGroup custom resources are modified. This PR is concerned with scaling worker pods (manually) when we change the replicas key in a DaskWorkerGroup resource.