### PR TITLE
Cancel in-progress CI builds on new commit

### DIFF
--- a/.github/workflows/helmcluster.yaml
+++ b/.github/workflows/helmcluster.yaml
@@ -15,6 +15,9 @@ on:
       - "dask_kubernetes/common/**"
       - "dask_kubernetes/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -15,6 +15,9 @@ on:
       - "dask_kubernetes/common/**"
       - "dask_kubernetes/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -15,6 +15,10 @@ on:
       - "dask_kubernetes/common/**"
       - "dask_kubernetes/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use [concurrency groups](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to cancel in-progress builds when new commits are pushed to PRs.