### PR TITLE
Enable additional worker groups

### DIFF
--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -183,3 +183,13 @@ def test_cluster_from_name(kopf_runner):
         with KubeCluster(name="bar") as firstcluster:
             with KubeCluster.from_name("bar") as secondcluster:
                 assert firstcluster == secondcluster
+
+
+def test_additional_worker_groups(kopf_runner):
+    with kopf_runner:
+        with KubeCluster(name="additionalgroups", n_workers=1) as cluster:
+            cluster.add_worker_group(name="more", n_workers=1)
+            with Client(cluster) as client:
+                client.wait_for_workers(2)
+                assert client.submit(lambda x: x + 1, 10).result() == 11
+            cluster.delete_worker_group(name="more")

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -11,6 +11,7 @@ from kopf.testing import KopfRunner
 from dask.distributed import Client
 
 DIR = pathlib.Path(__file__).parent.absolute()
+IMAGE = "dask-kubernetes:dev"
 
 
 @pytest.fixture()
@@ -149,7 +150,7 @@ from dask_kubernetes.experimental import KubeCluster
 @pytest.fixture
 def cluster(kopf_runner):
     with kopf_runner:
-        with KubeCluster(name="foo") as cluster:
+        with KubeCluster(name="foo", image=IMAGE) as cluster:
             yield cluster
 
 
@@ -162,17 +163,19 @@ def test_kubecluster(cluster):
 
 def test_multiple_clusters(kopf_runner):
     with kopf_runner:
-        with KubeCluster(name="bar") as cluster1:
+        with KubeCluster(name="bar", image=IMAGE) as cluster1:
             with Client(cluster1) as client1:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
-        with KubeCluster(name="baz") as cluster2:
+        with KubeCluster(name="baz", image=IMAGE) as cluster2:
             with Client(cluster2) as client2:
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
 
 
 def test_multiple_clusters_simultaneously(kopf_runner):
     with kopf_runner:
-        with KubeCluster(name="bar") as cluster1, KubeCluster(name="baz") as cluster2:
+        with KubeCluster(name="bar", image=IMAGE) as cluster1, KubeCluster(
+            name="baz", image=IMAGE
+        ) as cluster2:
             with Client(cluster1) as client1, Client(cluster2) as client2:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
@@ -180,14 +183,14 @@ def test_multiple_clusters_simultaneously(kopf_runner):
 
 def test_cluster_from_name(kopf_runner):
     with kopf_runner:
-        with KubeCluster(name="bar") as firstcluster:
+        with KubeCluster(name="bar", image=IMAGE) as firstcluster:
             with KubeCluster.from_name("bar") as secondcluster:
                 assert firstcluster == secondcluster
 
 
 def test_additional_worker_groups(kopf_runner):
     with kopf_runner:
-        with KubeCluster(name="additionalgroups", n_workers=1) as cluster:
+        with KubeCluster(name="additionalgroups", n_workers=1, image=IMAGE) as cluster:
             cluster.add_worker_group(name="more", n_workers=1)
             with Client(cluster) as client:
                 client.wait_for_workers(2)


### PR DESCRIPTION
Enabled the `add_worker_group` and `delete_worker_group` methods on `dask_kubernetes.experimental.KubeCluster` and made them a little more configurable.

Also added a test and documentation.