### PR TITLE
Add Kubernetes v1.25 support

### DIFF
--- a/.github/workflows/helmcluster.yaml
+++ b/.github/workflows/helmcluster.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4"]
+        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4"]
+        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4"]
+        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Dask Kubernetes
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Python Support
 
-.. image:: https://img.shields.io/badge/Kubernetes%20support-1.22%7C1.23%7C1.24-blue
+.. image:: https://img.shields.io/badge/Kubernetes%20support-1.22%7C1.23%7C1.24%7C1.25-blue
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Kubernetes Support
 

--- a/dask_kubernetes/classic/kubecluster.py
+++ b/dask_kubernetes/classic/kubecluster.py
@@ -582,7 +582,7 @@ class KubeCluster(SpecCluster):
         await ClusterAuth.load_first(self.auth)
 
         self.core_api = kubernetes.client.CoreV1Api()
-        self.policy_api = kubernetes.client.PolicyV1beta1Api()
+        self.policy_api = kubernetes.client.PolicyV1Api()
 
         if self.namespace is None:
             self.namespace = get_current_namespace()

--- a/dask_kubernetes/common/objects.py
+++ b/dask_kubernetes/common/objects.py
@@ -238,9 +238,7 @@ def make_service_from_dict(dict_):
 
 
 def make_pdb_from_dict(dict_):
-    return SERIALIZATION_API_CLIENT.deserialize(
-        dict_, client.V1beta1PodDisruptionBudget
-    )
+    return SERIALIZATION_API_CLIENT.deserialize(dict_, client.V1PodDisruptionBudget)
 
 
 def clean_pod_template(

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -40,7 +40,7 @@ kubernetes:
           targetPort: 8787
 
   scheduler-pdb-template:
-    apiVersion: policy/v1beta1
+    apiVersion: policy/v1
     kind: PodDisruptionBudget
     spec:
       minAvailable: 1

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Dask Kubernetes
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Python Support
 
-.. image:: https://img.shields.io/badge/Kubernetes%20support-1.22%7C1.23%7C1.24-blue
+.. image:: https://img.shields.io/badge/Kubernetes%20support-1.22%7C1.23%7C1.24%7C1.25-blue
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Kubernetes Support
 


### PR DESCRIPTION
- Updated CI to test against Kubernetes v1.25
- Updated README and docs badges
- `PodDisruptionBudget` no longer available in beta namespace with v1.25