### PR TITLE
Replace RPC with Scheduler HTTP API

### DIFF
--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -11,13 +11,17 @@ from .utils import check_dependency
 
 
 async def get_external_address_for_scheduler_service(
-    core_api, service, port_forward_cluster_ip=None, service_name_resolution_retries=20
+    core_api,
+    service,
+    port_forward_cluster_ip=None,
+    service_name_resolution_retries=20,
+    port_name="comm",
 ):
     """Take a service object and return the scheduler address."""
     [port] = [
         port.port
         for port in service.spec.ports
-        if port.name == service.metadata.name or port.name == "comm"
+        if port.name == service.metadata.name or port.name == port_name
     ]
     if service.spec.type == "LoadBalancer":
         lb = service.status.load_balancer.ingress[0]
@@ -104,13 +108,16 @@ async def port_forward_dashboard(service_name, namespace):
     return port
 
 
-async def get_scheduler_address(service_name, namespace):
+async def get_scheduler_address(service_name, namespace, port_name="comm"):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)
         service = await api.read_namespaced_service(service_name, namespace)
         port_forward_cluster_ip = None
         address = await get_external_address_for_scheduler_service(
-            api, service, port_forward_cluster_ip=port_forward_cluster_ip
+            api,
+            service,
+            port_forward_cluster_ip=port_forward_cluster_ip,
+            port_name=port_name,
         )
         return address
 

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -2,17 +2,12 @@ import asyncio
 import aiohttp
 import json
 
-from distributed.core import rpc
-
 import kopf
 import kubernetes_asyncio as kubernetes
 
 from uuid import uuid4
 
 from dask_kubernetes.common.auth import ClusterAuth
-from dask_kubernetes.common.networking import (
-    get_scheduler_address,
-)
 
 
 def build_scheduler_pod_spec(name, spec):
@@ -204,6 +199,7 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
                 data["spec"]["containers"][0]["args"].append(
                     f"--name={data['metadata']['name']}"
                 )
+                logger.info("Creating worker with config {data}")
                 kopf.adopt(data)
                 await api.create_namespaced_pod(
                     namespace=namespace,
@@ -213,12 +209,6 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
                 f"Scaled worker group {name} up to {spec['worker']['replicas']} workers."
             )
         if workers_needed < 0:
-            service_name = f"{name.split('-')[0]}-cluster-service"
-            address = await get_scheduler_address(service_name, namespace)
-            async with rpc(address) as scheduler:
-                worker_ids = await scheduler.workers_to_close(
-                    n=-workers_needed, attribute="name"
-                )
             async with aiohttp.ClientSession() as session:
                 params = {"n": -workers_needed}
                 async with session.post(
@@ -226,6 +216,10 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
                 ) as resp:
                     retired_workers = json.loads(await resp.text())["workers"]
                     logger.info(f"Retired workers API: {retired_workers}")
+            worker_ids = [
+                retired_workers[worker_address]["name"]
+                for worker_address in retired_workers.keys()
+            ]
             # TODO: Check that were deting workers in the right worker group
             logger.info(f"Workers to close: {worker_ids}")
             for wid in worker_ids:

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -1,10 +1,13 @@
 import asyncio
 import aiohttp
+from contextlib import suppress
 
 import kopf
 import kubernetes_asyncio as kubernetes
 
 from uuid import uuid4
+
+from distributed.core import rpc
 
 from dask_kubernetes.common.auth import ClusterAuth
 from dask_kubernetes.common.networking import (
@@ -194,6 +197,52 @@ async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
     )
 
 
+async def retire_workers(
+    n_workers, scheduler_service_name, worker_group_name, namespace, logger
+):
+    # Try gracefully retiring via the HTTP API
+    dashboard_address = await get_scheduler_address(
+        scheduler_service_name,
+        namespace,
+        port_name="dashboard",
+    )
+    async with aiohttp.ClientSession() as session:
+        url = f"{dashboard_address}/api/v1/retire_workers"
+        params = {"n": n_workers}
+        async with session.post(url, json=params) as resp:
+            if resp.status <= 300:
+                retired_workers = await resp.json()
+                return [retired_workers[w]["name"] for w in retired_workers.keys()]
+
+    # Otherwise try gracefully retiring via the RPC
+    logger.info(
+        f"Scaling {worker_group_name} failed via the HTTP API, falling back to the Dask RPC"
+    )
+    # Dask version mismatches between the operator and scheduler may cause this to fail in any number of unexpected ways
+    with suppress(Exception):
+        comm_address = await get_scheduler_address(
+            scheduler_service_name,
+            namespace,
+        )
+        async with rpc(comm_address) as scheduler_comm:
+            return await scheduler_comm.workers_to_close(
+                n=n_workers,
+                attribute="name",
+            )
+
+    # Finally fall back to last-in-first-out scaling
+    logger.info(
+        f"Scaling {worker_group_name} failed via the Dask RPC, falling back to LIFO scaling"
+    )
+    async with kubernetes.client.api_client.ApiClient() as api_client:
+        api = kubernetes.client.CoreV1Api(api_client)
+        workers = await api.list_namespaced_pod(
+            namespace=namespace,
+            label_selector=f"dask.org/workergroup-name={worker_group_name}",
+        )
+        return [w["metadata"]["name"] for w in workers.items[:-n_workers]]
+
+
 @kopf.on.update("daskworkergroup")
 async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
     async with kubernetes.client.api_client.ApiClient() as api_client:
@@ -225,20 +274,13 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
                 f"Scaled worker group {name} up to {spec['worker']['replicas']} workers."
             )
         if workers_needed < 0:
-            service_address = await get_scheduler_address(
-                f"{spec['cluster']}-service", namespace, port_name="dashboard"
+            worker_ids = await retire_workers(
+                n_workers=-workers_needed,
+                scheduler_service_name=f"{spec['cluster']}-service",
+                worker_group_name=name,
+                namespace=namespace,
+                logger=logger,
             )
-            async with aiohttp.ClientSession() as session:
-                params = {"n": -workers_needed}
-                async with session.post(
-                    f"{service_address}/api/v1/retire_workers", json=params
-                ) as resp:
-                    retired_workers = await resp.json()
-            worker_ids = [
-                retired_workers[worker_address]["name"]
-                for worker_address in retired_workers.keys()
-            ]
-            # TODO: Check that were deting workers in the right worker group
             logger.info(f"Workers to close: {worker_ids}")
             for wid in worker_ids:
                 await api.delete_namespaced_pod(

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -1,4 +1,6 @@
 import asyncio
+import aiohttp
+import json
 
 from distributed.core import rpc
 
@@ -212,6 +214,13 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
                 worker_ids = await scheduler.workers_to_close(
                     n=-workers_needed, attribute="name"
                 )
+            async with aiohttp.ClientSession() as session:
+                params = {"n": -workers_needed}
+                async with session.post(
+                    "http://localhost:8787/api/v1/workers_to_close", json=params
+                ) as resp:
+                    workers_to_close = json.loads(await resp.text())["workers"]
+                    logger.info(f"Workers to close API: {workers_to_close}")
             # TODO: Check that were deting workers in the right worker group
             logger.info(f"Workers to close: {worker_ids}")
             for wid in worker_ids:

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -233,11 +233,7 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
                 async with session.post(
                     f"{service_address}/api/v1/retire_workers", json=params
                 ) as resp:
-                    # This try block can be removed after https://github.com/dask/distributed/pull/6397 is merged
-                    try:
-                        retired_workers = await resp.json()
-                    except aiohttp.client_exceptions.ContentTypeError:
-                        retired_workers = await resp.json(content_type="text/json")
+                    retired_workers = await resp.json()
             worker_ids = [
                 retired_workers[worker_address]["name"]
                 for worker_address in retired_workers.keys()


### PR DESCRIPTION
This PR replaces the call to the RPC object in favor of the new scheduler HTTP API. 
Related Issue: [#5935](https://github.com/dask/distributed/issues/5935)
Related PR: [#6270](https://github.com/dask/distributed/pull/6270)