### PR TITLE
Bump Python version in Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,17 @@
 version: 2
 
 # Set the version of Python and other tools you might need
-build:
-  os: ubuntu-20.04
-  tools:
-    python: "3.9"
+sphinx:
+  configuration: doc/source/conf.py
+
+formats: all
+
+python:
+  version: 3.9
+  install:
+    - method: pip
+      path: .
+    - requirements: doc/requirements-docs.txt
+
+submodules:
+  include: all

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ sphinx:
 formats: all
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Since we dropped Python 3.7 in Dask lately and RtD defaults to it this PR manually bumps the version to 3.9.