### PR TITLE
Implement from name and connecting to existing clusters

### DIFF
--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -176,3 +176,10 @@ def test_multiple_clusters_simultaneously(kopf_runner):
             with Client(cluster1) as client1, Client(cluster2) as client2:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
+
+
+def test_cluster_from_name(kopf_runner):
+    with kopf_runner:
+        with KubeCluster(name="bar") as firstcluster:
+            with KubeCluster.from_name("bar") as secondcluster:
+                assert firstcluster == secondcluster


### PR DESCRIPTION
I've refactored things a little here so that when you create a cluster it checks if one with that name already exists and if so just connects to it.

```python
from dask_kubernetes.experimental import KubeCluster

# Create our cluster
cluster = KubeCluster(name="foo")

# We can create another class pointing to the same cluster resource "foo"
cluster2 = KubeCluster(name="foo")
```

You might not always want this, so you can explicitly set the `create_mode` kwargs to specify if you want create only, connect only or both.

```python
from dask_kubernetes.experimental import KubeCluster, CreateMode

# Will raise a `ValueError` if "foo" already exists
cluster = KubeCluster(name="foo", create_mode=CreateMode.CREATE_ONLY)
```

This also enables us to implement `from_name` for `dask-ctl` compatibility.

```python
from dask_kubernetes.experimental import KubeCluster, CreateMode

cluster = KubeCluster.from_name(name="foo")
# Is equivalent to
cluster = KubeCluster(name="foo", create_mode=CreateMode.CONNECT_ONLY)
```

I've also added the `shutdown_on_close` kwarg here that is used in a few other places. This allows us to close a `KubeCluster` object without deleting the actual cluster resource on Kubernetes.

```python
from dask_kubernetes.experimental import KubeCluster

cluster = KubeCluster(name="foo")
cluster.close()  # Disconnects from the cluster and deletes the resource

cluster = KubeCluster(name="foo", shutdown_on_close=False)
cluster.close()  # Just disconnects but leaves the resource running
```

This will be useful for multi-stage workflow pipelines that want to create/use/delete the cluster in different Python sessions.

If a `KubeCluster` object connects to an existing cluster then `shutdown_on_close` will be set to `False` automatically unless explicitly set to `True` to avoid accidental deletions.

```python
from dask_kubernetes.experimental import KubeCluster

cluster = KubeCluster.from_name(name="foo")
cluster.close()  # Just disconnects but leaves the resource running

cluster = KubeCluster.from_name(name="foo", shutdown_on_close=True)
cluster.close()  # Disconnects from the cluster and deletes the resource
```