### PR TITLE
Ensure workers are recreated if pods are deleted/lost

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -362,6 +362,7 @@ async def get_desired_workers(scheduler_service_name, namespace, logger):
 
 
 @kopf.on.update("daskworkergroup")
+@kopf.timer("daskworkergroup", interval=5.0)
 async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -134,6 +134,29 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     await client.wait_for_workers(3)
 
 
+@pytest.mark.asyncio
+async def test_group_recovers_from_pod_deletion(k8s_cluster, kopf_runner, gen_cluster):
+    with kopf_runner as runner:
+        async with gen_cluster() as cluster_name:
+            scheduler_pod_name = "simple-scheduler"
+            service_name = "simple-scheduler"
+            while "Running" not in k8s_cluster.kubectl(
+                "get", "pods", scheduler_pod_name
+            ):
+                await asyncio.sleep(0.1)
+            with k8s_cluster.port_forward(f"service/{service_name}", 8786) as port:
+                async with Client(
+                    f"tcp://localhost:{port}", asynchronous=True
+                ) as client:
+                    k8s_cluster.kubectl(
+                        "delete",
+                        "pods",
+                        "-l",
+                        "dask.org/cluster-name=simple,dask.org/component=worker",
+                    )
+                    await client.wait_for_workers(2)
+
+
 @pytest.mark.timeout(180)
 @pytest.mark.asyncio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):


### PR DESCRIPTION
Closes #603 

Added a timer to the `daskworkergroup_update` method so that the scaling logic is run every 5 seconds as well as when the group is updated. This function checks if the current number of pods matches the expected and creates/removes accordingly. 

If a node is terminated and pods are lost this timer should notice the mismatch and correct it.

Also added a test to check for this.

This does leave open the question of what about other resources like the scheduler pod or job runner pod. Should those also be recreated automatically, or should the parent resource go into an error state?