### PR TITLE
Delegate Docker Image building to chartpress

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,17 +53,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Operator Container image to GHCR
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: dask_kubernetes/operator/deployment/Dockerfile
-          push: ${{ github.repository == 'dask/dask-kubernetes' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
-          platforms: linux/amd64
-          tags: ghcr.io/dask/dask-kubernetes-operator:latest,ghcr.io/dask/dask-kubernetes-operator:${{ steps.get_version.outputs.VERSION }}
-
       - name: Build and publish operator Helm chart with chartpress
-        if: github.repository == 'dask/dask-kubernetes' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         env:
           # chartpress can make use of a personal access token by setting these
           # environment variables like this, for details see:
@@ -71,4 +61,13 @@ jobs:
           #
           GITHUB_ACTOR: ""
           GITHUB_TOKEN: "${{ secrets.dask_bot_token }}"
-        run: cd dask_kubernetes/operator/deployment/helm && chartpress --publish-chart
+          PUBLISH: ${{ github.repository == 'dask/dask-kubernetes' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+        run: |
+          cd dask_kubernetes/operator/deployment/helm
+
+          if ${PUBLISH} == true; then
+              chartpress --force-push --force-publish-chart
+          else
+              chartpress
+          fi
+

--- a/dask_kubernetes/operator/deployment/helm/chartpress.yaml
+++ b/dask_kubernetes/operator/deployment/helm/chartpress.yaml
@@ -21,3 +21,8 @@ charts:
     repo:
       git: dask/helm-chart
       published: https://helm.dask.org
+    images:
+      dask-kubernetes-operator:
+        imageName: ghcr.io/dask/dask-kubernetes-operator
+        dockerfilePath: ../Dockerfile
+        contextPath: ../../../../


### PR DESCRIPTION
Fixes #491 

I'm a little hesitant to make this change as the Helm Chart in the repo is a secondary install method so it seems like bad separation of concerns. But as @consideRatio points out just because `chartpress` builds the Docker image it doesn't mean we can't use it without the Helm Chart.

Chartpress now handles building the Docker image for the operator. The CI also now runs chartpress on every run but adds the `--force-push --force-publish-chart` flags on tags so we can continue testing the Docker image build on every run.

@consideRatio would you mind reviewing?