### PR TITLE
Enable passing custom specs

### DIFF
--- a/dask_kubernetes/experimental/__init__.py
+++ b/dask_kubernetes/experimental/__init__.py
@@ -1,1 +1,6 @@
-from .kubecluster import KubeCluster
+from .kubecluster import (
+    KubeCluster,
+    make_cluster_spec,
+    make_scheduler_spec,
+    make_worker_spec,
+)

--- a/dask_kubernetes/experimental/kubecluster.py
+++ b/dask_kubernetes/experimental/kubecluster.py
@@ -236,12 +236,12 @@ class KubeCluster(Cluster):
                 await self._close()
                 raise e
             await wait_for_scheduler(self.name, self.namespace)
-            await wait_for_service(core_api, self.name, self.namespace)
+            await wait_for_service(core_api, f"{self.name}-scheduler", self.namespace)
             scheduler_address = await self._get_scheduler_address()
             await wait_for_scheduler_comm(scheduler_address)
             self.scheduler_comm = rpc(scheduler_address)
             dashboard_address = await get_scheduler_address(
-                self.name,
+                f"{self.name}-scheduler",
                 self.namespace,
                 port_name="http-dashboard",
             )
@@ -292,7 +292,7 @@ class KubeCluster(Cluster):
                 return None
 
     async def _get_scheduler_address(self):
-        address = await get_scheduler_address(self.name, self.namespace)
+        address = await get_scheduler_address(f"{self.name}-scheduler", self.namespace)
         return address
 
     async def _wait_for_controller(self):

--- a/dask_kubernetes/experimental/kubecluster.py
+++ b/dask_kubernetes/experimental/kubecluster.py
@@ -264,7 +264,7 @@ class KubeCluster(Cluster):
                 self.env = container_spec["env"]
             else:
                 self.env = {}
-            service_name = cluster_spec["metadata"]["name"]
+            service_name = f"{cluster_spec['metadata']['name']}-scheduler"
             await wait_for_scheduler(self.name, self.namespace)
             await wait_for_service(core_api, service_name, self.namespace)
             scheduler_address = await self._get_scheduler_address()

--- a/dask_kubernetes/experimental/tests/test_kubecluster.py
+++ b/dask_kubernetes/experimental/tests/test_kubecluster.py
@@ -3,7 +3,7 @@ import pytest
 from dask.distributed import Client
 from distributed.utils import TimeoutError
 
-from dask_kubernetes.experimental import KubeCluster
+from dask_kubernetes.experimental import KubeCluster, make_cluster_spec
 
 
 @pytest.fixture
@@ -100,3 +100,13 @@ def test_adapt(kopf_runner, docker_image):
             # Need to clean up the DaskAutoscaler object
             # See https://github.com/dask/dask-kubernetes/issues/546
             cluster.scale(0)
+
+
+def test_custom_spec(kopf_runner, docker_image):
+    with kopf_runner:
+        spec = make_cluster_spec("customspec", image=docker_image)
+        with KubeCluster(
+            custom_cluster_spec=spec,
+        ) as cluster:
+            with Client(cluster) as client:
+                assert client.submit(lambda x: x + 1, 10).result() == 11

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -192,7 +192,7 @@ async def daskcluster_create_components(spec, name, namespace, logger, patch, **
             namespace=namespace,
             body=data,
         )
-        await wait_for_service(api, data["metadata"]["name"], namespace)
+        await wait_for_service(api, f"{data['metadata']['name']}-scheduler", namespace)
         logger.info(
             f"Scheduler service {data['metadata']['name']} created in {namespace}."
         )
@@ -352,7 +352,7 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
         if workers_needed < 0:
             worker_ids = await retire_workers(
                 n_workers=-workers_needed,
-                scheduler_service_name=spec["cluster"],
+                scheduler_service_name=f"{spec['cluster']}-scheduler",
                 worker_group_name=name,
                 namespace=namespace,
                 logger=logger,
@@ -455,7 +455,7 @@ async def daskautoscaler_adapt(spec, name, namespace, logger, **kwargs):
     # Ask the scheduler for the desired number of worker
     try:
         desired_workers = await get_desired_workers(
-            scheduler_service_name=spec["cluster"],
+            scheduler_service_name=f"{spec['cluster']}-scheduler",
             namespace=namespace,
             logger=logger,
         )

--- a/dask_kubernetes/operator/operator.py
+++ b/dask_kubernetes/operator/operator.py
@@ -49,7 +49,7 @@ def build_scheduler_service_spec(name, spec):
         "apiVersion": "v1",
         "kind": "Service",
         "metadata": {
-            "name": name,
+            "name": f"{name}-scheduler",
             "labels": {
                 "dask.org/cluster-name": name,
             },
@@ -81,7 +81,7 @@ def build_worker_pod_spec(worker_group_name, namespace, cluster_name, uuid, spec
         },
         {
             "name": "DASK_SCHEDULER_ADDRESS",
-            "value": f"tcp://{cluster_name}.{namespace}.svc.cluster.local:8786",
+            "value": f"tcp://{cluster_name}-scheduler.{namespace}.svc.cluster.local:8786",
         },
     ]
     for i in range(len(pod_spec["spec"]["containers"])):

--- a/dask_kubernetes/operator/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplecluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubernetes.dask.org/v1
 kind: DaskCluster
 metadata:
-  name: simple-cluster
+  name: simple
   namespace: default
 spec:
   worker:
@@ -51,7 +51,7 @@ spec:
     service:
       type: ClusterIP
       selector:
-        dask.org/cluster-name: simple-cluster
+        dask.org/cluster-name: simple
         dask.org/component: scheduler
       ports:
         - name: tcp-comm

--- a/dask_kubernetes/operator/tests/resources/simplejob.yaml
+++ b/dask_kubernetes/operator/tests/resources/simplejob.yaml
@@ -64,7 +64,7 @@ spec:
         service:
           type: ClusterIP
           selector:
-            dask.org/cluster-name: simple-job-cluster
+            dask.org/cluster-name: simple-job
             dask.org/component: scheduler
           ports:
             - name: tcp-comm

--- a/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/tests/resources/simpleworkergroup.yaml
@@ -1,10 +1,10 @@
 apiVersion: kubernetes.dask.org/v1
 kind: DaskWorkerGroup
 metadata:
-  name: simple-cluster-additional-worker-group
+  name: simple-additional
   namespace: default
 spec:
-  cluster: simple-cluster
+  cluster: simple
   worker:
     replicas: 2
     spec:

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -18,7 +18,7 @@ def gen_cluster(k8s_cluster):
     @asynccontextmanager
     async def cm():
         cluster_path = os.path.join(DIR, "resources", "simplecluster.yaml")
-        cluster_name = "simple-cluster"
+        cluster_name = "simple"
 
         # Create cluster resource
         k8s_cluster.kubectl("apply", "-f", cluster_path)
@@ -88,9 +88,9 @@ def test_operator_plugins(kopf_runner):
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
-            scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "simple-cluster-default-worker-group-worker"
-            service_name = "simple-cluster-service"
+            scheduler_pod_name = "simple"
+            worker_pod_name = "simple-default-worker"
+            service_name = "simple"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             while service_name not in k8s_cluster.kubectl("get", "svc"):
@@ -109,14 +109,14 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "scale",
                         "--replicas=5",
                         "daskworkergroup",
-                        "simple-cluster-default-worker-group",
+                        "simple-default",
                     )
                     await client.wait_for_workers(5)
                     k8s_cluster.kubectl(
                         "scale",
                         "--replicas=3",
                         "daskworkergroup",
-                        "simple-cluster-default-worker-group",
+                        "simple-default",
                     )
                     await client.wait_for_workers(3)
 
@@ -126,9 +126,9 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
-            scheduler_pod_name = "simple-cluster-scheduler"
-            worker_pod_name = "simple-cluster-default-worker-group-worker"
-            service_name = "simple-cluster-service"
+            scheduler_pod_name = "simple"
+            worker_pod_name = "simple-default-worker"
+            service_name = "simple"
 
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
@@ -177,15 +177,14 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
         async with gen_job() as job:
             assert job
 
-            cluster_name = f"{job}-cluster"
             runner_name = f"{job}-runner"
 
             # Assert that cluster is created
-            while cluster_name not in k8s_cluster.kubectl("get", "daskclusters"):
+            while job not in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
 
             # Assert job pod is created
-            while runner_name not in k8s_cluster.kubectl("get", "po"):
+            while job not in k8s_cluster.kubectl("get", "po"):
                 await asyncio.sleep(0.1)
 
             # Assert job pod runs to completion (will fail if doesn't connect to cluster)
@@ -193,7 +192,7 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
                 await asyncio.sleep(0.1)
 
             # Assert cluster is removed on completion
-            while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
+            while job in k8s_cluster.kubectl("get", "daskclusters"):
                 await asyncio.sleep(0.1)
 
     assert "A DaskJob has been created" in runner.stdout

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -88,9 +88,9 @@ def test_operator_plugins(kopf_runner):
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
-            scheduler_pod_name = "simple"
+            scheduler_pod_name = "simple-scheduler"
             worker_pod_name = "simple-default-worker"
-            service_name = "simple"
+            service_name = "simple-scheduler"
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)
             while service_name not in k8s_cluster.kubectl("get", "svc"):

--- a/dask_kubernetes/operator/tests/test_operator.py
+++ b/dask_kubernetes/operator/tests/test_operator.py
@@ -126,9 +126,9 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as cluster_name:
-            scheduler_pod_name = "simple"
+            scheduler_pod_name = "simple-scheduler"
             worker_pod_name = "simple-default-worker"
-            service_name = "simple"
+            service_name = "simple-scheduler"
 
             while scheduler_pod_name not in k8s_cluster.kubectl("get", "pods"):
                 await asyncio.sleep(0.1)

--- a/doc/source/operator_kubecluster.rst
+++ b/doc/source/operator_kubecluster.rst
@@ -92,7 +92,7 @@ Custom cluster spec
 -------------------
 
 The ``KubeCluster`` class can take a selection of keyword arguments to make it quick and easy to get started, however the underlying :doc:`DaskCluster <operator_resources>` resource can be much more complex and configured in many ways.
-Rather than exposing every posibility via keyword arguments instead you can pass a valid ``DaskCluster`` resource spec which will be used when creating the cluster.
+Rather than exposing every possibility via keyword arguments instead you can pass a valid ``DaskCluster`` resource spec which will be used when creating the cluster.
 You can also generate a spec with :func:`make_cluster_spec` which ``KubeCluster`` uses internally and then modify it with your custom options.
 
 
@@ -129,7 +129,7 @@ The ``cluster.add_worker_group()`` method also supports passing a ``custom_spec`
 
    cluster = KubeCluster(name="example")
 
-   worker_spec = make_worker_spec(cluster_name=cluster.name, n_workers=2, resources={"limits"{"nvidia.com/gpu": 1}})
+   worker_spec = make_worker_spec(cluster_name=cluster.name, n_workers=2, resources={"limits": {"nvidia.com/gpu": 1}})
    worker_spec["spec"]["nodeSelector"] = {"cloud.google.com/gke-nodepool": "gpu-node-pool"}
 
    cluster.add_worker_group(custom_spec=worker_spec)

--- a/doc/source/operator_resources.rst
+++ b/doc/source/operator_resources.rst
@@ -54,7 +54,7 @@ Let's create an example called ``cluster.yaml`` with the following configuration
     apiVersion: kubernetes.dask.org/v1
     kind: DaskCluster
     metadata:
-      name: simple-cluster
+      name: simple
     spec:
       worker:
         replicas: 2
@@ -97,7 +97,7 @@ Let's create an example called ``cluster.yaml`` with the following configuration
         service:
           type: NodePort
           selector:
-            dask.org/cluster-name: simple-cluster
+            dask.org/cluster-name: simple
             dask.org/component: scheduler
           ports:
           - name: tcp-comm
@@ -114,7 +114,7 @@ Editing this file will change the default configuration of you Dask cluster. See
 .. code-block:: console
 
    $ kubectl apply -f cluster.yaml
-   daskcluster.kubernetes.dask.org/simple-cluster created
+   daskcluster.kubernetes.dask.org/simple created
 
 We can list our clusters:
 
@@ -122,15 +122,15 @@ We can list our clusters:
 
    $ kubectl get daskclusters
    NAME             AGE
-   simple-cluster   47s
+   simple   47s
 
 To connect to this Dask cluster we can use the service that was created for us.
 
 .. code-block:: console
 
-   $ kubectl get svc -l dask.org/cluster-name=simple-cluster
+   $ kubectl get svc -l dask.org/cluster-name=simple
    NAME                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
-   simple-cluster-service   ClusterIP   10.96.85.120   <none>        8786/TCP,8787/TCP   86s
+   simple                   ClusterIP   10.96.85.120   <none>        8786/TCP,8787/TCP   86s
 
 We can see here that port ``8786`` has been exposed for the Dask communication along with ``8787`` for the Dashboard.
 
@@ -139,7 +139,7 @@ For this quick example we could use ``kubectl`` to port forward the service to y
 
 .. code-block:: console
 
-   $ kubectl port-forward svc/simple-cluster-service 8786:8786
+   $ kubectl port-forward svc/simple 8786:8786
    Forwarding from 127.0.0.1:8786 -> 8786
    Forwarding from [::1]:8786 -> 8786
 
@@ -156,12 +156,12 @@ We can also list all of the pods created by the operator to run our cluster.
 
 .. code-block:: console
 
-   $ kubectl get po -l dask.org/cluster-name=simple-cluster
+   $ kubectl get po -l dask.org/cluster-name=simple
    NAME                                                                          READY   STATUS    RESTARTS   AGE
-   simple-cluster-default-worker-group-worker-13f4f0d13bbc40a58cfb81eb374f26c3   1/1     Running   0          104s
-   simple-cluster-default-worker-group-worker-aa79dfae83264321a79f1f0ffe91f700   1/1     Running   0          104s
-   simple-cluster-default-worker-group-worker-f13c4f2103e14c2d86c1b272cd138fe6   1/1     Running   0          104s
-   simple-cluster-scheduler                                                      1/1     Running   0          104s
+   simple-default-worker-13f4f0d13bbc40a58cfb81eb374f26c3                        1/1     Running   0          104s
+   simple-default-worker-aa79dfae83264321a79f1f0ffe91f700                        1/1     Running   0          104s
+   simple-default-worker-f13c4f2103e14c2d86c1b272cd138fe6                        1/1     Running   0          104s
+   simple-scheduler                                                              1/1     Running   0          104s
 
 The workers we see here are created by our clusters default ``workergroup`` resource that was also created by the operator.
 
@@ -169,31 +169,31 @@ You can scale the ``workergroup`` like you would a ``Deployment`` or ``ReplicaSe
 
 .. code-block:: console
 
-   $ kubectl scale --replicas=5 daskworkergroup simple-cluster-default-worker-group
-   daskworkergroup.kubernetes.dask.org/simple-cluster-default-worker-group scaled
+   $ kubectl scale --replicas=5 daskworkergroup simple-default
+   daskworkergroup.kubernetes.dask.org/simple-default
 
 We can verify that new pods have been created.
 
 .. code-block:: console
 
-   $ kubectl get po -l dask.org/cluster-name=simple-cluster
+   $ kubectl get po -l dask.org/cluster-name=simple
    NAME                                                                          READY   STATUS    RESTARTS   AGE
-   simple-cluster-default-worker-group-worker-13f4f0d13bbc40a58cfb81eb374f26c3   1/1     Running   0          5m26s
-   simple-cluster-default-worker-group-worker-a52bf313590f432d9dc7395875583b52   1/1     Running   0          27s
-   simple-cluster-default-worker-group-worker-aa79dfae83264321a79f1f0ffe91f700   1/1     Running   0          5m26s
-   simple-cluster-default-worker-group-worker-f13c4f2103e14c2d86c1b272cd138fe6   1/1     Running   0          5m26s
-   simple-cluster-default-worker-group-worker-f4223a45b49d49288195c540c32f0fc0   1/1     Running   0          27s
-   simple-cluster-scheduler                                                      1/1     Running   0          5m26s
+   simple-default-worker-13f4f0d13bbc40a58cfb81eb374f26c3                        1/1     Running   0          5m26s
+   simple-default-worker-a52bf313590f432d9dc7395875583b52                        1/1     Running   0          27s
+   simple-default-worker-aa79dfae83264321a79f1f0ffe91f700                        1/1     Running   0          5m26s
+   simple-default-worker-f13c4f2103e14c2d86c1b272cd138fe6                        1/1     Running   0          5m26s
+   simple-default-worker-f4223a45b49d49288195c540c32f0fc0                        1/1     Running   0          27s
+   simple-scheduler                                                              1/1     Running   0          5m26s
 
 Finally we can delete the cluster either by deleting the manifest we applied before, or directly by name:
 
 .. code-block:: console
 
    $ kubectl delete -f cluster.yaml
-   daskcluster.kubernetes.dask.org "simple-cluster" deleted
+   daskcluster.kubernetes.dask.org "simple" deleted
 
-   $ kubectl delete daskcluster simple-cluster
-   daskcluster.kubernetes.dask.org "simple-cluster" deleted
+   $ kubectl delete daskcluster simple
+   daskcluster.kubernetes.dask.org "simple" deleted
 
 DaskWorkerGroup
 ---------------
@@ -246,9 +246,9 @@ Let's create an example called ``highmemworkers.yaml`` with the following config
     apiVersion: kubernetes.dask.org/v1
     kind: DaskWorkerGroup
     metadata:
-      name: simple-cluster-highmem-worker-group
+      name: simple-highmem
     spec:
-      cluster: simple-cluster
+      cluster: simple
       worker:
         replicas: 2
         spec:
@@ -276,16 +276,16 @@ See the :ref:`config`. Now apply ``highmemworkers.yaml``
 .. code-block:: console
 
    $ kubectl apply -f highmemworkers.yaml
-   daskworkergroup.kubernetes.dask.org/simple-cluster-highmem-worker-group created
+   daskworkergroup.kubernetes.dask.org/simple-highmem created
 
 We can list our clusters:
 
 .. code-block:: console
 
    $ kubectl get daskworkergroups
-   NAME                                  AGE
-   simple-cluster-default-worker-group   2 hours
-   simple-cluster-highmem-worker-group   47s
+   NAME                 AGE
+   simple-default       2 hours
+   simple-highmem       47s
 
 We don't need to worry about deleting this worker group seperately, because it has joined the existing cluster Kubernetes will delete it
 when the ``DaskCluster`` resource is deleted.
@@ -407,7 +407,7 @@ Let's create an example called ``job.yaml`` with the following configuration:
             service:
               type: ClusterIP
               selector:
-                dask.org/cluster-name: simple-job-cluster
+                dask.org/cluster-name: simple-job
                 dask.org/component: scheduler
               ports:
                 - name: tcp-comm
@@ -433,10 +433,10 @@ Now if we check our cluster resources we should see our job and cluster pods bei
 
     $ kubectl get pods
     NAME                                                        READY   STATUS              RESTARTS   AGE
-    simple-job-cluster-scheduler                                1/1     Running             0          8s
+    simple-job-scheduler                                        1/1     Running             0          8s
     simple-job-runner                                           1/1     Running             0          8s
-    simple-job-cluster-default-worker-group-worker-1f6c670fba   1/1     Running             0          8s
-    simple-job-cluster-default-worker-group-worker-791f93d9ec   1/1     Running             0          8s
+    simple-job-default-worker-1f6c670fba                        1/1     Running             0          8s
+    simple-job-default-worker-791f93d9ec                        1/1     Running             0          8s
 
 Our runner pod will be doing whatever we configured it to do. In our example you can see we just create a simple ``dask.distributed.Client`` object like this:
 
@@ -461,9 +461,9 @@ go into a ``Completed`` state and the Dask cluster will be cleaned up automatica
     $ kubectl get pods
     NAME                                                        READY   STATUS              RESTARTS   AGE
     simple-job-runner                                           0/1     Completed           0          14s
-    simple-job-cluster-scheduler                                1/1     Terminating         0          14s
-    simple-job-cluster-default-worker-group-worker-1f6c670fba   1/1     Terminating         0          14s
-    simple-job-cluster-default-worker-group-worker-791f93d9ec   1/1     Terminating         0          14s
+    simple-job-scheduler                                        1/1     Terminating         0          14s
+    simple-job-default-worker-1f6c670fba                        1/1     Terminating         0          14s
+    simple-job-default-worker-791f93d9ec                        1/1     Terminating         0          14s
 
 When you delete the ``DaskJob`` resource everything is delete automatically, whether that's just the ``Completed`` runner pod left over after a successful run or a full Dask cluster and runner that is still running.
 
@@ -530,16 +530,16 @@ and then update the number of replicas in the default ``DaskWorkerGroup``.
     apiVersion: kubernetes.dask.org/v1
     kind: DaskAutoscaler
     metadata:
-      name: simple-cluster-autoscaler
+      name: simple
     spec:
-      cluster: "simple-cluster"
+      cluster: "simple"
       minimum: 1  # we recommend always having a minimum of 1 worker so that an idle cluster can start working on tasks immediately
       maximum: 10 # you can place a hard limit on the number of workers regardless of what the scheduler requests
 
 .. code-block:: console
 
     $ kubectl apply -f autoscaler.yaml
-    daskautoscaler.kubernetes.dask.org/simple-cluster-autoscaler created
+    daskautoscaler.kubernetes.dask.org/simple created
 
 You can end the autoscaling at any time by deleting the resource. The number of workers will remain at whatever the autoscaler last
 set it to.
@@ -547,7 +547,7 @@ set it to.
 .. code-block:: console
 
     $ kubectl delete -f autoscaler.yaml
-    daskautoscaler.kubernetes.dask.org/simple-cluster-autoscaler deleted
+    daskautoscaler.kubernetes.dask.org/simple deleted
 
 .. note::
 


### PR DESCRIPTION
Closes #475 
Closes #544 

The `KubeCluster` class can take a selection of keyword arguments to make it quick and easy to get started, however the underlying `DaskCluster` resource can be much more complex and configured in many ways.
Rather than exposing every possibility via keyword arguments instead, you can pass a valid `DaskCluster` resource spec which will be used when creating the cluster.
You can also generate a spec with `make_cluster_spec` which `KubeCluster` uses internally and then modify it with your custom options.


```python

   from dask_kubernetes.experimental import KubeCluster, make_cluster_spec

   config = {
      "name": "foo",
      "n_workers": 2,
      "resources":{"requests": {"memory": "2Gi"}, "limits": {"memory": "64Gi"}}
   }

   cluster = KubeCluster(**config)
   # is equivalent to
   cluster = KubeCluster(custom_cluster_spec=make_cluster_spec(**config))

```

You can also modify the spec before passing it to `KubeCluster`, for example if you want to set `nodeSelector` on your worker pods you could do it like this:

```python

   from dask_kubernetes.experimental import KubeCluster, make_cluster_spec

   spec = make_cluster_spec(name="selector-example", n_workers=2)
   spec["spec"]["worker"]["spec"]["nodeSelector"] = {"disktype": "ssd"}

   cluster = KubeCluster(custom_cluster_spec=spec)

```

The `cluster.add_worker_group()` method also supports passing a `custom_spec` keyword argument which can be generated with `make_worker_spec`.

```python

   from dask_kubernetes.experimental import KubeCluster, make_worker_spec

   cluster = KubeCluster(name="example")

   worker_spec = make_worker_spec(cluster_name=cluster.name, n_workers=2, resources={"limits"{"nvidia.com/gpu": 1}})
   worker_spec["spec"]["nodeSelector"] = {"cloud.google.com/gke-nodepool": "gpu-node-pool"}

   cluster.add_worker_group(custom_spec=worker_spec)
```

I also took this opportunity to remove the type suffixes mentioned in #544 because they were confusing me while writing this.