### PR TITLE
Workaround for k8s-crd-resolver dependency issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: check-crd-updates
         name: check-crd-updates
-        entry: ci/pre-commit-crd.py v0.10.0
+        entry: ci/pre-commit-crd.py pin-openapi-spec-validator
         language: script
         types: [yaml]
         pass_filenames: true

--- a/ci/pre-commit-crd.py
+++ b/ci/pre-commit-crd.py
@@ -15,7 +15,7 @@ def install_deps(version):
             [
                 "pip",
                 "install",
-                f"git+http://github.com/elemental-lf/k8s-crd-resolver@{version}",
+                f"git+https://github.com/jacobtomlinson/k8s-crd-resolver.git@{version}",
             ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,7 @@ pytest-asyncio>=0.17
 git+https://codeberg.org/hjacobs/pytest-kind.git
 pytest-timeout
 pytest-rerunfailures
-git+http://github.com/elemental-lf/k8s-crd-resolver
+# Workarund for https://github.com/elemental-lf/k8s-crd-resolver/issues/1
+git+https://github.com/jacobtomlinson/k8s-crd-resolver.git@pin-openapi-spec-validator
+# git+http://github.com/elemental-lf/k8s-crd-resolver@v0.10.0
 dask[complete]


### PR DESCRIPTION
We use `k8s-crd-resolver` during the build process to generate k8s CRDs from templates. This happens in CI and also via `pre-commit` to keep the generated files in version control.

It looks like there is a dependency conflict where `k8s-crd-resolver` depends on `prance` which in turn depends on `openapi-spec-validator`. However, the `0.5.0` release of `openapi-spec-validator` has broken `prance`.

To resolve this in the short term I've forked `k8s-crd-resolver` and pinned the version of `openapi-spec-validator` to `<0.5.0`. xref https://github.com/elemental-lf/k8s-crd-resolver/pull/2

This PR switches `dask-kubernetes` to use my fork of `k8s-crd-resolver` for now. Once a new release of `prance` is available this can be reverted.