### PR TITLE
Document using inline JSON patch to update Kubeflow permissions

### DIFF
--- a/doc/source/operator_installation.rst
+++ b/doc/source/operator_installation.rst
@@ -63,21 +63,12 @@ User permissions
 
 Kubeflow doesn't know anything about our Dask custom resource definitions so we need to update the ``kubeflow-kubernetes-edit`` cluster role. This role
 allows users with cluster edit permissions to create pods, jobs and other resources and we need to add the Dask custom resources to that list. Edit the
-existing ``clusterrole`` and add a new rule to the ``rules`` section for ``kubernetes.dask.org``.
+existing ``clusterrole`` and add a new rule to the ``rules`` section for ``kubernetes.dask.org`` what allows all operations on all custom resources.
 
 .. code-block:: console
 
-     $ kubectl edit clusterrole kubeflow-kubernetes-edit
-      …
-      rules:
-      …
-      - apiGroups:
-         - "kubernetes.dask.org"
-         verbs:
-         - "*"
-         resources:
-         - "*"
-      …
+     $ kubectl patch clusterrole kubeflow-kubernetes-edit --type="json" --patch '[{"op": "add", "path": "/rules/-", "value": {"apiGroups": ["kubernetes.dask.org"],"resources": ["*"],"verbs": ["*"]}}]'
+     clusterrole.rbac.authorization.k8s.io/kubeflow-kubernetes-edit patched
 
 Dashboard access
 ^^^^^^^^^^^^^^^^

--- a/doc/source/operator_installation.rst
+++ b/doc/source/operator_installation.rst
@@ -63,7 +63,7 @@ User permissions
 
 Kubeflow doesn't know anything about our Dask custom resource definitions so we need to update the ``kubeflow-kubernetes-edit`` cluster role. This role
 allows users with cluster edit permissions to create pods, jobs and other resources and we need to add the Dask custom resources to that list. Edit the
-existing ``clusterrole`` and add a new rule to the ``rules`` section for ``kubernetes.dask.org`` what allows all operations on all custom resources.
+existing ``clusterrole`` and add a new rule to the ``rules`` section for ``kubernetes.dask.org`` that allows all operations on all custom resources in our API namespace.
 
 .. code-block:: console
 


### PR DESCRIPTION
I finally managed to get my head around how to append something to a list instead of overwriting it when using `kubectl patch`. This PR updates the docs to use this technique instead of using `kubectl edit` and doing it interactively.

Turns out setting `kubectl patch --type="json" ...` allows you to use [JSON patch syntax](https://jsonpatch.com/) which is neat!