### PR TITLE
Pass on annotations from dask custom resources

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -15,10 +15,10 @@ from dask_kubernetes.common.networking import (
     get_scheduler_address,
 )
 
-_DEFAULT_ANNOTATIONS = [
-    "kopf.zalando.org/last-handled-configuration",
-    "kubectl.kubernetes.io/last-applied-configuration",
-]
+_ANNOTATION_NAMESPACES_TO_IGNORE = (
+    "kopf.zalando.org",
+    "kubectl.kubernetes.io",
+)
 
 # Load operator plugins from other packages
 PLUGINS = []
@@ -37,7 +37,10 @@ def _get_dask_cluster_annotations(meta):
     return {
         annotation_key: annotation_value
         for annotation_key, annotation_value in meta.annotations.items()
-        if annotation_key not in _DEFAULT_ANNOTATIONS
+        if not any(
+            annotation_key.startswith(namespace)
+            for namespace in _ANNOTATION_NAMESPACES_TO_IGNORE
+        )
     }
 
 

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -61,7 +61,7 @@ def build_scheduler_pod_spec(cluster_name, spec, annotations):
     }
 
 
-def build_scheduler_service_spec(cluster_name, spec):
+def build_scheduler_service_spec(cluster_name, spec, annotations):
     return {
         "apiVersion": "v1",
         "kind": "Service",
@@ -70,6 +70,7 @@ def build_scheduler_service_spec(cluster_name, spec):
             "labels": {
                 "dask.org/cluster-name": cluster_name,
             },
+            "annotations": annotations,
         },
         "spec": spec,
     }
@@ -220,7 +221,9 @@ async def daskcluster_create_components(spec, name, namespace, logger, patch, **
         logger.info(f"Scheduler pod {data['metadata']['name']} created in {namespace}.")
 
         # TODO Check for existing scheduler service
-        data = build_scheduler_service_spec(name, scheduler_spec.get("service"))
+        data = build_scheduler_service_spec(
+            name, scheduler_spec.get("service"), annotations
+        )
         kopf.adopt(data)
         await api.create_namespaced_service(
             namespace=namespace,

--- a/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
@@ -3,6 +3,8 @@ kind: DaskCluster
 metadata:
   name: simple
   namespace: default
+  annotations:
+    test-annotation: "annotation-value"
 spec:
   worker:
     replicas: 2
@@ -17,7 +19,7 @@ spec:
             - $(DASK_WORKER_NAME)
           env:
             - name: WORKER_ENV
-              value: hello-world # We dont test the value, just the name
+              value: hello-world # We don't test the value, just the name
   scheduler:
     spec:
       containers:

--- a/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
   annotations:
     test-annotation: "annotation-value"
+    "kopf.zalando.org/foobar": "should-not-be-propagated"
+    "kubectl.kubernetes.io": "should-not-be-propagated"
 spec:
   worker:
     replicas: 2

--- a/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
@@ -3,6 +3,8 @@ kind: DaskJob
 metadata:
   name: simple-job
   namespace: default
+  annotations:
+    test-annotation: "annotation-value"
 spec:
   job:
     spec:

--- a/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
   annotations:
     test-annotation: "annotation-value"
+    "kopf.zalando.org/foobar": "should-not-be-propagated"
+    "kubectl.kubernetes.io": "should-not-be-propagated"
 spec:
   job:
     spec:

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -175,6 +175,18 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             )  # First and last char is a quote
             assert scheduler_annotations == _EXPECTED_ANNOTATIONS
 
+            # Get the first annotation (the only one) of the scheduler
+            service_annotations = json.loads(
+                k8s_cluster.kubectl(
+                    "get",
+                    "svc",
+                    "--selector=dask.org/cluster-name=simple",
+                    "-o",
+                    "jsonpath='{.items[0].metadata.annotations}'",
+                )[1:-1]
+            )  # First and last char is a quote
+            assert service_annotations == _EXPECTED_ANNOTATIONS
+
             # Get the first env value (the only one) of the first worker
             worker_env = k8s_cluster.kubectl(
                 "get",

--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -61,6 +61,10 @@ Worker Groups
 A ``DaskWorkerGroup`` represents a homogenous group of workers that can be scaled. The resource is similar to a native Kubernetes ``Deployment`` in that it manages a group of workers
 with some intelligence around the ``Pod`` lifecycle. A worker group must be attached to a Dask Cluster resource in order to function.
 
+All `Kubernetes annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>` on the
+``DaskWorkerGroup`` resource will be passed onto worker ``Pod`` resources.
+
+
 Clusters
 ^^^^^^^^
 
@@ -72,12 +76,20 @@ The operator also has support for creating additional worker groups. These are e
 configuration settings and can be scaled separately. You can then use `resource annotations <https://distributed.dask.org/en/stable/resources.html>`_
 to schedule different tasks to different groups.
 
+All `Kubernetes annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>` on the
+``DaskCluster`` resource will be passed onto the scheduler ``Pod`` as well the ``DaskWorkerGroup`` resources.
+
 For example you may wish to have a smaller pool of workers that have more memory for memory intensive tasks, or GPUs for compute intensive tasks.
 
 Jobs
 ^^^^
 
 A ``DaskJob`` is a batch style resource that creates a ``Pod`` to perform some specific task from start to finish alongside a ``DaskCluster`` that can be leveraged to perform the work.
+
+All `Kubernetes annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>` on the
+``DaskJob`` resource will be passed on to the job-runner ``Pod`` resource. If one also wants to set Kubernetes
+annotations on the cluster-related resources (scheduler and worker ``Pods``), these can be set as
+``spec.cluster.metadata`` in the ``DaskJob`` resource.
 
 Once the job ``Pod`` runs to completion the cluster is removed automatically to save resources. This is great for workflows like training a distributed machine learning model with Dask.
 

--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -78,9 +78,9 @@ configuration settings and can be scaled separately. You can then use `resource 
 to schedule different tasks to different groups.
 
 All `Kubernetes annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>` on the
-``DaskCluster`` resource will be passed onto the scheduler ``Pod`` as well the ``DaskWorkerGroup`` resources.
-Annotations created by `kopf` or `kubectl` (i.e. starting with "kopf.zalando.org" or "kubectl.kubernetes.io") will not
-be passed on.
+``DaskCluster`` resource will be passed onto the scheduler ``Pod`` and ``Service`` as well the ``DaskWorkerGroup``
+resources. Annotations created by `kopf` or `kubectl` (i.e. starting with "kopf.zalando.org" or "kubectl.kubernetes.io")
+will not be passed on.
 
 For example you may wish to have a smaller pool of workers that have more memory for memory intensive tasks, or GPUs for compute intensive tasks.
 

--- a/doc/source/operator.rst
+++ b/doc/source/operator.rst
@@ -62,7 +62,8 @@ A ``DaskWorkerGroup`` represents a homogenous group of workers that can be scale
 with some intelligence around the ``Pod`` lifecycle. A worker group must be attached to a Dask Cluster resource in order to function.
 
 All `Kubernetes annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>` on the
-``DaskWorkerGroup`` resource will be passed onto worker ``Pod`` resources.
+``DaskWorkerGroup`` resource will be passed onto worker ``Pod`` resources. Annotations created by `kopf` or
+`kubectl` (i.e. starting with "kopf.zalando.org" or "kubectl.kubernetes.io") will not be passed on.
 
 
 Clusters
@@ -78,6 +79,8 @@ to schedule different tasks to different groups.
 
 All `Kubernetes annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>` on the
 ``DaskCluster`` resource will be passed onto the scheduler ``Pod`` as well the ``DaskWorkerGroup`` resources.
+Annotations created by `kopf` or `kubectl` (i.e. starting with "kopf.zalando.org" or "kubectl.kubernetes.io") will not
+be passed on.
 
 For example you may wish to have a smaller pool of workers that have more memory for memory intensive tasks, or GPUs for compute intensive tasks.
 
@@ -89,7 +92,8 @@ A ``DaskJob`` is a batch style resource that creates a ``Pod`` to perform some s
 All `Kubernetes annotations <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>` on the
 ``DaskJob`` resource will be passed on to the job-runner ``Pod`` resource. If one also wants to set Kubernetes
 annotations on the cluster-related resources (scheduler and worker ``Pods``), these can be set as
-``spec.cluster.metadata`` in the ``DaskJob`` resource.
+``spec.cluster.metadata`` in the ``DaskJob`` resource. Annotations created by `kopf` or `kubectl` (i.e. starting with
+"kopf.zalando.org" or "kubectl.kubernetes.io") will not be passed on.
 
 Once the job ``Pod`` runs to completion the cluster is removed automatically to save resources. This is great for workflows like training a distributed machine learning model with Dask.
 


### PR DESCRIPTION
As described in https://github.com/dask/dask-kubernetes/issues/571, it would be nice if there was a possibility to add annotations to `dask`-related pods.

This PR adds this capability by: 
- Passing on all annotations set on the `DaskCluster` CR to the scheduler `Pod` as well as the `DaskWorkerGroup` CR
- Passing on all annotations set on the `DaskWorkerGroup` CR to the worker `Pod`s
- Passing on all annotation set on the `DaskJob` CR to the job-runner `Pod`

A small issue I've noticed when implementing this was that there are already some "default" `kopf` and kubernetes related annotations on resources, which I've chosen to ignore: 
-   "kopf.zalando.org/last-handled-configuration"
-   "kubectl.kubernetes.io/last-applied-configuration"


Feel free to suggest alternatives, happy to change things up


Fixes https://github.com/dask/dask-kubernetes/issues/571