### PR TITLE
Improve operator helm install commands

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -39,9 +39,7 @@ Kubernetes resources.  It is designed to dynamically launch ad-hoc deployments.
 .. code-block:: console
 
     $ # Install operator CRDs and controller, needs to be done once on your Kubernetes cluster
-    $ helm repo add dask https://helm.dask.org && helm repo update
-    $ kubectl create ns dask-operator
-    $ helm install --namespace dask-operator dask-operator dask/dask-kubernetes-operator
+    $ helm install --repo https://helm.dask.org --create-namespace -n dask-operator --generate-name dask-kubernetes-operator
 
 .. code-block:: python
 

--- a/doc/source/kubecluster_migrating.rst
+++ b/doc/source/kubecluster_migrating.rst
@@ -41,9 +41,22 @@ The quickest way to install things is with ``helm``.
 
 .. code-block:: console
 
-    $ helm repo add dask https://helm.dask.org && helm repo update
-    $ kubectl create ns dask-operator
-    $ helm install --namespace dask-operator dask-operator dask/dask-kubernetes-operator
+    $ helm repo add dask https://helm.dask.org
+    "dask" has been added to your repositories
+
+    $ helm repo update
+    Hang tight while we grab the latest from your chart repositories...
+    ...Successfully got an update from the "dask" chart repository
+    Update Complete. ⎈Happy Helming!⎈
+
+    $ helm install --create-namespace -n dask-operator --generate-name dask/dask-kubernetes-operator
+    NAME: dask-kubernetes-operator-1666875935
+    NAMESPACE: dask-operator
+    STATUS: deployed
+    REVISION: 1
+    TEST SUITE: None
+    NOTES:
+    Operator has been installed successfully.
 
 Now that you have the controller and CRDs installed on your cluster you can start using the new :class:`dask_kubernetes.operator.KubeCluster`.
 

--- a/doc/source/operator_installation.rst
+++ b/doc/source/operator_installation.rst
@@ -43,9 +43,22 @@ The chart is published in the `Dask Helm repo <https://helm.dask.org>`_ reposito
 
 .. code-block:: console
 
-    $ helm repo add dask https://helm.dask.org && helm repo update
-    $ kubectl create ns dask-operator
-    $ helm install --namespace dask-operator dask-operator dask/dask-kubernetes-operator
+    $ helm repo add dask https://helm.dask.org
+    "dask" has been added to your repositories
+
+    $ helm repo update
+    Hang tight while we grab the latest from your chart repositories...
+    ...Successfully got an update from the "dask" chart repository
+    Update Complete. ⎈Happy Helming!⎈
+
+    $ helm install --create-namespace -n dask-operator --generate-name dask/dask-kubernetes-operator
+    NAME: dask-kubernetes-operator-1666875935
+    NAMESPACE: dask-operator
+    STATUS: deployed
+    REVISION: 1
+    TEST SUITE: None
+    NOTES:
+    Operator has been installed successfully.
 
 This will install the custom resource definitions, service account, roles, and the operator deployment.
 


### PR DESCRIPTION
Updated the general `helm install` commands with better console output for the `helm repo add` and `helm repo update` commands as well as adding some quality of life flags to the `helm install` like `--create-namespace` and `--generate-name`.

```console
$ helm repo add dask https://helm.dask.org
"dask" has been added to your repositories

$ helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "dask" chart repository
Update Complete. ⎈Happy Helming!⎈

$ helm install --create-namespace -n dask-operator --generate-name dask/dask-kubernetes-operator
NAME: dask-kubernetes-operator-1666875935
NAMESPACE: dask-operator
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Operator has been installed successfully.
```

Also updated the quickstart example with a one-liner that skips adding and updating the repo.

```console
$ helm install --repo https://helm.dask.org --create-namespace -n dask-operator --generate-name dask-kubernetes-operator
NAME: dask-kubernetes-operator-1666875935
NAMESPACE: dask-operator
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Operator has been installed successfully.
```