### PR TITLE
feat: add service account roles/rolebinding to operator helm chart

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
@@ -9,4 +9,56 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}-role-cluster
+rules:
+  # Framework: knowing which other operators are running (i.e. peering).
+  - apiGroups: [kopf.dev]
+    resources: [clusterkopfpeerings]
+    verbs: [list, watch, patch, get]
+
+  # Framework: runtime observation of namespaces & CRDs (addition/deletion).
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [list, watch]
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [list, watch]
+
+  # Framework: admission webhook configuration management.
+  - apiGroups:
+      [admissionregistration.k8s.io/v1, admissionregistration.k8s.io/v1beta1]
+    resources: [validatingwebhookconfigurations, mutatingwebhookconfigurations]
+    verbs: [create, patch]
+
+  # Application: watching & handling for the custom resource we declare.
+  - apiGroups: [kubernetes.dask.org]
+    resources: [daskclusters, daskworkergroups]
+    verbs: [get, list, watch, patch, create, delete]
+
+  # Application: other resources it produces and manipulates.
+  # Here, we create/delete Pods.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [create, delete, get, watch, list]
+  
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [create, delete, get, watch, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}-rolebinding-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}-role-cluster
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -41,6 +41,25 @@ This will create the appropriate roles, service accounts and a deployment for th
    kube-system   dask-kubernetes-operator-775b8bbbd5-zdrf7   1/1     Running   0          74s
 
 
+Installing the operator with Helm
+---------------------------------
+
+Along with a set of kubernetes manifests, the operator has a basic Helm chart which can be used to manage the installation of the operator.
+The chart is published in the ``dask/helm-charts`` repository, and can be installed via:
+
+.. code-block:: console
+
+    $ helm repo add dask https://helm.dask.org
+    $ helm repo update
+    $ helm install --version 2022.5.0 myrelease dask/dask-kubernetes-operator
+
+This will install the custom resource definitions, service account, roles, and the operator deployment.
+
+.. warning::
+    Please note that `Helm does not support updating or deleting CRDs. <https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations>`_ If updates
+    are made to the CRD templates in future releases (to support future k8s releases, for example) you may have to manually update the CRDs.
+
+
 Creating a Dask cluster via ``kubectl``
 ---------------------------------------
 

--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -45,13 +45,13 @@ Installing the operator with Helm
 ---------------------------------
 
 Along with a set of kubernetes manifests, the operator has a basic Helm chart which can be used to manage the installation of the operator.
-The chart is published in the ``dask/helm-charts`` repository, and can be installed via:
+The chart is published in the `Dask Helm repo <https://helm.dask.org>`_ repository, and can be installed via:
 
 .. code-block:: console
 
     $ helm repo add dask https://helm.dask.org
     $ helm repo update
-    $ helm install --version 2022.5.0 myrelease dask/dask-kubernetes-operator
+    $ helm install myrelease dask/dask-kubernetes-operator
 
 This will install the custom resource definitions, service account, roles, and the operator deployment.
 


### PR DESCRIPTION
Add the roles/rolebindings to the default service account in the operator helm chart. 

Also added a bit of documentation for using the helm chart. The biggest issue to point out here is the lack of update/delete support for CRDs in helm. Maybe we could also add some doco about default values? What do you reckon?

Related to #479