### PR TITLE
Fix operator scaling down

### DIFF
--- a/dask_kubernetes/experimental/kubecluster.py
+++ b/dask_kubernetes/experimental/kubecluster.py
@@ -536,6 +536,8 @@ class KubeCluster(Cluster):
                         "args": [
                             "dask-worker",
                             f"tcp://{service_name}.{self.namespace}.svc.cluster.local:8786",
+                            "--name",
+                            "$(DASK_WORKER_NAME)",
                         ],
                         "env": env,
                         "resources": self.resources,

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -14,6 +14,8 @@ spec:
           args:
             - dask-worker
             - tcp://simple-cluster-service.default.svc.cluster.local:8786
+            - --name
+            - $(DASK_WORKER_NAME)
           env:
             - name: WORKER_ENV
               value: hello-world # We dont test the value, just the name
@@ -46,7 +48,7 @@ spec:
             - name: SCHEDULER_ENV
               value: hello-world
     service:
-      type: NodePort
+      type: ClusterIP
       selector:
         dask.org/cluster-name: simple-cluster
         dask.org/component: scheduler

--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -86,6 +86,8 @@ Let's create an example called ``cluster.yaml`` with the following configuration
               - dask-worker
               # Note the name of the cluster service, which adds "-service" to the end
               - tcp://simple-cluster-service.default.svc.cluster.local:8786
+              - --name
+              - $(DASK_WORKER_NAME)
       scheduler:
         spec:
           containers:
@@ -299,6 +301,8 @@ Let's create an example called ``highmemworkers.yaml`` with the following config
               - dask-worker
               # Note the name of the cluster service, which adds "-service" to the end
               - tcp://simple-cluster-service.default.svc.cluster.local:8786
+              - --name
+              - $(DASK_WORKER_NAME)
 
 The main thing we need to ensure is that the ``cluster`` option matches the name of the cluster we created earlier. This will cause
 the workers to join that cluster.


### PR DESCRIPTION
Fixes #442

Now that we ask the scheduler which pods to remove we need the scheduler to tell us the name of the pod (currently the worker name defaults to the local TCP address it listens on). So scaling down fails because the name the scheduler has for the worker doesn't match the name of the pod.

This PR adds an env var injection to the pod creation that sets a `DASK_WORKER_NAME` variable and updates the specs to use that. Env var injection was discussed in #474 but this is the first implementation that does it. It would be great if this was setting was configurable via the Dask config system though so we wouldn't need to do it in the command.

Tests aren't catching this currently because `wait_for_workers` is checking for a minimum number, not an absolute number. Rather than increasing test complexity here, I've raised dask/distributed#6374 to hopefully add optional support for waiting for an absolute number.

I've also changed the `NodePort` setting on the test cluster to `ClusterIP` so that the port forwarding works correctly for all developers (kind doesn't like `NodePort`).