### PR TITLE
Wait for LoadBalancer service readiness

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -186,9 +186,19 @@ async def wait_for_service(api, service_name, namespace):
     """Block until service is available."""
     while True:
         try:
-            await api.read_namespaced_service(service_name, namespace)
-            break
+            service = await api.read_namespaced_service(service_name, namespace)
+
+            # If the service is of type LoadBalancer, also wait until it's ready.
+            if (
+                service.spec.type == "LoadBalancer"
+                and len(service.status.load_balancer.ingress or []) == 0
+            ):
+                pass
+            else:
+                break
         except Exception:
+            pass
+        finally:
             await asyncio.sleep(0.1)
 
 

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -364,7 +364,14 @@ class KubeCluster(Cluster):
                 timeout_seconds=self._resource_timeout,
             ):
                 cluster = event["object"]
-                if "status" in cluster and "phase" in cluster["status"]:
+
+                # Wait until the phase is actually Running, ignoring
+                # other non-ready phases such as Created.
+                if (
+                    "status" in cluster
+                    and "phase" in cluster["status"]
+                    and cluster["status"]["phase"] == "Running"
+                ):
                     return
                 await asyncio.sleep(0.1)
         raise TimeoutError(


### PR DESCRIPTION
The controller should not change the phase to Running until the LoadBalancer service is truly ready.

This requires the client to also check for actual value of the phase in the status.