### PR TITLE
Add Istio support

### DIFF
--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -36,6 +36,16 @@ def k8s_cluster(kind_cluster, docker_image):
     del os.environ["KUBECONFIG"]
 
 
+@pytest.fixture(scope="session", autouse=True)
+def install_istio(k8s_cluster):
+    if bool(os.environ.get("TEST_ISTIO", False)):
+        check_dependency("istioctl")
+        subprocess.check_output(["istioctl", "install", "--set", "profile=demo", "-y"])
+        k8s_cluster.kubectl(
+            "label", "namespace", "default", "istio-injection=enabled", "--overwrite"
+        )
+
+
 @pytest.fixture(scope="session")
 def ns(k8s_cluster):
     return "default"

--- a/dask_kubernetes/experimental/kubecluster.py
+++ b/dask_kubernetes/experimental/kubecluster.py
@@ -558,15 +558,17 @@ class KubeCluster(Cluster):
 
 @atexit.register
 def reap_clusters():
-    async def _reap_clusters():
-        for cluster in list(KubeCluster._instances):
-            if cluster.shutdown_on_close and cluster.status != Status.closed:
-                await ClusterAuth.load_first(cluster.auth)
-                with suppress(TimeoutError):
-                    if cluster.asynchronous:
-                        await cluster.close(timeout=10)
-                    else:
-                        cluster.close(timeout=10)
+    with suppress(Exception):
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_reap_clusters())
+        async def _reap_clusters():
+            for cluster in list(KubeCluster._instances):
+                if cluster.shutdown_on_close and cluster.status != Status.closed:
+                    await ClusterAuth.load_first(cluster.auth)
+                    with suppress(TimeoutError):
+                        if cluster.asynchronous:
+                            await cluster.close(timeout=10)
+                        else:
+                            cluster.close(timeout=10)
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(_reap_clusters())

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -195,7 +195,7 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
         if workers_needed > 0:
             for _ in range(workers_needed):
                 data = build_worker_pod_spec(
-                    name, spec["cluster"], uuid4().hex, spec["worker"]["spec"]
+                    name, spec["cluster"], uuid4().hex[:10], spec["worker"]["spec"]
                 )
                 kopf.adopt(data)
                 await api.create_namespaced_pod(

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -14,6 +14,21 @@ spec:
           args:
             - dask-worker
             - tcp://simple-cluster-service.default.svc.cluster.local:8786
+            - --name
+            - ${DASK_WORKER_NAME}
+            - --dashboard-address
+            - 0.0.0.0:8787
+            - --listen-address
+            - tcp://0.0.0.0:8788
+            - --contact-address
+            - tcp://${DASK_WORKER_NAME}.default.svc.cluster.local:8788
+          ports:
+            - name: comm
+              containerPort: 8788
+              protocol: TCP
+            - name: dashboard
+              containerPort: 8787
+              protocol: TCP
           env:
             - name: WORKER_ENV
               value: hello-world # We dont test the value, just the name

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -86,7 +86,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     await client.wait_for_workers(3)
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(300)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:


### PR DESCRIPTION
Closes #482.

The PR aims to ensure the operator will play nicely with Istio. As discussed in #482 the way to achieve this is for the workers to have a service each and ensure all network connections within the Dask cluster are going via services rather than directly pod to pod.

To kick things off in this PR I've added a fixture that installs Istio into the kind cluster that gets created, but it is opt-in. To enable it you need to set the `TEST_ISTIO=true` env var. This means we can enable Istio in the operator CI but not the Helm or classic `KubeCluster` CI.

I also had to shorten the `uuid` that was being appended to the worker name because Istio was reusing that name and appending more and was hitting a character limit. We should possibly consider reducing the length of some of our naming schemes.

I've then added a service in front of the workers and tried to get the Dask cluster to only speak via those. Things are not 100% working with this though.

I'm also doing some environment variable injection as discussed in #474. The use case here is so that the worker can correctly set its name.