### PR TITLE
Install kubectl for Dask Operator

### DIFF
--- a/dask_kubernetes/operator/deployment/Dockerfile
+++ b/dask_kubernetes/operator/deployment/Dockerfile
@@ -10,5 +10,13 @@ WORKDIR /src/dask_kubernetes
 # Install dependencies
 RUN pip install .
 
+# We don't use TARGETARCH so as to support non-buildkit builds
+RUN MAGICARCH=$(dpkg --print-architecture) && \
+    curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${MAGICARCH}/kubectl" && \
+    mkdir -p /usr/local/bin && \
+    mv ./kubectl /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    kubectl version --client
+
 # Start operator
 CMD kopf run -m dask_kubernetes.operator --verbose --all-namespaces


### PR DESCRIPTION
As a part of #392, we want to install `kubectl` in the Docker image.