### PR TITLE
Add linting for operator Helm Chart

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -16,7 +16,7 @@ on:
       - "dask_kubernetes/*"
 
 jobs:
-  k8sAPI:
+  lint-manifests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -16,19 +16,20 @@ on:
       - "dask_kubernetes/*"
 
 jobs:
-  lint-manifests:
+  lint-chart:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Lint Helm Chart
+        run: helm lint dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator
       - name: Download Pluto
         uses: FairwindsOps/pluto/github-action@master
       - name: Generate templates
         run: |
           mkdir manifests
           helm template --include-crds dask-operator dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator > manifests/generated.yaml
-      - name: Use pluto
-        run: |
-          pluto detect-files -d manifests
+      - name: Check for deprecated APIs
+        run: pluto detect-files -d manifests
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -23,13 +23,9 @@ jobs:
       - name: Lint Helm Chart
         run: helm lint dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator
       - name: Download Pluto
-        uses: FairwindsOps/pluto/github-action@master
-      - name: Generate templates
-        run: |
-          mkdir manifests
-          helm template --include-crds dask-operator dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator > manifests/generated.yaml
+        uses: FairwindsOps/pluto/github-action@v5.11.1
       - name: Check for deprecated APIs
-        run: pluto detect-files -d manifests
+        run: helm template --include-crds dask-operator dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator | pluto detect -
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -24,8 +24,8 @@ jobs:
         uses: FairwindsOps/pluto/github-action@master
       - name: Generate templates
         run: |
-        mkdir manifests
-        helm template --include-crds dask-operator dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator > manifests/generated.yaml
+          mkdir manifests
+          helm template --include-crds dask-operator dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator > manifests/generated.yaml
       - name: Use pluto
         run: |
           pluto detect-files -d manifests

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -16,6 +16,20 @@ on:
       - "dask_kubernetes/*"
 
 jobs:
+  k8sAPI:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Pluto
+        uses: FairwindsOps/pluto/github-action@master
+      - name: Generate templates
+        run: |
+        mkdir manifests
+        helm template --include-crds dask-operator dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator > manifests/generated.yaml
+      - name: Use pluto
+        run: |
+          pluto detect-files -d manifests
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
Uses helm to lint the chart and pluto to check operator install manifests for deprecated versions.

https://github.com/FairwindsOps/pluto

- Checks out code
- Runs `helm lint`
- Uses `helm` to generate a static manifest
- Runs `pluto` on the manifest