### PR TITLE
Explicitly specify operator's image version

### DIFF
--- a/dask_kubernetes/operator/deployment/manifests/operator.yaml
+++ b/dask_kubernetes/operator/deployment/manifests/operator.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: dask-kubernetes-operator
       containers:
         - name: operator
-          image: ghcr.io/dask/dask-kubernetes-operator:latest
+          image: ghcr.io/dask/dask-kubernetes-operator:2022.10.1
           imagePullPolicy: IfNotPresent
 ---
 apiVersion: v1


### PR DESCRIPTION
I know this is not a generic solution but it is better than a broken operator deployment.

Addresses https://github.com/dask/dask-kubernetes/issues/592