### PR TITLE
Add docker image and manifest for deployment

### DIFF
--- a/dask_kubernetes/operator/deployment/Dockerfile
+++ b/dask_kubernetes/operator/deployment/Dockerfile
@@ -11,4 +11,4 @@ WORKDIR /src/dask_kubernetes
 RUN pip install .
 
 # Start operator
-CMD kopf run -m dask_kubernetes.operator.daskcluster --verbose --all-namespaces
+CMD kopf run -m dask_kubernetes.operator --verbose --all-namespaces

--- a/dask_kubernetes/operator/deployment/Dockerfile
+++ b/dask_kubernetes/operator/deployment/Dockerfile
@@ -1,0 +1,14 @@
+# This images needs to be built from the top level of the project
+# $ docker build -t ghcr.io/dask/dask-kubernetes-operator:latest -f dask_kubernetes/operator/deployment/Dockerfile .
+
+FROM python:3.8
+
+# Copy source
+COPY . /src/dask_kubernetes
+WORKDIR /src/dask_kubernetes
+
+# Install dependencies
+RUN pip install .
+
+# Start operator
+CMD kopf run -m dask_kubernetes.operator.daskcluster --verbose --all-namespaces

--- a/dask_kubernetes/operator/deployment/manifest.yaml
+++ b/dask_kubernetes/operator/deployment/manifest.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: "kube-system"
+  name: dask-kubernetes-operator
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      application: dask-kubernetes-operator
+  template:
+    metadata:
+      labels:
+        application: dask-kubernetes-operator
+    spec:
+      serviceAccountName: dask-kubernetes-operator
+      containers:
+        - name: operator
+          image: ghcr.io/dask/dask-kubernetes-operator:latest
+          imagePullPolicy: IfNotPresent
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: "kube-system"
+  name: dask-kubernetes-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dask-kubernetes-operator-role-cluster
+rules:
+  # Framework: knowing which other operators are running (i.e. peering).
+  - apiGroups: [kopf.dev]
+    resources: [clusterkopfpeerings]
+    verbs: [list, watch, patch, get]
+
+  # Framework: runtime observation of namespaces & CRDs (addition/deletion).
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+
+  # Framework: admission webhook configuration management.
+  - apiGroups:
+      [admissionregistration.k8s.io/v1, admissionregistration.k8s.io/v1beta1]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [create, patch]
+
+  # Application: watching & handling for the custom resource we declare.
+  - apiGroups: [kubernetes.dask.org]
+    resources: [daskcluster, daskworkergroup]
+    verbs: [list, watch, patch]
+
+  # Application: other resources it produces and manipulates.
+  # Here, we create/delete Pods.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [create, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dask-kubernetes-operator-rolebinding-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dask-kubernetes-operator-role-cluster
+subjects:
+  - kind: ServiceAccount
+    name: dask-kubernetes-operator
+    namespace: "kube-system"


### PR DESCRIPTION
Adds some initial packaging for the operator.

First the operator gets wrapped in a container image:

```
$ docker build -t ghcr.io/dask/dask-kubernetes-operator:latest -f dask_kubernetes/operator/deployment/Dockerfile .
```

_For local dev you'll need to push this to your kubernetes cluster, for me on `kind` it meant running `kind load docker-image --name pytest-kind ghcr.io/dask/dask-kubernetes-operator:latest`_

Then to install the operator on Kubernetes you need to apply the example manifest which creates a service account, cluster role, binding and deployment.

```
$ kubectl apply -f dask_kubernetes/operator/deployment/manifest.yaml
```

Now the operator is running and you can create `daskcluster` resources (assuming you have the CRDs installed).