### PR TITLE
Fix string escaping in kubernetes.yaml

### DIFF
--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -12,7 +12,7 @@ kubernetes:
   scheduler-service-type: "ClusterIP"
 
   # Operator KubeCluster options
-  image: ghcr.io/dask/dask:latest"
+  image: "ghcr.io/dask/dask:latest"
   resources: {}
   worker-command: "dask-worker"
   port-forward-cluster-ip: null


### PR DESCRIPTION
Looks like there's a missing `"` in the `image:` field of the Operator. This adds it :)