### PR TITLE
fix: environ may duplicate keys for str format

### DIFF
--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -569,8 +569,9 @@ class KubeCluster(SpecCluster):
         if self.namespace is None:
             self.namespace = namespace_default()
 
+        environ = {k:v for k, v in os.environ.items() if k not in ['user', 'uuid']}
         self._generate_name = self._generate_name.format(
-            user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ
+            user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **environ
         )
         self._generate_name = escape(self._generate_name)
 

--- a/dask_kubernetes/core.py
+++ b/dask_kubernetes/core.py
@@ -569,7 +569,7 @@ class KubeCluster(SpecCluster):
         if self.namespace is None:
             self.namespace = namespace_default()
 
-        environ = {k:v for k, v in os.environ.items() if k not in ['user', 'uuid']}
+        environ = {k: v for k, v in os.environ.items() if k not in ["user", "uuid"]}
         self._generate_name = self._generate_name.format(
             user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **environ
         )


### PR DESCRIPTION
In an interesting edge-case, when you have `user` or `uuid` env variables defines str.format dies because of dupplicate keys. The fix is to filter the environ dictionary and remove those 2 keys

fixes #453 

I was unable to test this locally properly because tests were failing for me when I downloaded the project.