### PR TITLE
Update examples with correct container name

### DIFF
--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -61,7 +61,7 @@ kubernetes:
     # spec:
     #   restartPolicy: Never
     #   containers:
-    #   - name: dask
+    #   - -scheduler
     #     image: ghcr.io/dask/dask:latest
     #     args:
     #       - dask-scheduler
@@ -83,7 +83,7 @@ kubernetes:
     # spec:
     #   restartPolicy: Never
     #   containers:
-    #   - name: dask
+    #   - name: dask-worker
     #     image: ghcr.io/dask/dask:latest
     #     args:
     #       - dask-worker

--- a/doc/source/kubecluster.rst
+++ b/doc/source/kubecluster.rst
@@ -59,7 +59,7 @@ that will be used as a template.
       - image: ghcr.io/dask/dask:latest
         imagePullPolicy: IfNotPresent
         args: [dask-worker, --nthreads, '2', --no-dashboard, --memory-limit, 6GB, --death-timeout, '60']
-        name: dask
+        name: dask-worker
         env:
           - name: EXTRA_PIP_PACKAGES
             value: git+https://github.com/dask/distributed


### PR DESCRIPTION
xref #498 

Looks like the container name has to be `dask-worker` so updating the example to reflect that.