### PR TITLE
Fix docker image name in documentation

### DIFF
--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -217,7 +217,7 @@ Let's create an example called ``highmemworkers.yaml`` with the following config
    spec:
       cluster: simple-cluster
       imagePullSecrets: null
-      image: "dask-kubernetes:dev"
+      image: "daskdev/dask:latest"
       imagePullPolicy: "IfNotPresent"
       replicas: 2
       resources:

--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -217,7 +217,7 @@ Let's create an example called ``highmemworkers.yaml`` with the following config
    spec:
       cluster: simple-cluster
       imagePullSecrets: null
-      image: "daskdev/dask:latest"
+      image: "ghcr.io/dask/dask:latest"
       imagePullPolicy: "IfNotPresent"
       replicas: 2
       resources:


### PR DESCRIPTION
Quick fix for a docker image name in the documentation, so the `highmem-worker-group` workers run correctly.