### PR TITLE
Only test older k8s versions agianst latest Python

### DIFF
--- a/.github/workflows/helmcluster.yaml
+++ b/.github/workflows/helmcluster.yaml
@@ -23,7 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
+        kubernetes-version: ["1.25.0"]
+        include:
+        - python-version: "3.10"
+          kubernetes-version: "1.22.13"
+        - python-version: "3.10"
+          kubernetes-version: "1.23.10"
+        - python-version: "3.10"
+          kubernetes-version: "1.24.4"
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -23,7 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
+        kubernetes-version: ["1.25.0"]
+        include:
+        - python-version: "3.10"
+          kubernetes-version: "1.22.13"
+        - python-version: "3.10"
+          kubernetes-version: "1.23.10"
+        - python-version: "3.10"
+          kubernetes-version: "1.24.4"
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -25,7 +25,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        kubernetes-version: ["1.22.13", "1.23.10", "1.24.4", "1.25.0"]
+        kubernetes-version: ["1.25.0"]
+        include:
+        - python-version: "3.10"
+          kubernetes-version: "1.22.13"
+        - python-version: "3.10"
+          kubernetes-version: "1.23.10"
+        - python-version: "3.10"
+          kubernetes-version: "1.24.4"
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig


### PR DESCRIPTION
Follow up to #556. Reduces the test matrix to something a little more manageable.

- Stop testing **all** supported Python versions against **all** supported Kubernetes versions
- Test **all** supported Python versions against **latest** Kubernetes
- Test **all** supported Kubernetes versions against **latest** Python

Reduces the number of jobs from `p * k` to `p + k - 1`.

<img width="467" alt="image" src="https://user-images.githubusercontent.com/1610850/189919621-19a0eb7d-e2a0-42cc-a45b-e2c4f1a3f2d2.png">
