### PR TITLE
Drop Python 3.7 and add CI for 3.9 and 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,14 +8,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - uses: pre-commit/action@v2.0.0
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=(open("README.rst").read() if exists("README.rst") else ""),
     zip_safe=False,
     install_requires=list(open("requirements.txt").read().strip().split("\n")),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points="""
         [dask_cluster_discovery]
         helmcluster=dask_kubernetes.helm:discover


### PR DESCRIPTION
Given that folks are still having 3.7 issues in #376 and we are discussing dropping it in dask/community#213 I'm going to drop support here now. Also adding CI to test against 3.9 and 3.10.,