### PR TITLE
Fix helm chart Dask logo

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/Chart.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/Chart.yaml
@@ -7,4 +7,4 @@ appVersion: "2022.4.1"
 home: https://kubernetes.dask.org/
 sources:
   - https://github.com/dask/dask-kubernetes/
-icon: https://docs.dask.org/en/latest/_images/dask_icon_no_pad.svg
+icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200


### PR DESCRIPTION
We just updated the Dask logo. Pointing the logo in the chart to the GitHub avatar as we do in the other helm charts to avoid having to change this again in the future.