### PR TITLE
Allow workergroups scaling

### DIFF
--- a/dask_kubernetes/operator/deployment/manifests/operator.yaml
+++ b/dask_kubernetes/operator/deployment/manifests/operator.yaml
@@ -61,7 +61,7 @@ rules:
 
   # Application: watching & handling for the custom resource we declare.
   - apiGroups: [kubernetes.dask.org]
-    resources: [daskclusters, daskworkergroups, daskjobs]
+    resources: [daskclusters, daskworkergroups, daskworkergroups/scale, daskjobs]
     verbs: [get, list, watch, patch, create, delete]
 
   # Application: other resources it produces and manipulates.


### PR DESCRIPTION
Scale management breaks for a role due to a lack of permissions.

Also guys, could you please cut new release afterwards. There is a serious bug related to `self.name=name` fix in the current one (dask-kubernetes=2022.5.2).