### PR TITLE
Add missing `daskjobs/status` permissions

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
@@ -36,7 +36,7 @@ rules:
 
   # Application: watching & handling for the custom resource we declare.
   - apiGroups: [kubernetes.dask.org]
-    resources: [daskclusters, daskworkergroups, daskjobs, daskautoscalers, daskworkergroups/scale]
+    resources: [daskclusters, daskworkergroups, daskjobs, daskjobs/status, daskautoscalers, daskworkergroups/scale]
     verbs: [get, list, watch, patch, create, delete]
 
   # Application: other resources it produces and manipulates.


### PR DESCRIPTION
When working on the Flyte `dask` plugin, I've noticed that the operator does not have permissions to change `daskjobs/status`, this adds the missing permission. 

Sorry for not checking this.