### PR TITLE
Remove uneccessary cluster key

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -476,7 +476,6 @@ class KubeCluster(Cluster):
             spec = custom_spec
         else:
             spec = make_worker_spec(
-                cluster_name=self.name,
                 env=env or self.env,
                 resources=resources or self.resources,
                 worker_command=worker_command or self.worker_command,

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -483,6 +483,7 @@ class KubeCluster(Cluster):
                 n_workers=n_workers or self.n_workers,
                 image=image or self.image,
             )
+            spec["cluster"] = self.name
         data = {
             "apiVersion": "kubernetes.dask.org/v1",
             "kind": "DaskWorkerGroup",
@@ -706,7 +707,6 @@ def make_cluster_spec(
         "metadata": {"name": name},
         "spec": {
             "worker": make_worker_spec(
-                cluster_name=name,
                 env=env,
                 resources=resources,
                 worker_command=worker_command,
@@ -725,7 +725,6 @@ def make_cluster_spec(
 
 
 def make_worker_spec(
-    cluster_name,
     image="ghcr.io/dask/dask:latest",
     n_workers=3,
     resources=None,
@@ -744,7 +743,6 @@ def make_worker_spec(
     args = worker_command + ["--name", "$(DASK_WORKER_NAME)"]
 
     return {
-        "cluster": cluster_name,
         "replicas": n_workers,
         "spec": {
             "containers": [


### PR DESCRIPTION
The `DaskCluster` doesn't need the `cluster` key to be set in the worker spec. Only the `DaskWorkerGroup` needs that.

By including it the spec generated by `make_cluster_spec` actually fails validation with kubectl.

```console
$ python -c "import yaml; from dask_kubernetes.operator import make_cluster_spec; print(yaml.dump(make_cluster_spec(name='test')))" | kubectl apply -f -        
error: error validating "STDIN": error validating data: ValidationError(DaskCluster.spec.worker): unknown field "cluster" in org.dask.kubernetes.v1.DaskCluster.spec.worker; if you choose to ignore these errors, turn validation off with --validate=false
```

Removing it from `make_worker_spec` and explicitly adding it in the `add_worker_group` call.