### PR TITLE
Add operator Docker build and release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,16 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Push Operator Container image to GHCR
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: dask_kubernetes/operator/deployment/Dockerfile
+          push: ${{ github.repository == 'dask/dask-kubernetes' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+          platforms: linux/amd64
+          tags: ghcr.io/dask/dask-kubernetes-operator:latest,ghcr.io/dask/dask-kubernetes-operator:${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Get the version
         id: get_version
         run: |
-          VERSION=${GITHUB_REF/refs\/tags\//}
-          echo ::set-output name=VERSION::${VERSION/\//-/}
+          if [[ "$GITHUB_REF" == *"refs/tags"* ]]; then
+            echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+          else
+            echo ::set-output name=VERSION::dev
+          fi
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,14 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        if: github.repository == 'dask/dask-kubernetes' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push Operator Container image to GHCR
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: |
+          VERSION=${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=VERSION::${VERSION/\//-/}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
Adds a step to the release CI that builds the Operator docker image. If it is run on a tag it will also push to GHCR.