### PR TITLE
Start the cluster operator.KubeCluster when created asynchronously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ credentials.csv
 *.pub
 *.rdp
 *_rsa
+
+# IDEs
+.idea/
+.vscode/

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -5,6 +5,7 @@ import atexit
 from contextlib import suppress
 from enum import Enum
 import getpass
+import logging
 import os
 import time
 from typing import ClassVar
@@ -37,6 +38,8 @@ from dask_kubernetes.common.networking import (
     wait_for_scheduler_comm,
 )
 from dask_kubernetes.common.utils import get_current_namespace
+
+logger = logging.getLogger(__name__)
 
 
 class CreateMode(Enum):
@@ -569,8 +572,9 @@ class KubeCluster(Cluster):
                     )
                 except ApiException as e:
                     if e.reason == "Not Found":
-                        # TODO: maybe add a warning or do nothing?
-                        pass
+                        logger.warning(
+                            "Failed to delete DaskCluster, looks like it has already been deleted."
+                        )
                     else:
                         raise
             start = time.time()

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -244,6 +244,14 @@ class KubeCluster(Cluster):
 
         await super()._start()
 
+    def __await__(self):
+        async def _():
+            if self.status == Status.created:
+                await self._start()
+            return self
+
+        return _().__await__()
+
     async def _create_cluster(self):
         if self.shutdown_on_close is None:
             self.shutdown_on_close = True

--- a/dask_kubernetes/operator/kubecluster/tests/conftest.py
+++ b/dask_kubernetes/operator/kubecluster/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import pytest_asyncio
 
 import dask.config
 
@@ -10,4 +11,14 @@ def cluster(kopf_runner, docker_image):
     with dask.config.set({"kubernetes.name": "foo-{uuid}"}):
         with kopf_runner:
             with KubeCluster(image=docker_image, n_workers=1) as cluster:
+                yield cluster
+
+
+@pytest_asyncio.fixture
+async def async_cluster(kopf_runner, docker_image):
+    with dask.config.set({"kubernetes.name": "foo-{uuid}"}):
+        with kopf_runner:
+            async with KubeCluster(
+                image=docker_image, n_workers=1, asynchronous=True
+            ) as cluster:
                 yield cluster

--- a/dask_kubernetes/operator/kubecluster/tests/test_discovery.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_discovery.py
@@ -6,12 +6,11 @@ from dask_kubernetes.operator import discover
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Has asyncio issues on CI")
-async def test_discovery(cluster):
+async def test_discovery(async_cluster):
     clusters = [name async for name, _ in discover()]
-    assert cluster.name in clusters
-    async with KubeCluster.from_name(cluster.name, asynchronous=True) as cluster2:
-        assert cluster == cluster2
+    assert async_cluster.name in clusters
+    async with KubeCluster.from_name(async_cluster.name, asynchronous=True) as cluster2:
+        assert async_cluster == cluster2
         assert "id" in cluster2.scheduler_info
         async with Client(cluster2, asynchronous=True) as client:
             assert await client.submit(lambda x: x + 1, 10).result() == 11

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -22,6 +22,19 @@ def test_kubecluster(cluster):
         assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
+@pytest.mark.asyncio
+async def test_kubecluster_async(kopf_runner, docker_image):
+    with kopf_runner:
+        async with KubeCluster(
+            name="async",
+            image=docker_image,
+            n_workers=1,
+            asynchronous=True,
+        ) as cluster:
+            async with Client(cluster, asynchronous=True) as client:
+                assert await client.submit(lambda x: x + 1, 10).result() == 11
+
+
 def test_custom_worker_command(kopf_runner, docker_image):
     with kopf_runner:
         with KubeCluster(

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -83,15 +83,12 @@ def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image):
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
 
 
-@pytest.mark.skip(
-    reason="Failing due to a race condition that I can't get to the bottom of"
-)
-def test_cluster_from_name(kopf_runner, docker_image, namespace):
+def test_cluster_from_name(kopf_runner, docker_image, ns):
     with kopf_runner:
         with KubeCluster(
-            name="abc", namespace=namespace, image=docker_image, n_workers=1
+            name="abc", namespace=ns, image=docker_image, n_workers=1
         ) as firstcluster:
-            with KubeCluster.from_name("abc", namespace=namespace) as secondcluster:
+            with KubeCluster.from_name("abc", namespace=ns) as secondcluster:
                 assert firstcluster == secondcluster
 
 


### PR DESCRIPTION
## Description

This PR adds support to automatically start an `operator.KubeCluster` when created with the `asynchronous` parameter set to `True`.

## References

- Closes #598 