### PR TITLE
Connectivity fixes

### DIFF
--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -42,7 +42,9 @@ async def get_external_address_for_scheduler_service(
             with suppress(socket.gaierror):
                 # Try to resolve the service name. If we are inside the cluster this should succeed.
                 host = f"{service.metadata.name}.{service.metadata.namespace}"
-                if _is_service_available(host=host, port=port, retries=service_name_resolution_retries):
+                if _is_service_available(
+                    host=host, port=port, retries=service_name_resolution_retries
+                ):
                     return _tcp_address(host, port)
 
         # If the service name is unresolvable, we are outside the cluster and we need to port forward the service.

--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -14,10 +14,6 @@ from distributed.core import rpc
 from .utils import check_dependency
 
 
-def _tcp_address(host, port):
-    return f"tcp://{host}:{port}"
-
-
 async def get_external_address_for_scheduler_service(
     core_api,
     service,
@@ -45,14 +41,14 @@ async def get_external_address_for_scheduler_service(
                 if _is_service_available(
                     host=host, port=port, retries=service_name_resolution_retries
                 ):
-                    return _tcp_address(host, port)
+                    return f"tcp://{host}:{port}"
 
         # If the service name is unresolvable, we are outside the cluster and we need to port forward the service.
         host = "localhost"
         port = await port_forward_service(
             service.metadata.name, service.metadata.namespace, port
         )
-    return _tcp_address(host, port)
+    return f"tcp://{host}:{port}"
 
 
 def _is_service_available(host, port, retries=20):

--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 import random
 import socket
 import subprocess
@@ -33,18 +34,19 @@ async def get_external_address_for_scheduler_service(
         nodes = await core_api.list_node()
         host = nodes.items[0].status.addresses[0].address
     elif service.spec.type == "ClusterIP":
-        try:
-            # Try to resolve the service name. If we are inside the cluster this should succeed.
-            host = f"{service.metadata.name}.{service.metadata.namespace}"
-            _is_service_available(
-                host=host, port=port, retries=service_name_resolution_retries
-            )
-        except socket.gaierror:
-            # If we are outside it will fail and we need to port forward the service.
-            host = "localhost"
-            port = await port_forward_service(
-                service.metadata.name, service.metadata.namespace, port
-            )
+        if not port_forward_cluster_ip:
+            with suppress(socket.gaierror):
+                # Try to resolve the service name. If we are inside the cluster this should succeed.
+                host = f"{service.metadata.name}.{service.metadata.namespace}"
+                _is_service_available(
+                    host=host, port=port, retries=service_name_resolution_retries
+                )
+
+        # If the service name is unresolvable, we are outside the cluster and we need to port forward the service.
+        host = "localhost"
+        port = await port_forward_service(
+            service.metadata.name, service.metadata.namespace, port
+        )
     return f"tcp://{host}:{port}"
 
 
@@ -89,19 +91,20 @@ async def port_forward_service(service_name, namespace, remote_port, local_port=
     )
     finalize(kproc, kproc.kill)
 
-    if await is_comm_open("localhost", local_port, retries=100):
+    if await is_comm_open("localhost", local_port, retries=2000):
         return local_port
     raise ConnectionError("kubectl port forward failed")
 
 
-async def is_comm_open(ip, port, retries=10):
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+async def is_comm_open(ip, port, retries=200):
     while retries > 0:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         result = sock.connect_ex((ip, port))
+        sock.close()
         if result == 0:
             return True
         else:
-            time.sleep(2)
+            time.sleep(0.1)
             retries -= 1
     return False
 
@@ -111,11 +114,10 @@ async def port_forward_dashboard(service_name, namespace):
     return port
 
 
-async def get_scheduler_address(service_name, namespace, port_name="tcp-comm"):
+async def get_scheduler_address(service_name, namespace, port_name="tcp-comm", port_forward_cluster_ip=None):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)
         service = await api.read_namespaced_service(service_name, namespace)
-        port_forward_cluster_ip = None
         address = await get_external_address_for_scheduler_service(
             api,
             service,

--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -116,7 +116,9 @@ async def port_forward_dashboard(service_name, namespace):
     return port
 
 
-async def get_scheduler_address(service_name, namespace, port_name="tcp-comm", port_forward_cluster_ip=None):
+async def get_scheduler_address(
+    service_name, namespace, port_name="tcp-comm", port_forward_cluster_ip=None
+):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)
         service = await api.read_namespaced_service(service_name, namespace)

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -292,6 +292,7 @@ class KubeCluster(Cluster):
                 f"{self.name}-scheduler",
                 self.namespace,
                 port_name="http-dashboard",
+                port_forward_cluster_ip=self.port_forward_cluster_ip
             )
             self.forwarded_dashboard_port = dashboard_address.split(":")[-1]
 
@@ -322,6 +323,7 @@ class KubeCluster(Cluster):
                 service_name,
                 self.namespace,
                 port_name="http-dashboard",
+                port_forward_cluster_ip=self.port_forward_cluster_ip
             )
             self.forwarded_dashboard_port = dashboard_address.split(":")[-1]
 
@@ -340,7 +342,11 @@ class KubeCluster(Cluster):
                 return None
 
     async def _get_scheduler_address(self):
-        address = await get_scheduler_address(f"{self.name}-scheduler", self.namespace)
+        address = await get_scheduler_address(
+            f"{self.name}-scheduler",
+            self.namespace,
+            port_forward_cluster_ip=self.port_forward_cluster_ip
+        )
         return address
 
     async def _wait_for_controller(self):
@@ -842,5 +848,4 @@ def reap_clusters():
                     else:
                         cluster.close(timeout=10)
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_reap_clusters())
+    asyncio.run(_reap_clusters())

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -292,7 +292,7 @@ class KubeCluster(Cluster):
                 f"{self.name}-scheduler",
                 self.namespace,
                 port_name="http-dashboard",
-                port_forward_cluster_ip=self.port_forward_cluster_ip
+                port_forward_cluster_ip=self.port_forward_cluster_ip,
             )
             self.forwarded_dashboard_port = dashboard_address.split(":")[-1]
 
@@ -323,7 +323,7 @@ class KubeCluster(Cluster):
                 service_name,
                 self.namespace,
                 port_name="http-dashboard",
-                port_forward_cluster_ip=self.port_forward_cluster_ip
+                port_forward_cluster_ip=self.port_forward_cluster_ip,
             )
             self.forwarded_dashboard_port = dashboard_address.split(":")[-1]
 
@@ -345,7 +345,7 @@ class KubeCluster(Cluster):
         address = await get_scheduler_address(
             f"{self.name}-scheduler",
             self.namespace,
-            port_forward_cluster_ip=self.port_forward_cluster_ip
+            port_forward_cluster_ip=self.port_forward_cluster_ip,
         )
         return address
 

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -848,4 +848,5 @@ def reap_clusters():
                     else:
                         cluster.close(timeout=10)
 
-    asyncio.run(_reap_clusters())
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(_reap_clusters())


### PR DESCRIPTION
This fixes #566.  

I also thread the `port_forward_cluster_ip` KubeCluster argument through to `get_external_address_for_scheduler_service` in order to match the behavior more closely to what I believe the intention is in the [docs](https://kubernetes.dask.org/en/latest/operator_kubecluster.html#dask_kubernetes.operator.KubeCluster).  If my interpretation or implementation here is incorrect, I am happy to correct it. I found it to be important for fast connectivity to remote clusters.  Before, we needed to wait for it to timeout (10s) before port forwarding the service and connecting remotely.