### PR TITLE
Fix potential typo in kubecluster.py

### DIFF
--- a/dask_kubernetes/classic/kubecluster.py
+++ b/dask_kubernetes/classic/kubecluster.py
@@ -97,7 +97,7 @@ class Pod(ProcessInterface):
             except ApiException as e:
                 if e.reason == "Not Found":
                     logger.debug(
-                        "Pod %s in namespace %s has been deleated already.",
+                        "Pod %s in namespace %s has been deleted already.",
                         name,
                         namespace,
                     )


### PR DESCRIPTION
Based on contexts, it should be "deleted" instead of "deleated"