### PR TITLE
Try running tests in parallel

### DIFF
--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Run tests
         env:
           KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
-        run: pytest dask_kubernetes/common/tests dask_kubernetes/classic/tests
+        run: pytest -n 2 dask_kubernetes/common/tests dask_kubernetes/classic/tests
       - name: Debug k8s resources
         if: success() || failure()
         run: kubectl get all -A

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -38,7 +38,9 @@ jobs:
       - name: Run tests
         env:
           KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
-        run: pytest -n 2 dask_kubernetes/common/tests dask_kubernetes/classic/tests
+        run: |
+          pytest dask_kubernetes/common/tests/test_kind.py && \
+          pytest -n 2 dask_kubernetes/common/tests dask_kubernetes/classic/tests
       - name: Debug k8s resources
         if: success() || failure()
         run: kubectl get all -A

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,7 @@ pytest-asyncio>=0.17
 git+https://codeberg.org/hjacobs/pytest-kind.git
 pytest-timeout
 pytest-rerunfailures
+pytest-xdist
 # Workarund for https://github.com/elemental-lf/k8s-crd-resolver/issues/1
 git+https://github.com/jacobtomlinson/k8s-crd-resolver.git@pin-openapi-spec-validator
 # git+http://github.com/elemental-lf/k8s-crd-resolver@v0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tag_prefix =
 parentdir_prefix = dask-kubernetes-
 
 [tool:pytest]
-addopts = -v --keep-cluster --durations=10 -n 2
+addopts = -v --keep-cluster --durations=10
 timeout = 300
 reruns = 5
 asyncio_mode = strict

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tag_prefix =
 parentdir_prefix = dask-kubernetes-
 
 [tool:pytest]
-addopts = -v --keep-cluster --durations=10
+addopts = -v --keep-cluster --durations=10 -n 2
 timeout = 300
 reruns = 5
 asyncio_mode = strict


### PR DESCRIPTION
The CI is taking nearly 30 minutes at the moment, experimenting with running tests in parallel to bring that time down.

Initial timings:

| Suite | Time (approx) |
| --- | --- |
| `HelmCluster` | 5 mins |
| `KubeCluster` (classic) | 28 mins |
| `KubeCluster` (operator) | 21 mins |