### PR TITLE
Fix worker to scheduler pairing

### DIFF
--- a/dask_kubernetes/experimental/kubecluster.py
+++ b/dask_kubernetes/experimental/kubecluster.py
@@ -203,7 +203,12 @@ class KubeCluster(Cluster):
 
     async def _add_worker_group(self, name, n=3):
         data = build_worker_group_spec(
-            f"{self.name}-cluster-{name}", self.image, n, self.resources, self.env
+            f"{self.name}-cluster-{name}",
+            f"{self.name}-cluster",
+            self.image,
+            n,
+            self.resources,
+            self.env,
         )
         async with kubernetes.client.api_client.ApiClient() as api_client:
             custom_objects_api = kubernetes.client.CustomObjectsApi(api_client)
@@ -239,7 +244,7 @@ class KubeCluster(Cluster):
                 version="v1",
                 plural="daskworkergroups",
                 namespace=self.namespace,
-                name=name,
+                name=f"{self.name}-cluster-{name}",
             )
 
     def close(self):

--- a/dask_kubernetes/operator/customresources/daskworkergroup.yaml
+++ b/dask_kubernetes/operator/customresources/daskworkergroup.yaml
@@ -22,6 +22,9 @@ spec:
             spec:
               type: object
               properties:
+                cluster:
+                  type: string
+                  description: Cluster that this worker group is a part of
                 imagePullSecrets:
                   type: object
                   description: Container image secrets

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -114,8 +114,8 @@ def build_scheduler_service_spec(name):
     }
 
 
-def build_worker_pod_spec(name, namespace, image, n, scheduler_name, env):
-    worker_name = f"{name}-worker-{n}"
+def build_worker_pod_spec(name, namespace, image, uuid, scheduler_name, env):
+    worker_name = f"{name}-worker-{uuid}"
     return {
         "apiVersion": "v1",
         "kind": "Pod",
@@ -144,12 +144,13 @@ def build_worker_pod_spec(name, namespace, image, n, scheduler_name, env):
     }
 
 
-def build_worker_group_spec(name, image, replicas, resources, env):
+def build_worker_group_spec(name, cluster, image, replicas, resources, env):
     return {
         "apiVersion": "kubernetes.dask.org/v1",
         "kind": "DaskWorkerGroup",
         "metadata": {"name": f"{name}-worker-group"},
         "spec": {
+            "cluster": cluster,
             "imagePullSecrets": None,
             "image": image,
             "imagePullPolicy": "IfNotPresent",
@@ -222,7 +223,7 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         )
 
         # TODO Check for existing scheduler service
-        data = build_scheduler_service_spec(name)
+        data = build_scheduler_service_spec(name=name)
         kopf.adopt(data)
         await api.create_namespaced_service(
             namespace=namespace,
@@ -234,11 +235,12 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
             with the following config: {data['spec']}"
         )
         data = build_worker_group_spec(
-            f"{name}-default",
-            spec.get("image"),
-            spec.get("replicas"),
-            spec.get("resources"),
-            spec.get("env"),
+            name=f"{name}-default",
+            cluster=name,
+            image=spec.get("image"),
+            replicas=spec.get("replicas"),
+            resources=spec.get("resources"),
+            env=spec.get("env"),
         )
         # TODO: Next line is not needed if we can get worker groups adopted by the cluster
         kopf.adopt(data)
@@ -260,26 +262,18 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
 async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)
-
-        cluster = await kubernetes.client.CustomObjectsApi(
-            api_client
-        ).list_cluster_custom_object(
-            group="kubernetes.dask.org", version="v1", plural="daskclusters"
-        )
-
-        scheduler_name = cluster["items"][0]["metadata"]["name"]
         num_workers = spec["replicas"]
-        for i in range(num_workers):
+        for _ in range(num_workers):
             data = build_worker_pod_spec(
-                name,
-                namespace,
-                spec.get("image"),
-                uuid4().hex,
-                scheduler_name,
-                spec.get("env", []),
+                name=name,
+                namespace=namespace,
+                image=spec.get("image"),
+                uuid=uuid4().hex,
+                scheduler_name=spec.get("cluster"),
+                env=spec.get("env", []),
             )
             kopf.adopt(data)
-            worker_pod = await api.create_namespaced_pod(
+            await api.create_namespaced_pod(
                 namespace=namespace,
                 body=data,
             )
@@ -290,13 +284,6 @@ async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
 async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)
-
-        scheduler = await kubernetes.client.CustomObjectsApi(
-            api_client
-        ).list_cluster_custom_object(
-            group="kubernetes.dask.org", version="v1", plural="daskclusters"
-        )
-        scheduler_name = scheduler["items"][0]["metadata"]["name"]
         workers = await api.list_namespaced_pod(
             namespace=namespace,
             label_selector=f"dask.org/workergroup-name={name}",
@@ -305,17 +292,17 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
         desired_workers = spec["replicas"]
         workers_needed = desired_workers - current_workers
         if workers_needed > 0:
-            for i in range(workers_needed):
+            for _ in range(workers_needed):
                 data = build_worker_pod_spec(
-                    name,
-                    namespace,
-                    spec.get("image"),
-                    uuid4().hex,
-                    scheduler_name,
-                    spec.get("env", []),
+                    name=name,
+                    namespace=namespace,
+                    image=spec.get("image"),
+                    uuid=uuid4().hex,
+                    scheduler_name=spec.get("cluster"),
+                    env=spec.get("env", []),
                 )
                 kopf.adopt(data)
-                worker_pod = await api.create_namespaced_pod(
+                await api.create_namespaced_pod(
                     namespace=namespace,
                     body=data,
                 )

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -168,3 +168,11 @@ def test_multiple_clusters(kopf_runner):
         with KubeCluster(name="baz") as cluster2:
             with Client(cluster2) as client2:
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
+
+
+def test_multiple_clusters_simultaneously(kopf_runner):
+    with kopf_runner:
+        with KubeCluster(name="bar") as cluster1, KubeCluster(name="baz") as cluster2:
+            with Client(cluster1) as client1, Client(cluster2) as client2:
+                assert client1.submit(lambda x: x + 1, 10).result() == 11
+                assert client2.submit(lambda x: x + 1, 10).result() == 11


### PR DESCRIPTION
Closes #449 

- Add `cluster` property to worker groups to make it easier for them to find their own scheduler. 
- Small hygiene tweaks