### PR TITLE
Handle cluster service status via the scheduler service status

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -246,7 +246,6 @@ async def daskcluster_create_components(spec, name, namespace, logger, patch, **
             namespace=namespace,
             body=data,
         )
-        await wait_for_service(api, data["metadata"]["name"], namespace)
         logger.info(
             f"Scheduler service {data['metadata']['name']} created in {namespace}."
         )

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -181,7 +181,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )  # First and last char is a quote
-            assert scheduler_annotations == _EXPECTED_ANNOTATIONS
+            assert _EXPECTED_ANNOTATIONS <= scheduler_annotations
 
             # Get the first annotation (the only one) of the scheduler
             service_annotations = json.loads(
@@ -193,7 +193,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )  # First and last char is a quote
-            assert service_annotations == _EXPECTED_ANNOTATIONS
+            assert _EXPECTED_ANNOTATIONS <= service_annotations
 
             # Get the first env value (the only one) of the first worker
             worker_env = k8s_cluster.kubectl(
@@ -217,7 +217,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )
-            assert worker_annotations == _EXPECTED_ANNOTATIONS
+            assert _EXPECTED_ANNOTATIONS <= worker_annotations
 
 
 def _get_job_status(k8s_cluster):
@@ -310,9 +310,7 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )
-            # There might be more annotations on the job runner than expected
-            for key, value in _EXPECTED_ANNOTATIONS.items():
-                assert job_annotations[key] == value
+            _EXPECTED_ANNOTATIONS <= job_annotations
 
             # Assert job pod runs to completion (will fail if doesn't connect to cluster)
             while "Completed" not in k8s_cluster.kubectl("get", "po", runner_name):

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -189,7 +189,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )  # First and last char is a quote
-            assert _EXPECTED_ANNOTATIONS <= scheduler_annotations
+            assert _EXPECTED_ANNOTATIONS.items() <= scheduler_annotations.items()
 
             # Get the first annotation (the only one) of the scheduler
             service_annotations = json.loads(
@@ -201,7 +201,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )  # First and last char is a quote
-            assert _EXPECTED_ANNOTATIONS <= service_annotations
+            assert _EXPECTED_ANNOTATIONS.items() <= service_annotations.items()
 
             # Get the first env value (the only one) of the first worker
             worker_env = k8s_cluster.kubectl(
@@ -225,7 +225,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )
-            assert _EXPECTED_ANNOTATIONS <= worker_annotations
+            assert _EXPECTED_ANNOTATIONS.items() <= worker_annotations.items()
 
 
 def _get_job_status(k8s_cluster):
@@ -320,7 +320,7 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
                     "jsonpath='{.items[0].metadata.annotations}'",
                 )[1:-1]
             )
-            _EXPECTED_ANNOTATIONS <= job_annotations
+            _EXPECTED_ANNOTATIONS.items() <= job_annotations.items()
 
             # Assert job pod runs to completion (will fail if doesn't connect to cluster)
             while "Completed" not in k8s_cluster.kubectl("get", "po", runner_name):

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -26,9 +26,6 @@ from distributed.utils import (
 )
 
 from dask_kubernetes.common.auth import ClusterAuth
-from dask_kubernetes.operator.controller import (
-    wait_for_service,
-)
 
 from dask_kubernetes.common.networking import (
     get_scheduler_address,
@@ -841,6 +838,26 @@ def make_scheduler_spec(
             ],
         },
     }
+
+
+async def wait_for_service(api, service_name, namespace):
+    """Block until service is available."""
+    while True:
+        try:
+            service = await api.read_namespaced_service(service_name, namespace)
+
+            # If the service is of type LoadBalancer, also wait until it's ready.
+            if (
+                service.spec.type == "LoadBalancer"
+                and len(service.status.load_balancer.ingress or []) == 0
+            ):
+                pass
+            else:
+                break
+        except Exception:
+            pass
+        finally:
+            await asyncio.sleep(0.1)
 
 
 @atexit.register


### PR DESCRIPTION
Instead of waiting for the service within the cluster creation handler we handle the service status updates directly and only move the cluster into `Running` state if the service is up.