### PR TITLE
Add check for kubectl dependecy in operator

### DIFF
--- a/dask_kubernetes/operator/daskcluster.py
+++ b/dask_kubernetes/operator/daskcluster.py
@@ -10,6 +10,7 @@ import kubernetes_asyncio as kubernetes
 from uuid import uuid4
 
 from dask_kubernetes.utils import get_external_address_for_scheduler_service
+from dask_kubernetes.utils import check_dependency
 
 
 def build_scheduler_pod_spec(name, image):
@@ -223,6 +224,7 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
             namespace=namespace,
             body=data,
         )
+        check_dependency("kubectl")
         services = subprocess.check_output(
             [
                 "kubectl",


### PR DESCRIPTION
As apart of #392. Since the operator is using a `kubectl` command, we need to check that kubectl is installed.