### PR TITLE
Allow custom worker command

### DIFF
--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 curl -L https://istio.io/downloadIstio | sh -
 mv istio-*/bin/istioctl /usr/local/bin/istioctl
 

--- a/dask_kubernetes/experimental/tests/test_kubecluster.py
+++ b/dask_kubernetes/experimental/tests/test_kubecluster.py
@@ -19,6 +19,17 @@ def test_kubecluster(cluster):
         assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
+def test_custom_worker_command(kopf_runner, docker_image):
+    with kopf_runner:
+        with KubeCluster(
+            name="customworker",
+            docker_image=docker_image,
+            worker_command=["python", "-m", "distributed.cli.dask_worker"],
+        ) as cluster:
+            with Client(cluster) as client:
+                assert client.submit(lambda x: x + 1, 10).result() == 11
+
+
 def test_multiple_clusters(kopf_runner, docker_image):
     with kopf_runner:
         with KubeCluster(name="bar", image=docker_image) as cluster1:

--- a/dask_kubernetes/experimental/tests/test_kubecluster.py
+++ b/dask_kubernetes/experimental/tests/test_kubecluster.py
@@ -23,7 +23,7 @@ def test_custom_worker_command(kopf_runner, docker_image):
     with kopf_runner:
         with KubeCluster(
             name="customworker",
-            docker_image=docker_image,
+            image=docker_image,
             worker_command=["python", "-m", "distributed.cli.dask_worker"],
         ) as cluster:
             with Client(cluster) as client:


### PR DESCRIPTION
Allow users to set a custom worker command in `dask_kubernetes.experimental.KubeCluster`.

```python
cluster = KubeCluster(name="customworkercommand",
                      worker_command=["python", "-m", "distributed.cli.dask_worker"])
```

Closes #537 