### PR TITLE
Add missing `daskautoscalers` permission

### DIFF
--- a/dask_kubernetes/operator/deployment/manifests/operator.yaml
+++ b/dask_kubernetes/operator/deployment/manifests/operator.yaml
@@ -61,7 +61,7 @@ rules:
 
   # Application: watching & handling for the custom resource we declare.
   - apiGroups: [kubernetes.dask.org]
-    resources: [daskclusters, daskworkergroups, daskworkergroups/scale, daskjobs]
+    resources: [daskclusters, daskworkergroups, daskworkergroups/scale, daskjobs, daskautoscalers]
     verbs: [get, list, watch, patch, create, delete]
 
   # Application: other resources it produces and manipulates.


### PR DESCRIPTION
Looks like `operator.yaml` was missing the `daskautoscalers` permission. This PR adds it :)