### PR TITLE
Implement DaskJob resource

### DIFF
--- a/dask_kubernetes/operator/__init__.py
+++ b/dask_kubernetes/operator/__init__.py
@@ -1,1 +1,2 @@
 from .daskcluster import *
+from .daskjob import *

--- a/dask_kubernetes/operator/customresources/daskjob.yaml
+++ b/dask_kubernetes/operator/customresources/daskjob.yaml
@@ -1,16 +1,16 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: daskworkergroups.kubernetes.dask.org
+  name: daskjobs.kubernetes.dask.org
 spec:
   scope: Namespaced
   group: kubernetes.dask.org
   names:
-    kind: DaskWorkerGroup
-    plural: daskworkergroups
-    singular: daskworkergroup
+    kind: DaskJob
+    plural: daskjobs
+    singular: daskjob
     shortNames:
-      - daskworker
+      - daskjob
   versions:
     - name: v1
       served: true
@@ -25,7 +25,3 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
-      subresources:
-        scale:
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas

--- a/dask_kubernetes/operator/daskjob.py
+++ b/dask_kubernetes/operator/daskjob.py
@@ -1,0 +1,16 @@
+import kopf
+
+
+@kopf.on.create("daskjob")
+async def daskjob_create(spec, name, namespace, logger, **kwargs):
+    # TODO Create a Dask Cluster
+    # TODO Create a pod that will use the Dask cluster
+    pass
+
+
+@kopf.on.field(
+    "pods", field="status.phase", labels={"dask-cluster": kopf.PRESENT}, new="Succeeded"
+)
+async def daskjob_succeeded(old, new, **kwargs):
+    # TODO Once pod has comepleted delete the Dask Cluster again
+    pass

--- a/dask_kubernetes/operator/tests/resources/simplejob.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplejob.yaml
@@ -1,0 +1,35 @@
+apiVersion: kubernetes.dask.org/v1
+kind: DaskCluster
+metadata:
+  name: simple-cluster
+spec:
+  job:
+    template:
+      spec:
+        containers:
+          - name: job
+            image: daskdev/dask:latest
+            command:
+              [
+                "python",
+                "-c",
+                "'from dask.distributed import Client; import dask.array as da; client = Client(); print(client.cluster); print(da.random.random((10_000, 10_000), chunks=(1000, 1000)).mean().compute())'",
+              ]
+        restartPolicy: Never
+  cluster:
+    imagePullSecrets: null
+    image: "daskdev/dask:latest"
+    imagePullPolicy: "IfNotPresent"
+    protocol: "tcp"
+    scheduler:
+      resources: {}
+      env: {}
+      serviceType: "ClusterIP"
+      # nodeSelector: null
+      # securityContext: null
+      # affinity: null
+      # tolerations: null
+      # serviceAccountName: null
+    replicas: 3
+    resources: {}
+    env: {}

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -45,6 +45,7 @@ async def gen_cluster(k8s_cluster):
 def test_customresources(k8s_cluster, gen_cluster):
     assert "daskclusters.kubernetes.dask.org" in k8s_cluster.kubectl("get", "crd")
     assert "daskworkergroups.kubernetes.dask.org" in k8s_cluster.kubectl("get", "crd")
+    assert "daskjobs.kubernetes.dask.org" in k8s_cluster.kubectl("get", "crd")
 
 
 def test_operator_runs(kopf_runner):


### PR DESCRIPTION
Implement a `DaskJob` resource which will create a `DaskCluster`, run a pod to completion that leverages the cluster and then tears down the cluster. Useful for batch style workflows with Dask.