### PR TITLE
Add a wait for scheduler to be running before port forwarding

### DIFF
--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -296,5 +296,5 @@ async def wait_for_terminating_pod(
                 break
             await asyncio.sleep(1)
 
-    except:
+    except Exception:
         return

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -39,6 +39,10 @@ async def gen_cluster(k8s_cluster):
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
 
+            # Give resources some time to clean up
+            # TODO replace with more robust checks when creating pods
+            await asyncio.sleep(5)
+
     yield cm
 
 

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -39,10 +39,6 @@ async def gen_cluster(k8s_cluster):
             while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
 
-            # Give resources some time to clean up
-            # TODO replace with more robust checks when creating pods
-            await asyncio.sleep(5)
-
     yield cm
 
 

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -63,13 +63,13 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
             worker_pod_name = "simple-cluster-default-worker-group-worker"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
-                await asyncio.sleep(0.1)
-            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
-                await asyncio.sleep(0.1)
             while "Running" not in k8s_cluster.kubectl(
                 "get", "pods", scheduler_pod_name
             ):
+                await asyncio.sleep(0.1)
+            while cluster_name not in k8s_cluster.kubectl("get", "svc"):
+                await asyncio.sleep(0.1)
+            while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
@@ -100,11 +100,14 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             worker_pod_name = "simple-cluster-default-worker-group-worker"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
+            while "Running" not in k8s_cluster.kubectl(
+                "get", "pods", scheduler_pod_name
+            ):
+                await asyncio.sleep(0.1)
             while cluster_name not in k8s_cluster.kubectl("get", "svc"):
                 await asyncio.sleep(0.1)
             while worker_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
-
             with k8s_cluster.port_forward(f"service/{cluster_name}", 8786) as port:
                 async with Client(
                     f"tcp://localhost:{port}", asynchronous=True


### PR DESCRIPTION
I was having issues with running the `test_simplecluster ` test locally. The port forward was happening before the scheduler pod was ready and timing out.

I've copied the wait from the `test_scalesimplecluster` and also reordered things to match.