### PR TITLE
Set scheduler address in injected environment variable

### DIFF
--- a/dask_kubernetes/experimental/kubecluster.py
+++ b/dask_kubernetes/experimental/kubecluster.py
@@ -535,7 +535,6 @@ class KubeCluster(Cluster):
                         "image": self.image,
                         "args": [
                             "dask-worker",
-                            f"tcp://{service_name}.{self.namespace}.svc.cluster.local:8786",
                             "--name",
                             "$(DASK_WORKER_NAME)",
                         ],

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -13,7 +13,6 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - dask-worker
-            - tcp://simple-cluster-service.default.svc.cluster.local:8786
             - --name
             - $(DASK_WORKER_NAME)
           env:

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -14,7 +14,6 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - dask-worker
-            - tcp://simple-cluster-service.default.svc.cluster.local:8786
           env:
             - name: WORKER_ENV
               value: hello-world # We dont test the value, just the name


### PR DESCRIPTION
Rather than passing the scheduler address via the pod args (and requiring all folks writing YAML manifests to do the same) this PR injects the `DASK_SCHEDULER_ADDRESS` as an env var in all worker pod containers.

This is a step towards removing boilerplate from the YAML xref #474