### PR TITLE
Fix worker group adoptions

### DIFF
--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -281,9 +281,6 @@ async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
             body=new_spec,
         )
         logger.info(f"Successfully adopted by {spec['cluster']}")
-    await daskworkergroup_update(
-        spec=spec, name=name, namespace=namespace, logger=logger, **kwargs
-    )
 
 
 @kopf.on.update("daskworkergroup")

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -281,6 +281,9 @@ async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
             body=new_spec,
         )
         logger.info(f"Successfully adopted by {spec['cluster']}")
+    await daskworkergroup_update(
+        spec=spec, name=name, namespace=namespace, logger=logger, **kwargs
+    )
 
 
 @kopf.on.update("daskworkergroup")


### PR DESCRIPTION
When a workergroup is created it now patches itself with the ownership pointing to the cluster object in the create hook. This means that additional worker groups will also be correctly owned by the cluster. 

I also removed the pod creation logic from the create hook and just call the update hook instead to reduce duplication.