### PR TITLE
Disable istio sidecar injection

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -18,6 +18,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -33,4 +34,5 @@ jobs:
       - name: Run tests
         env:
           KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
+          TEST_ISTIO: "true"
         run: pytest dask_kubernetes/common/tests dask_kubernetes/operator/tests dask_kubernetes/experimental/tests

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+curl -L https://istio.io/downloadIstio | sh -
+mv istio-*/bin/istioctl /usr/local/bin/istioctl
+
 pip install -e .
 pip install -r requirements-test.txt
 pip install git+https://github.com/dask/distributed@main

--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -36,6 +36,16 @@ def k8s_cluster(kind_cluster, docker_image):
     del os.environ["KUBECONFIG"]
 
 
+@pytest.fixture(scope="session", autouse=True)
+def install_istio(k8s_cluster):
+    if bool(os.environ.get("TEST_ISTIO", False)):
+        check_dependency("istioctl")
+        subprocess.check_output(["istioctl", "install", "--set", "profile=demo", "-y"])
+        k8s_cluster.kubectl(
+            "label", "namespace", "default", "istio-injection=enabled", "--overwrite"
+        )
+
+
 @pytest.fixture(scope="session")
 def ns(k8s_cluster):
     return "default"

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -22,6 +22,7 @@ def build_scheduler_pod_spec(name, spec):
             "labels": {
                 "dask.org/cluster-name": name,
                 "dask.org/component": "scheduler",
+                "sidecar.istio.io/inject": "false",
             },
         },
         "spec": spec,
@@ -53,6 +54,7 @@ def build_worker_pod_spec(name, cluster_name, n, spec):
                 "dask.org/cluster-name": cluster_name,
                 "dask.org/workergroup-name": name,
                 "dask.org/component": "worker",
+                "sidecar.istio.io/inject": "false",
             },
         },
         "spec": spec,


### PR DESCRIPTION
In #488 I am working on getting Dask clusters created by the operator to play nicely with Istio. So far this has been more challenging than I expected.

This PR is intended as a stop-gap which adds Istio to the CI but adds labels to the scheduler and worker pods to disable sidecar injection. This should mean the operator will work on clusters running Istio, but without the benefit of actually using it.

Hopefully, these changes will be quickly replaced by efforts in #488.

xref #482 