### PR TITLE
Merge main into operator feature branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,14 +8,14 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - uses: pre-commit/action@v2.0.0
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -165,12 +165,19 @@ class Scheduler(Pod):
         Set to 0 to disable the timeout (not recommended).
     """
 
-    def __init__(self, idle_timeout: str, service_wait_timeout_s: int = None, **kwargs):
+    def __init__(
+        self,
+        idle_timeout: str,
+        service_wait_timeout_s: int = None,
+        service_name_retries: int = None,
+        **kwargs
+    ):
         super().__init__(**kwargs)
         self.cluster._log("Creating scheduler pod on cluster. This may take some time.")
         self.service = None
         self._idle_timeout = idle_timeout
         self._service_wait_timeout_s = service_wait_timeout_s
+        self._service_name_retries = service_name_retries
         if self._idle_timeout is not None:
             self.pod_template.spec.containers[0].args += [
                 "--idle-timeout",
@@ -198,7 +205,9 @@ class Scheduler(Pod):
             port=SCHEDULER_PORT,
         )
         self.external_address = await get_external_address_for_scheduler_service(
-            self.core_api, self.service
+            self.core_api,
+            self.service,
+            service_name_resolution_retries=self._service_name_retries,
         )
 
         self.pdb = await self._create_pdb()
@@ -254,7 +263,7 @@ class Scheduler(Pod):
         pdb_template_dict = dask.config.get("kubernetes.scheduler-pdb-template")
         self.pdb_template = clean_pdb_template(make_pdb_from_dict(pdb_template_dict))
         self.pdb_template.metadata.name = self.cluster_name
-        self.pdb_template.spec.labels = copy.deepcopy(self.base_labels)
+        self.pdb_template.metadata.labels = copy.deepcopy(self.base_labels)
         self.pdb_template.spec.selector.match_labels[
             "dask.org/cluster-name"
         ] = self.cluster_name
@@ -329,6 +338,11 @@ class KubeCluster(SpecCluster):
         Timeout, in seconds, to wait for the remote scheduler service to be ready.
         Defaults to 30 seconds.
         Set to 0 to disable the timeout (not recommended).
+    scheduler_service_name_resolution_retries: int (optional)
+        Number of retries to resolve scheduler service name when running
+        from within the Kubernetes cluster.
+        Defaults to 20.
+        Must be set to 1 or greater.
     deploy_mode: str (optional)
         Run the scheduler as "local" or "remote".
         Defaults to ``"remote"``.
@@ -414,6 +428,7 @@ class KubeCluster(SpecCluster):
         dashboard_address=None,
         security=None,
         scheduler_service_wait_timeout=None,
+        scheduler_service_name_resolution_retries=None,
         scheduler_pod_template=None,
         **kwargs
     ):
@@ -458,6 +473,10 @@ class KubeCluster(SpecCluster):
         self._scheduler_service_wait_timeout = dask.config.get(
             "kubernetes.scheduler-service-wait-timeout",
             override_with=scheduler_service_wait_timeout,
+        )
+        self._scheduler_service_name_resolution_retries = dask.config.get(
+            "kubernetes.scheduler-service-name-resolution-retries",
+            override_with=scheduler_service_name_resolution_retries,
         )
         self.security = security
         if self.security and not isinstance(
@@ -585,6 +604,7 @@ class KubeCluster(SpecCluster):
                 "options": {
                     "idle_timeout": self._idle_timeout,
                     "service_wait_timeout_s": self._scheduler_service_wait_timeout,
+                    "service_name_retries": self._scheduler_service_name_resolution_retries,
                     "pod_template": self.scheduler_pod_template,
                     **common_options,
                 },

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -17,6 +17,10 @@ kubernetes:
   # Timeout to wait for the scheduler service to be up (in seconds)
   # Set it to 0 to wait indefinitely (not recommended)
   scheduler-service-wait-timeout: 30
+  # Number of retries to resolve scheduler service name when running
+  # from within the Kubernetes cluster.
+  # Must be set to 1 or greater.
+  scheduler-service-name-resolution-retries: 20
 
   scheduler-service-template:
     apiVersion: v1

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -117,6 +117,7 @@ def make_pod_spec(
     extra_container_config={},
     extra_pod_config={},
     memory_limit=None,
+    resources=None,
     memory_request=None,
     cpu_limit=None,
     cpu_request=None,
@@ -124,6 +125,42 @@ def make_pod_spec(
 ):
     """
     Create generic pod template from input parameters
+
+    Parameters
+    ----------
+    image : str
+        Docker image name
+    labels : dict
+        Dict of labels to pass to ``V1ObjectMeta``
+    threads_per_worker : int
+        Number of threads per each worker
+    env : dict
+        Dict of environment variables to pass to ``V1Container``
+    extra_container_config : dict
+        Extra config attributes to set on the container object
+    extra_pod_config : dict
+        Extra config attributes to set on the pod object
+    memory_limit : int, float, or str
+        Bytes of memory per process that the worker can use.
+        This can be:
+            - an integer (bytes), note 0 is a special case for no memory management.
+            - a float (fraction of total system memory).
+            - a string (like 5GB or 5000M).
+            - 'auto' for automatically computing the memory limit.  [default: auto]
+    resources : str
+        Resources for task constraints like "GPU=2 MEM=10e9". Resources are applied
+        separately to each worker process (only relevant when starting multiple
+        worker processes. Passed to the `--resources` option in ``dask-worker``.
+    cpu_limit : float or str
+        CPU resource limits (applied to ``spec.containers[].resources.limits.cpu``)
+    cpu_requests : float or str
+        CPU resource requests (applied to ``spec.containers[].resources.requests.cpu``)
+    annotations : dict
+        Dict of annotations passed to ``V1ObjectMeta``
+
+    Returns
+    -------
+    pod : V1PodSpec
 
     Examples
     --------
@@ -139,6 +176,8 @@ def make_pod_spec(
     ]
     if memory_limit:
         args.extend(["--memory-limit", str(memory_limit)])
+    if resources:
+        args.extend(["--resources", str(resources)])
     pod = client.V1Pod(
         metadata=client.V1ObjectMeta(labels=labels, annotations=annotations),
         spec=client.V1PodSpec(
@@ -194,7 +233,7 @@ def make_pdb_from_dict(dict_):
 
 
 def clean_pod_template(pod_template, match_node_purpose="prefer", pod_type="worker"):
-    """ Normalize pod template """
+    """Normalize pod template"""
     pod_template = copy.deepcopy(pod_template)
 
     # Make sure metadata / labels / env objects exist, so they can be modified
@@ -286,7 +325,7 @@ def clean_pod_template(pod_template, match_node_purpose="prefer", pod_type="work
 
 
 def clean_service_template(service_template):
-    """ Normalize service template and check for type errors """
+    """Normalize service template and check for type errors"""
 
     service_template = copy.deepcopy(service_template)
 
@@ -301,7 +340,7 @@ def clean_service_template(service_template):
 
 
 def clean_pdb_template(pdb_template):
-    """ Normalize pdb template and check for type errors """
+    """Normalize pdb template and check for type errors"""
 
     pdb_template = copy.deepcopy(pdb_template)
 

--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -87,6 +87,26 @@ def test_extra_container_config_merge(docker_image, loop):
         assert pod.spec.containers[0].args[-1] == "last-item"
 
 
+def test_worker_args(docker_image, loop):
+    """
+    Test that dask-worker arguments are added to the container args
+    """
+    with KubeCluster(
+        make_pod_spec(
+            docker_image,
+            memory_limit="5000M",
+            resources="FOO=1 BAR=2",
+        ),
+        loop=loop,
+        n_workers=0,
+    ) as cluster:
+
+        pod = cluster.pod_template
+
+        for arg in ["--memory-limit", "5000M", "--resources", "FOO=1 BAR=2"]:
+            assert arg in pod.spec.containers[0].args
+
+
 def test_make_pod_from_dict():
     d = {
         "kind": "Pod",

--- a/doc/source/kubecluster.rst
+++ b/doc/source/kubecluster.rst
@@ -320,6 +320,7 @@ API
    InCluster
    KubeConfig
    KubeAuth
+   make_pod_spec
 
 .. autoclass:: KubeCluster
    :members:
@@ -332,3 +333,5 @@ API
 .. autoclass:: KubeConfig
 
 .. autoclass:: KubeAuth
+
+.. autofunction:: make_pod_spec

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=(open("README.rst").read() if exists("README.rst") else ""),
     zip_safe=False,
     install_requires=list(open("requirements.txt").read().strip().split("\n")),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points="""
         [dask_cluster_discovery]
         helmcluster=dask_kubernetes.helm:discover


### PR DESCRIPTION
There have been a few changes on `main` since we started the `dask-operator` feature branch. Primarily dropping Python 3.7 and adding CI for 3.8, 3.9 and 3.10. Pulling these changes into the feature branch so that we are correctly testing against supported Python versions while developing.