### PR TITLE
Add a status to DaskCluster resources and use that to timeout the KubeCluster

### DIFF
--- a/dask_kubernetes/experimental/tests/test_kubecluster.py
+++ b/dask_kubernetes/experimental/tests/test_kubecluster.py
@@ -83,4 +83,4 @@ def test_additional_worker_groups(kopf_runner, docker_image):
 
 def test_cluster_without_operator(docker_image):
     with pytest.raises(TimeoutError, match="is the Dask Operator running"):
-        KubeCluster(name="noop", n_workers=1, image=docker_image, operator_timeout=1)
+        KubeCluster(name="noop", n_workers=1, image=docker_image, resource_timeout=1)

--- a/dask_kubernetes/experimental/tests/test_kubecluster.py
+++ b/dask_kubernetes/experimental/tests/test_kubecluster.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dask.distributed import Client
+from distributed.utils import TimeoutError
 
 from dask_kubernetes.experimental import KubeCluster
 
@@ -78,3 +79,8 @@ def test_additional_worker_groups(kopf_runner, docker_image):
                 client.wait_for_workers(2)
                 assert client.submit(lambda x: x + 1, 10).result() == 11
             cluster.delete_worker_group(name="more")
+
+
+def test_cluster_without_operator(docker_image):
+    with pytest.raises(TimeoutError, match="is the Dask Operator running"):
+        KubeCluster(name="noop", n_workers=1, image=docker_image, operator_timeout=1)

--- a/dask_kubernetes/operator/customresources/templates.yaml
+++ b/dask_kubernetes/operator/customresources/templates.yaml
@@ -33,6 +33,10 @@ definitions:
     properties:
       status:
         type: object
+        properties:
+          phase:
+            type: string
+            description: Status of the Dask cluster
       spec:
         type: object
         required:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
@@ -5894,6 +5894,9 @@ spec:
             - worker
             type: object
           status:
+            properties:
+              phase:
+                type: string
             type: object
         required:
         - spec

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
@@ -5897,6 +5897,9 @@ spec:
                     - worker
                     type: object
                   status:
+                    properties:
+                      phase:
+                        type: string
                     type: object
                 required:
                 - spec

--- a/dask_kubernetes/operator/deployment/manifests/daskcluster.yaml
+++ b/dask_kubernetes/operator/deployment/manifests/daskcluster.yaml
@@ -5894,6 +5894,9 @@ spec:
             - worker
             type: object
           status:
+            properties:
+              phase:
+                type: string
             type: object
         required:
         - spec

--- a/dask_kubernetes/operator/deployment/manifests/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/manifests/daskjob.yaml
@@ -5897,6 +5897,9 @@ spec:
                     - worker
                     type: object
                   status:
+                    properties:
+                      phase:
+                        type: string
                     type: object
                 required:
                 - spec

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -144,12 +144,22 @@ async def startup(**kwargs):
 
 
 @kopf.on.create("daskcluster")
-async def daskcluster_create(spec, name, namespace, logger, **kwargs):
-    logger.info(
-        f"A DaskCluster has been created called {name} in {namespace} with the following config: {spec}"
-    )
+async def daskcluster_create(name, namespace, logger, patch, **kwargs):
+    """When DaskCluster resource is created set the status.phase.
+
+    This allows us to track that the operator is running.
+    """
+    logger.info(f"DaskCluster {name} created in {namespace}.")
+    patch.status["phase"] = "Created"
+
+
+@kopf.on.field("daskcluster", field="status.phase", new="Created")
+async def daskcluster_create_components(spec, name, namespace, logger, patch, **kwargs):
+    """When the DaskCluster status.phase goes into Pending create the cluster components."""
+    logger.info("Creating Dask cluster components.")
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)
+        custom_api = kubernetes.client.CustomObjectsApi(api_client)
 
         # TODO Check for existing scheduler pod
         scheduler_spec = spec.get("scheduler", {})
@@ -160,10 +170,7 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
             body=data,
         )
         # await wait_for_scheduler(name, namespace)
-        logger.info(
-            f"A scheduler pod has been created called {data['metadata']['name']} in {namespace} \
-            with the following config: {data['spec']}"
-        )
+        logger.info(f"Scheduler pod {data['metadata']['name']} created in {namespace}.")
 
         # TODO Check for existing scheduler service
         data = build_scheduler_service_spec(name, scheduler_spec.get("service"))
@@ -174,26 +181,23 @@ async def daskcluster_create(spec, name, namespace, logger, **kwargs):
         )
         await wait_for_service(api, data["metadata"]["name"], namespace)
         logger.info(
-            f"A scheduler service has been created called {data['metadata']['name']} in {namespace} \
-            with the following config: {data['spec']}"
+            f"Scheduler service {data['metadata']['name']} created in {namespace}."
         )
 
         worker_spec = spec.get("worker", {})
         data = build_worker_group_spec(name, worker_spec)
         # TODO: Next line is not needed if we can get worker groups adopted by the cluster
         kopf.adopt(data)
-        api = kubernetes.client.CustomObjectsApi(api_client)
-        await api.create_namespaced_custom_object(
+        await custom_api.create_namespaced_custom_object(
             group="kubernetes.dask.org",
             version="v1",
             plural="daskworkergroups",
             namespace=namespace,
             body=data,
         )
-        logger.info(
-            f"A worker group has been created called {data['metadata']['name']} in {namespace} \
-            with the following config: {data['spec']}"
-        )
+        logger.info(f"Worker group {data['metadata']['name']} created in {namespace}.")
+    # TODO Set to "Pending" here and track scheduler readiness before finally setting to "Running"
+    patch.status["phase"] = "Running"
 
 
 @kopf.on.create("daskworkergroup")
@@ -344,7 +348,7 @@ async def daskjob_create(spec, name, namespace, logger, **kwargs):
             body=cluster_spec,
         )
         logger.info(
-            f"A cluster for the job {name} has been created called {cluster_spec['metadata']['name']} in {namespace}"
+            f"Cluster {cluster_spec['metadata']['name']} for job {name} created in {namespace}."
         )
 
         job_pod_spec = build_job_pod_spec(

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -3,6 +3,7 @@ import pytest
 import asyncio
 from contextlib import asynccontextmanager
 import pathlib
+import re
 
 import os.path
 
@@ -161,9 +162,9 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             assert "WORKER_ENV" in worker_env
             assert cluster_name
 
-    assert "A DaskCluster has been created" in runner.stdout
-    assert "A scheduler pod has been created" in runner.stdout
-    assert "A worker group has been created" in runner.stdout
+    assert re.match("DaskCluster .+ created", runner.stdout)
+    assert re.match("Scheduler pod .+ created", runner.stdout)
+    assert re.match("Worker group .+ created", runner.stdout)
 
 
 @pytest.mark.asyncio

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -162,9 +162,9 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             assert "WORKER_ENV" in worker_env
             assert cluster_name
 
-    assert re.match("DaskCluster .+ created", runner.stdout)
-    assert re.match("Scheduler pod .+ created", runner.stdout)
-    assert re.match("Worker group .+ created", runner.stdout)
+    assert re.match(".*DaskCluster .+ created.*", runner.stdout)
+    assert re.match(".*Scheduler pod .+ created.*", runner.stdout)
+    assert re.match(".*Worker group .+ created.*", runner.stdout)
 
 
 @pytest.mark.asyncio

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -3,7 +3,6 @@ import pytest
 import asyncio
 from contextlib import asynccontextmanager
 import pathlib
-import re
 
 import os.path
 
@@ -161,10 +160,6 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             # Just check if its in the string, no need to parse the json
             assert "WORKER_ENV" in worker_env
             assert cluster_name
-
-    assert re.match(".*DaskCluster .+ created.*", runner.stdout)
-    assert re.match(".*Scheduler pod .+ created.*", runner.stdout)
-    assert re.match(".*Worker group .+ created.*", runner.stdout)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes  #490.

I've added a `status.phase` property to the `DaskCluster` resource and implemented two statuses `Created` and `Running`.

I've updated the controller so that the creation event on `DaskCluster` resources just sets the phase to `Created`. I've then created another hook that watches for that phase being set which then creates the downstream resources, once they have been created the phase is updated to `Running`.

Then the `experimental.KubeCluster` now has a `_wait_for_operator` method that watches for this `status.phase` property. If this doesn't get set after 60 seconds (configurable) the cluster creation will time out because the operator controller is likely not running or in a failed state. This is great because currently, the class will just hang if the controller isn't running.