### PR TITLE
Add daskautoscalers in the cluster role rules

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
@@ -36,7 +36,7 @@ rules:
 
   # Application: watching & handling for the custom resource we declare.
   - apiGroups: [kubernetes.dask.org]
-    resources: [daskclusters, daskworkergroups, daskjobs]
+    resources: [daskclusters, daskworkergroups, daskjobs, daskautoscalers]
     verbs: [get, list, watch, patch, create, delete]
 
   # Application: other resources it produces and manipulates.


### PR DESCRIPTION
This PR adds the `daskautoscalers` resource in the `clusterrole` rules.
Without it, the `dask-operator` pod fail to start with the error:
```
[2022-10-12 17:46:55,501] kopf._core.reactor.o [ERROR   ] Watcher for daskautoscalers.v1.kubernetes.dask.org@none has failed: ('daskautoscalers.kubernetes.dask.org is forbidden: User "system:serviceaccount:dask:dask-kubernetes-operator" cannot list resource "daskautoscalers" in API group "kubernetes.dask.org" at the cluster scope')
```