### PR TITLE
Fix missing container name in `Pod.logs()`

### DIFF
--- a/dask_kubernetes/constants.py
+++ b/dask_kubernetes/constants.py
@@ -1,0 +1,1 @@
+DASK_CONTAINER_NAME = "dask-worker"

--- a/dask_kubernetes/constants.py
+++ b/dask_kubernetes/constants.py
@@ -1,1 +1,1 @@
-DASK_CONTAINER_NAME = "dask-worker"
+KUBECLUSTER_WORKER_CONTAINER_NAME = "dask-worker"

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -16,7 +16,7 @@ from distributed.utils import Log, Logs
 import kubernetes_asyncio as kubernetes
 from kubernetes_asyncio.client.rest import ApiException
 
-from .constants import DASK_CONTAINER_NAME
+from .constants import KUBECLUSTER_WORKER_CONTAINER_NAME
 from .objects import (
     make_pod_from_dict,
     make_service_from_dict,
@@ -109,7 +109,7 @@ class Pod(ProcessInterface):
             log = await self.core_api.read_namespaced_pod_log(
                 self._pod.metadata.name,
                 self.namespace,
-                container=DASK_CONTAINER_NAME,
+                container=KUBECLUSTER_WORKER_CONTAINER_NAME,
             )
         except ApiException as e:
             if "waiting to start" in str(e):

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -16,6 +16,7 @@ from distributed.utils import Log, Logs
 import kubernetes_asyncio as kubernetes
 from kubernetes_asyncio.client.rest import ApiException
 
+from .constants import DASK_CONTAINER_NAME
 from .objects import (
     make_pod_from_dict,
     make_service_from_dict,
@@ -106,7 +107,9 @@ class Pod(ProcessInterface):
     async def logs(self):
         try:
             log = await self.core_api.read_namespaced_pod_log(
-                self._pod.metadata.name, self.namespace
+                self._pod.metadata.name,
+                self.namespace,
+                container=DASK_CONTAINER_NAME,
             )
         except ApiException as e:
             if "waiting to start" in str(e):

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -8,6 +8,8 @@ import json
 
 from kubernetes.client.configuration import Configuration
 
+from dask_kubernetes.constants import DASK_CONTAINER_NAME
+
 _FakeResponse = namedtuple("_FakeResponse", ["data"])
 
 
@@ -184,7 +186,7 @@ def make_pod_spec(
             restart_policy="Never",
             containers=[
                 client.V1Container(
-                    name="dask-worker",
+                    name=DASK_CONTAINER_NAME,
                     image=image,
                     args=args,
                     env=[client.V1EnvVar(name=k, value=v) for k, v in env.items()],

--- a/dask_kubernetes/objects.py
+++ b/dask_kubernetes/objects.py
@@ -8,7 +8,7 @@ import json
 
 from kubernetes.client.configuration import Configuration
 
-from dask_kubernetes.constants import DASK_CONTAINER_NAME
+from dask_kubernetes.constants import KUBECLUSTER_WORKER_CONTAINER_NAME
 
 _FakeResponse = namedtuple("_FakeResponse", ["data"])
 
@@ -186,7 +186,7 @@ def make_pod_spec(
             restart_policy="Never",
             containers=[
                 client.V1Container(
-                    name=DASK_CONTAINER_NAME,
+                    name=KUBECLUSTER_WORKER_CONTAINER_NAME,
                     image=image,
                     args=args,
                     env=[client.V1EnvVar(name=k, value=v) for k, v in env.items()],

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -23,6 +23,7 @@ from dask_kubernetes import (
 from dask.utils import tmpfile
 from distributed.utils_test import captured_logger
 
+from dask_kubernetes.constants import DASK_CONTAINER_NAME
 
 TEST_DIR = os.path.abspath(os.path.join(__file__, ".."))
 CONFIG_DEMO = os.path.join(TEST_DIR, "config-demo.yaml")
@@ -226,7 +227,7 @@ async def test_pod_from_yaml(k8s_cluster, docker_image):
                     ],
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": "dask-worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         },
@@ -274,7 +275,7 @@ async def test_pod_expand_env_vars(k8s_cluster, docker_image):
                         ],
                         "image": "${FOO_IMAGE}",
                         "imagePullPolicy": "IfNotPresent",
-                        "name": "dask-worker",
+                        "name": DASK_CONTAINER_NAME,
                     }
                 ]
             },
@@ -308,7 +309,7 @@ async def test_pod_template_dict(docker_image):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": "dask-worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         },
@@ -349,7 +350,7 @@ async def test_pod_template_minimal_dict(k8s_cluster, docker_image):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": "worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         }
@@ -365,11 +366,13 @@ async def test_pod_template_minimal_dict(k8s_cluster, docker_image):
 
 @pytest.mark.asyncio
 async def test_pod_template_from_conf(docker_image):
-    spec = {"spec": {"containers": [{"name": "some-name", "image": docker_image}]}}
+    spec = {
+        "spec": {"containers": [{"name": DASK_CONTAINER_NAME, "image": docker_image}]}
+    }
 
     with dask.config.set({"kubernetes.worker-template": spec}):
         async with KubeCluster(**cluster_kwargs) as cluster:
-            assert cluster.pod_template.spec.containers[0].name == "some-name"
+            assert cluster.pod_template.spec.containers[0].name == DASK_CONTAINER_NAME
 
 
 @pytest.mark.asyncio
@@ -573,7 +576,7 @@ async def test_automatic_startup(k8s_cluster, docker_image):
                         "1",
                     ],
                     "image": docker_image,
-                    "name": "dask-worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         },

--- a/dask_kubernetes/tests/test_async.py
+++ b/dask_kubernetes/tests/test_async.py
@@ -23,7 +23,7 @@ from dask_kubernetes import (
 from dask.utils import tmpfile
 from distributed.utils_test import captured_logger
 
-from dask_kubernetes.constants import DASK_CONTAINER_NAME
+from dask_kubernetes.constants import KUBECLUSTER_WORKER_CONTAINER_NAME
 
 TEST_DIR = os.path.abspath(os.path.join(__file__, ".."))
 CONFIG_DEMO = os.path.join(TEST_DIR, "config-demo.yaml")
@@ -227,7 +227,7 @@ async def test_pod_from_yaml(k8s_cluster, docker_image):
                     ],
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         },
@@ -275,7 +275,7 @@ async def test_pod_expand_env_vars(k8s_cluster, docker_image):
                         ],
                         "image": "${FOO_IMAGE}",
                         "imagePullPolicy": "IfNotPresent",
-                        "name": DASK_CONTAINER_NAME,
+                        "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                     }
                 ]
             },
@@ -309,7 +309,7 @@ async def test_pod_template_dict(docker_image):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         },
@@ -350,7 +350,7 @@ async def test_pod_template_minimal_dict(k8s_cluster, docker_image):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         }
@@ -367,12 +367,19 @@ async def test_pod_template_minimal_dict(k8s_cluster, docker_image):
 @pytest.mark.asyncio
 async def test_pod_template_from_conf(docker_image):
     spec = {
-        "spec": {"containers": [{"name": DASK_CONTAINER_NAME, "image": docker_image}]}
+        "spec": {
+            "containers": [
+                {"name": KUBECLUSTER_WORKER_CONTAINER_NAME, "image": docker_image}
+            ]
+        }
     }
 
     with dask.config.set({"kubernetes.worker-template": spec}):
         async with KubeCluster(**cluster_kwargs) as cluster:
-            assert cluster.pod_template.spec.containers[0].name == DASK_CONTAINER_NAME
+            assert (
+                cluster.pod_template.spec.containers[0].name
+                == KUBECLUSTER_WORKER_CONTAINER_NAME
+            )
 
 
 @pytest.mark.asyncio
@@ -576,7 +583,7 @@ async def test_automatic_startup(k8s_cluster, docker_image):
                         "1",
                     ],
                     "image": docker_image,
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         },

--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -1,4 +1,5 @@
 from dask_kubernetes import KubeCluster
+from dask_kubernetes.constants import DASK_CONTAINER_NAME
 from dask_kubernetes.objects import make_pod_spec, make_pod_from_dict
 from distributed.utils_test import loop  # noqa: F401
 
@@ -121,7 +122,7 @@ def test_make_pod_from_dict():
                         "1",
                     ],
                     "image": "image-name",
-                    "name": "dask-worker",
+                    "name": DASK_CONTAINER_NAME,
                     "securityContext": {
                         "capabilities": {"add": ["SYS_ADMIN"]},
                         "privileged": True,

--- a/dask_kubernetes/tests/test_objects.py
+++ b/dask_kubernetes/tests/test_objects.py
@@ -1,5 +1,5 @@
 from dask_kubernetes import KubeCluster
-from dask_kubernetes.constants import DASK_CONTAINER_NAME
+from dask_kubernetes.constants import KUBECLUSTER_WORKER_CONTAINER_NAME
 from dask_kubernetes.objects import make_pod_spec, make_pod_from_dict
 from distributed.utils_test import loop  # noqa: F401
 
@@ -122,7 +122,7 @@ def test_make_pod_from_dict():
                         "1",
                     ],
                     "image": "image-name",
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                     "securityContext": {
                         "capabilities": {"add": ["SYS_ADMIN"]},
                         "privileged": True,

--- a/dask_kubernetes/tests/test_sync.py
+++ b/dask_kubernetes/tests/test_sync.py
@@ -12,7 +12,7 @@ from dask.distributed import Client, wait
 from distributed.utils_test import loop, captured_logger  # noqa: F401
 from dask.utils import tmpfile
 
-from dask_kubernetes.constants import DASK_CONTAINER_NAME
+from dask_kubernetes.constants import KUBECLUSTER_WORKER_CONTAINER_NAME
 
 TEST_DIR = os.path.abspath(os.path.join(__file__, ".."))
 CONFIG_DEMO = os.path.join(TEST_DIR, "config-demo.yaml")
@@ -103,7 +103,7 @@ def dont_test_pod_template_yaml(docker_image, loop):
                     ],
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         },
@@ -149,7 +149,7 @@ def test_pod_template_yaml_expand_env_vars(docker_image, loop):
                         ],
                         "image": "${FOO_IMAGE}",
                         "imagePullPolicy": "IfNotPresent",
-                        "name": DASK_CONTAINER_NAME,
+                        "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                     }
                 ]
             },
@@ -182,7 +182,7 @@ def test_pod_template_dict(docker_image, loop):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         },
@@ -221,7 +221,7 @@ def test_pod_template_minimal_dict(docker_image, loop):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         }
@@ -237,12 +237,19 @@ def test_pod_template_minimal_dict(docker_image, loop):
 
 def test_pod_template_from_conf(docker_image):
     spec = {
-        "spec": {"containers": [{"name": DASK_CONTAINER_NAME, "image": docker_image}]}
+        "spec": {
+            "containers": [
+                {"name": KUBECLUSTER_WORKER_CONTAINER_NAME, "image": docker_image}
+            ]
+        }
     }
 
     with dask.config.set({"kubernetes.worker-template": spec}):
         with KubeCluster() as cluster:
-            assert cluster.pod_template.spec.containers[0].name == DASK_CONTAINER_NAME
+            assert (
+                cluster.pod_template.spec.containers[0].name
+                == KUBECLUSTER_WORKER_CONTAINER_NAME
+            )
 
 
 def test_bad_args():
@@ -314,7 +321,7 @@ def test_automatic_startup(docker_image):
                         "1",
                     ],
                     "image": docker_image,
-                    "name": DASK_CONTAINER_NAME,
+                    "name": KUBECLUSTER_WORKER_CONTAINER_NAME,
                 }
             ]
         },

--- a/dask_kubernetes/tests/test_sync.py
+++ b/dask_kubernetes/tests/test_sync.py
@@ -12,6 +12,8 @@ from dask.distributed import Client, wait
 from distributed.utils_test import loop, captured_logger  # noqa: F401
 from dask.utils import tmpfile
 
+from dask_kubernetes.constants import DASK_CONTAINER_NAME
+
 TEST_DIR = os.path.abspath(os.path.join(__file__, ".."))
 CONFIG_DEMO = os.path.join(TEST_DIR, "config-demo.yaml")
 FAKE_CERT = os.path.join(TEST_DIR, "fake-cert-file")
@@ -101,7 +103,7 @@ def dont_test_pod_template_yaml(docker_image, loop):
                     ],
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": "dask-worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         },
@@ -147,7 +149,7 @@ def test_pod_template_yaml_expand_env_vars(docker_image, loop):
                         ],
                         "image": "${FOO_IMAGE}",
                         "imagePullPolicy": "IfNotPresent",
-                        "name": "dask-worker",
+                        "name": DASK_CONTAINER_NAME,
                     }
                 ]
             },
@@ -180,7 +182,7 @@ def test_pod_template_dict(docker_image, loop):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": "dask-worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         },
@@ -219,7 +221,7 @@ def test_pod_template_minimal_dict(docker_image, loop):
                     "command": None,
                     "image": docker_image,
                     "imagePullPolicy": "IfNotPresent",
-                    "name": "worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         }
@@ -234,11 +236,13 @@ def test_pod_template_minimal_dict(docker_image, loop):
 
 
 def test_pod_template_from_conf(docker_image):
-    spec = {"spec": {"containers": [{"name": "some-name", "image": docker_image}]}}
+    spec = {
+        "spec": {"containers": [{"name": DASK_CONTAINER_NAME, "image": docker_image}]}
+    }
 
     with dask.config.set({"kubernetes.worker-template": spec}):
         with KubeCluster() as cluster:
-            assert cluster.pod_template.spec.containers[0].name == "some-name"
+            assert cluster.pod_template.spec.containers[0].name == DASK_CONTAINER_NAME
 
 
 def test_bad_args():
@@ -310,7 +314,7 @@ def test_automatic_startup(docker_image):
                         "1",
                     ],
                     "image": docker_image,
-                    "name": "dask-worker",
+                    "name": DASK_CONTAINER_NAME,
                 }
             ]
         },


### PR DESCRIPTION
`Pod.logs()` will fail when there are multiple containers within one pod. 

It will fail with e.g: 
```
kubernetes_asyncio.client.exceptions.ApiException: (400)
Reason: Bad Request
HTTP response headers: <CIMultiDictProxy('Audit-Id': '6665d5a7-0ace-40f6-8986-96f9713d1275', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Date': 'Thu, 24 Mar 2022 11:30:43 GMT', 'Content-Length': '249')>
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"a container name must be specified for pod dask-bstadlbauer-5abb6a0e-2s5xvr, choose one of: [vault-agent-init dask-worker vault-agent]","reason":"BadRequest","code":400}
```

This is an issue, as some secret injection frameworks use a sidecar container within the same pod to inject secrets.
Whilst fixing this, I've also tried to extract all strings referencing "dask-worker" container name into `constants.DASK_CONTAINER_NAME`. Let me know if you want to keep that as it was before and I'll revert it. 

Side-note: it seems like both, the scheduler, as well as the workers are named "dask-worker" in k8s. As I had troubles starting tests on my local machine, I have not added a test to replicate the issue.