### PR TITLE
Test against multiple k8s versions

### DIFF
--- a/.github/workflows/helmcluster.yaml
+++ b/.github/workflows/helmcluster.yaml
@@ -2,12 +2,14 @@ name: "HelmCluster"
 on:
   pull_request:
     paths:
+      - ".github/workflows/helmcluster.yaml"
       - "ci/**"
       - "dask_kubernetes/helm/**"
       - "dask_kubernetes/common/**"
       - "dask_kubernetes/*"
   push:
     paths:
+      - ".github/workflows/helmcluster.yaml"
       - "ci/**"
       - "dask_kubernetes/helm/**"
       - "dask_kubernetes/common/**"
@@ -21,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
+        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
@@ -33,6 +36,8 @@ jobs:
       - name: Install deps
         run: ./ci/install-deps.sh
       - name: Run tests
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
         run: pytest dask_kubernetes/common/tests dask_kubernetes/helm/tests
       - name: Debug k8s resources
         if: success() || failure()

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -2,12 +2,14 @@ name: "KubeCluster"
 on:
   pull_request:
     paths:
+      - ".github/workflows/kubecluster.yaml"
       - "ci/**"
       - "dask_kubernetes/classic/**"
       - "dask_kubernetes/common/**"
       - "dask_kubernetes/*"
   push:
     paths:
+      - ".github/workflows/kubecluster.yaml"
       - "ci/**"
       - "dask_kubernetes/classic/**"
       - "dask_kubernetes/common/**"
@@ -21,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
+        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
@@ -33,6 +36,8 @@ jobs:
       - name: Install deps
         run: ./ci/install-deps.sh
       - name: Run tests
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
         run: pytest dask_kubernetes/common/tests dask_kubernetes/classic/tests
       - name: Debug k8s resources
         if: success() || failure()

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
+        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig
@@ -36,6 +37,7 @@ jobs:
         run: ./ci/install-deps.sh
       - name: Run tests
         env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
           TEST_ISTIO: "true"
         run: pytest dask_kubernetes/common/tests dask_kubernetes/operator/tests dask_kubernetes/experimental/tests
       - name: Debug k8s resources

--- a/README.rst
+++ b/README.rst
@@ -21,5 +21,13 @@ Dask Kubernetes
    :target: https://anaconda.org/conda-forge/dask-kubernetes
    :alt: Conda Forge
 
+.. image:: https://img.shields.io/badge/python%20support-3.8%7C3.9%7C3.10-blue
+   :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
+   :alt: Python Support
+
+.. image:: https://img.shields.io/badge/Kubernetes%20support-1.22%7C1.23%7C1.24-blue
+   :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
+   :alt: Kubernetes Support
+
 
 Native Kubernetes integration for Dask.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,23 @@
 Dask Kubernetes
 ===============
 
+.. image:: https://img.shields.io/pypi/v/dask-kubernetes
+   :target: https://pypi.org/project/dask-kubernetes/
+   :alt: PyPI
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/dask-kubernetes
+   :target: https://anaconda.org/conda-forge/dask-kubernetes
+   :alt: Conda Forge
+
+.. image:: https://img.shields.io/badge/python%20support-3.8%7C3.9%7C3.10-blue
+   :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
+   :alt: Python Support
+
+.. image:: https://img.shields.io/badge/Kubernetes%20support-1.22%7C1.23%7C1.24-blue
+   :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
+   :alt: Kubernetes Support
+
+
 .. currentmodule:: dask_kubernetes
 
 Welcome to the documentation for ``dask-kubernetes``.

--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -45,3 +45,23 @@ or use ``pip`` locally if you want to install all dependencies as well::
 You can also install directly from git main branch::
 
     pip install git+https://github.com/dask/dask-kubernetes
+
+Supported Versions
+------------------
+
+Python
+^^^^^^
+
+All Dask projects generally follow the `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_ deprecation policy for Python where each Python minor version is support ed for 42 months.
+Due to Python's 12 month release cycle this ensures at least the current version and two previous versions are supported.
+
+The Dask Kubernetes CI tests all PRs against all supported Python versions.
+
+Kubernetes
+^^^^^^^^^^
+
+For Kubernetes we support all Kubernetes versions that are `supported by the Kubernetes maintainers <https://kubernetes.io/releases/>`_.
+Typically this means each Kubernetes version is supported for 12 months.
+Due to the 4-6 month release cycle this also ensures that at least the current and two previous versions are supported.
+
+Due to the time it would take to test against all Kubernetes versions only the latest supported version is tested for PRs and all other versions are tested nightly.


### PR DESCRIPTION
For a long time we've tested against the latest version of Kubernetes that `kind` uses by default. With the recent `1.25` release there seem to be some breakages, but fixing those could cause problems with older Kubernetes versions.

We don't pin this currently so CI failures started with the latest `kind` release which was outside of our control.

To make things clearer and easier to test I've explicitly set which Kubernetes version to test against and updated the CI matrix to also test against all supported Kubernetes versions and added a section to the docs to describe which versions we support.

The proposed support is for Python we follow [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) along with the rest of Dask and for Kubernetes we will follow the [yearly support KEP](https://kubernetes.io/releases/patch-releases/#support-period).