### PR TITLE
Fix Docker image name in operator tests

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM daskdev/dask:latest
+FROM ghcr.io/dask/dask:latest
 
 # Install latest dev builds of Dask and Distributed
 RUN pip install git+https://github.com/dask/distributed@main

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: simple-cluster
 spec:
   imagePullSecrets: null
-  image: "daskdev/dask:latest"
+  image: "dask-kubernetes:dev"
   imagePullPolicy: "IfNotPresent"
   protocol: "tcp"
   scheduler:

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: simple-cluster-additional-worker-group
 spec:
   imagePullSecrets: null
-  image: "daskdev/dask:latest"
+  image: "dask-kubernetes:dev"
   imagePullPolicy: "IfNotPresent"
   replicas: 2
   resources: {}


### PR DESCRIPTION
Operator tests are using the latest Dask release container but we install `dask` and `distributed` from source in CI so we end up with mismatched environments in the clusters we create in our tests.

We already build a `dask-kubernetes:dev` image for testing to fix this but don't seem to be using it in the operator tests.

This PR updates the operator tests and also sets the CI image to build from gchr.io instead of Docker Hub.