### PR TITLE
Add status to dask job

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -50,10 +50,6 @@ class SchedulerCommError(Exception):
     """Raised when unable to communicate with a scheduler."""
 
 
-def build_scheduler_pod_spec(name, spec):
-    pass
-
-
 def _get_dask_cluster_annotations(meta):
     return {
         annotation_key: annotation_value
@@ -134,12 +130,16 @@ def build_worker_pod_spec(
     return pod_spec
 
 
+def get_job_runner_pod_name(job_name):
+    return f"{job_name}-runner"
+
+
 def build_job_pod_spec(job_name, cluster_name, namespace, spec, annotations):
     pod_spec = {
         "apiVersion": "v1",
         "kind": "Pod",
         "metadata": {
-            "name": f"{job_name}-runner",
+            "name": get_job_runner_pod_name(job_name),
             "labels": {
                 "dask.org/cluster-name": cluster_name,
                 "dask.org/component": "job-runner",
@@ -471,6 +471,7 @@ async def daskjob_create_components(spec, name, namespace, logger, patch, **kwar
         )
         patch.status["clusterName"] = cluster_name
         patch.status["jobStatus"] = DaskJobStatus.CLUSTER_CREATED.value
+        patch.status["jobRunnerPodName"] = get_job_runner_pod_name(name)
 
 
 @kopf.on.field(

--- a/dask_kubernetes/operator/controller/tests/resources/failedjob.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/failedjob.yaml
@@ -1,0 +1,71 @@
+apiVersion: kubernetes.dask.org/v1
+kind: DaskJob
+metadata:
+  name: failed-job
+  namespace: default
+spec:
+  job:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: job
+          image: "dask-kubernetes:dev"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - python
+            - -c
+            - "from dask.distributed import Client; client = Client(name='job'); assert False"
+  cluster:
+    spec:
+      worker:
+        replicas: 2
+        spec:
+          containers:
+            - name: worker
+              image: "dask-kubernetes:dev"
+              imagePullPolicy: "IfNotPresent"
+              args:
+                - dask-worker
+                - --name
+                - $(DASK_WORKER_NAME)
+      scheduler:
+        spec:
+          containers:
+            - name: scheduler
+              image: "dask-kubernetes:dev"
+              imagePullPolicy: "IfNotPresent"
+              args:
+                - dask-scheduler
+              ports:
+                - name: tcp-comm
+                  containerPort: 8786
+                  protocol: TCP
+                - name: http-dashboard
+                  containerPort: 8787
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  port: http-dashboard
+                  path: /health
+                initialDelaySeconds: 5
+                periodSeconds: 10
+              livenessProbe:
+                httpGet:
+                  port: http-dashboard
+                  path: /health
+                initialDelaySeconds: 15
+                periodSeconds: 20
+        service:
+          type: ClusterIP
+          selector:
+            dask.org/cluster-name: simple-job
+            dask.org/component: scheduler
+          ports:
+            - name: tcp-comm
+              protocol: TCP
+              port: 8786
+              targetPort: "tcp-comm"
+            - name: http-dashboard
+              protocol: TCP
+              port: 8787
+              targetPort: "http-dashboard"

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -232,34 +232,26 @@ def _get_job_status(k8s_cluster):
 
 
 def _assert_job_status_created(job_status):
-    assert job_status == {"jobStatus": "JobCreated"}
+    assert "jobStatus" in job_status
 
 
 def _assert_job_status_cluster_created(job, job_status):
-    assert job_status == {
-        "clusterName": job,
-        "jobRunnerPodName": get_job_runner_pod_name(job),
-        "jobStatus": "ClusterCreated",
-    }
+    assert "jobStatus" in job_status
+    assert job_status["clusterName"] == job
+    assert job_status["jobRunnerPodName"] == get_job_runner_pod_name(job)
 
 
 def _assert_job_status_running(job, job_status):
+    assert "jobStatus" in job_status
     assert job_status["clusterName"] == job
-    assert job_status["jobStatus"] == "Running"
     assert job_status["jobRunnerPodName"] == get_job_runner_pod_name(job)
     start_time = datetime.strptime(job_status["startTime"], KUBERNETES_DATETIME_FORMAT)
     assert datetime.utcnow() > start_time > (datetime.utcnow() - timedelta(seconds=10))
-    assert set(job_status.keys()) == {
-        "clusterName",
-        "jobRunnerPodName",
-        "jobStatus",
-        "startTime",
-    }
 
 
 def _assert_final_job_status(job, job_status, expected_status):
-    assert job_status["clusterName"] == job
     assert job_status["jobStatus"] == expected_status
+    assert job_status["clusterName"] == job
     assert job_status["jobRunnerPodName"] == get_job_runner_pod_name(job)
     start_time = datetime.strptime(job_status["startTime"], KUBERNETES_DATETIME_FORMAT)
     assert datetime.utcnow() > start_time > (datetime.utcnow() - timedelta(minutes=1))

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -13,7 +13,6 @@ import yaml
 from dask.distributed import Client
 
 from dask_kubernetes.operator.controller import (
-    DaskJobStatus,
     KUBERNETES_DATETIME_FORMAT,
     get_job_runner_pod_name,
 )
@@ -233,20 +232,20 @@ def _get_job_status(k8s_cluster):
 
 
 def _assert_job_status_created(job_status):
-    assert job_status == {"jobStatus": DaskJobStatus.JOB_CREATED.value}
+    assert job_status == {"jobStatus": "JobCreated"}
 
 
 def _assert_job_status_cluster_created(job, job_status):
     assert job_status == {
         "clusterName": job,
         "jobRunnerPodName": get_job_runner_pod_name(job),
-        "jobStatus": DaskJobStatus.CLUSTER_CREATED.value,
+        "jobStatus": "ClusterCreated",
     }
 
 
 def _assert_job_status_running(job, job_status):
     assert job_status["clusterName"] == job
-    assert job_status["jobStatus"] == DaskJobStatus.RUNNING.value
+    assert job_status["jobStatus"] == "Running"
     assert job_status["jobRunnerPodName"] == get_job_runner_pod_name(job)
     start_time = datetime.strptime(job_status["startTime"], KUBERNETES_DATETIME_FORMAT)
     assert datetime.utcnow() > start_time > (datetime.utcnow() - timedelta(seconds=10))
@@ -332,7 +331,7 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
                 await asyncio.sleep(0.1)
 
             job_status = _get_job_status(k8s_cluster)
-            _assert_final_job_status(job, job_status, DaskJobStatus.SUCCESSFUL.value)
+            _assert_final_job_status(job, job_status, "Successful")
 
     assert "A DaskJob has been created" in runner.stdout
     assert "Job succeeded, deleting Dask cluster." in runner.stdout
@@ -382,7 +381,7 @@ async def test_failed_job(k8s_cluster, kopf_runner, gen_job):
                 await asyncio.sleep(0.1)
 
             job_status = _get_job_status(k8s_cluster)
-            _assert_final_job_status(job, job_status, DaskJobStatus.FAILED.value)
+            _assert_final_job_status(job, job_status, "Failed")
 
     assert "A DaskJob has been created" in runner.stdout
     assert "Job failed, deleting Dask cluster." in runner.stdout

--- a/dask_kubernetes/operator/customresources/daskjob.yaml
+++ b/dask_kubernetes/operator/customresources/daskjob.yaml
@@ -20,6 +20,22 @@ spec:
           type: object
           properties:
             status:
+              properties:
+                clusterName:
+                  type: string
+                endTime:
+                  type: string
+                  format: date-time
+                  nullable: true
+                jobStatus:
+                  type: string
+                  nullable: true
+                startTime:
+                  type: string
+                  format: date-time
+                  nullable: true
+              required:
+                - jobStatus
               type: object
             spec:
               type: object
@@ -34,3 +50,12 @@ spec:
                       $ref: 'python://k8s_crd_resolver/schemata/k8s-1.21.1.json#/definitions/io.k8s.api.core.v1.PodSpec'
                 cluster:
                   $ref: 'python://dask_kubernetes/operator/customresources/templates.yaml#/definitions/dask.k8s.api.v1.DaskCluster'
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.jobStatus
+          name: Status
+          type: string
+        - jsonPath: .spec.cluster.spec.worker.replicas
+          name: Number Of Workers
+          type: integer

--- a/dask_kubernetes/operator/customresources/daskjob.yaml
+++ b/dask_kubernetes/operator/customresources/daskjob.yaml
@@ -27,6 +27,9 @@ spec:
                   type: string
                   format: date-time
                   nullable: true
+                jobRunnerPodName:
+                  type: string
+                  nullable: true
                 jobStatus:
                   type: string
                   nullable: true

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
@@ -12,7 +12,14 @@ spec:
     singular: daskjob
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.jobStatus
+      name: Status
+      type: string
+    - jsonPath: .spec.cluster.spec.worker.replicas
+      name: Number Of Workers
+      type: integer
+    name: v1
     schema:
       openAPIV3Schema:
         properties:
@@ -8796,7 +8803,25 @@ spec:
             - job
             type: object
           status:
+            properties:
+              clusterName:
+                type: string
+              endTime:
+                format: date-time
+                nullable: true
+                type: string
+              jobStatus:
+                nullable: true
+                type: string
+              startTime:
+                format: date-time
+                nullable: true
+                type: string
+            required:
+            - jobStatus
             type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
@@ -8810,6 +8810,9 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              jobRunnerPodName:
+                nullable: true
+                type: string
               jobStatus:
                 nullable: true
                 type: string

--- a/dask_kubernetes/operator/deployment/manifests/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/manifests/daskjob.yaml
@@ -12,7 +12,14 @@ spec:
     singular: daskjob
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.jobStatus
+      name: Status
+      type: string
+    - jsonPath: .spec.cluster.spec.worker.replicas
+      name: Number Of Workers
+      type: integer
+    name: v1
     schema:
       openAPIV3Schema:
         properties:
@@ -8796,7 +8803,25 @@ spec:
             - job
             type: object
           status:
+            properties:
+              clusterName:
+                type: string
+              endTime:
+                format: date-time
+                nullable: true
+                type: string
+              jobStatus:
+                nullable: true
+                type: string
+              startTime:
+                format: date-time
+                nullable: true
+                type: string
+            required:
+            - jobStatus
             type: object
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/dask_kubernetes/operator/deployment/manifests/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/manifests/daskjob.yaml
@@ -8810,6 +8810,9 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              jobRunnerPodName:
+                nullable: true
+                type: string
               jobStatus:
                 nullable: true
                 type: string


### PR DESCRIPTION
This PR aims at adding some `status` information to the `DaskJob` CRD.

In particular it adds the following fields to `status`: 
- `jobStatus`: Status of the job. string, required. Can by any of: 
    - `JobCreated`: Job CR was created
    - `ClusterCreated`: The `DaskCluster` CR associated with the job has been created
    - `Running`: The job-runner pod is in "Running" state
    - `Successful`: The job-runner pod is in `Succeeded` state
    - `Failed`: The job-runner pod is in the `Failed` statue
- `clusterName`: Name of the `DaskCluster` resorce to be created (string)
- `jobRunnerPodName`: The name of the job-runner pod
- `startTime`: Time when the job-runner pod started running
- `endTime`: Time when the job-runner pod went into the `Succeeded` state

@jacobtomlinson: Happy to change any of the stated/the behavior in general. 

The `test_job` test is also becoming quite large, let me know if I should pull some functions out or split it into multiple tests.

cc @hamersaw

**Edit 2022-10-21**: 
- Split the `Completed` state in into a `Successful` and `Failed` state
- Added `jobRunnerPodName`

Closes #573