### PR TITLE
Get chartpress to update image tag

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/chartpress.yaml
+++ b/dask_kubernetes/operator/deployment/helm/chartpress.yaml
@@ -26,3 +26,5 @@ charts:
         imageName: ghcr.io/dask/dask-kubernetes-operator
         dockerfilePath: ../Dockerfile
         contextPath: ../../../../
+        valuesPath:
+          - image


### PR DESCRIPTION
Fixes #518 

When the helm chart is published it will now update the image tag in the `values.yaml`.