### PR TITLE
Ensure the operator can coexist with dask-gateway

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -57,6 +57,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install deps
         run: ./ci/install-deps.sh
+      - name: Install Dask Gateway  # To ensure the operator can coexist with Gateway
+        run: helm install --generate-name dask-gateway --repo=https://helm.dask.org --create-namespace --namespace dask-gateway
       - name: Run tests
         env:
           KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -57,8 +57,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install deps
         run: ./ci/install-deps.sh
-      - name: Install Dask Gateway  # To ensure the operator can coexist with Gateway
-        run: helm install --generate-name dask-gateway --repo=https://helm.dask.org --create-namespace --namespace dask-gateway
       - name: Run tests
         env:
           KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}

--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -74,6 +74,38 @@ def run_generate(crd_path, patch_path, temp_path):
 
 
 @pytest.fixture(scope="session", autouse=True)
+def install_gateway(k8s_cluster):
+    # To ensure the operator can coexist with Gateway
+    subprocess.run(
+        [
+            "helm",
+            "upgrade",
+            "dask-gateway",
+            "dask-gateway",
+            "--install",
+            "--repo=https://helm.dask.org",
+            "--create-namespace",
+            "--namespace",
+            "dask-gateway",
+        ],
+        check=True,
+        env={**os.environ},
+    )
+    yield
+    subprocess.run(
+        [
+            "helm",
+            "delete",
+            "--namespace",
+            "dask-gateway",
+            "dask-gateway",
+        ],
+        check=True,
+        env={**os.environ},
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
 def customresources(k8s_cluster):
 
     temp_dir = tempfile.TemporaryDirectory()

--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -75,6 +75,7 @@ def run_generate(crd_path, patch_path, temp_path):
 
 @pytest.fixture(scope="session", autouse=True)
 def install_gateway(k8s_cluster):
+    check_dependency("helm")
     # To ensure the operator can coexist with Gateway
     subprocess.run(
         [

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -207,7 +207,7 @@ async def startup(**kwargs):
     await ClusterAuth.load_first()
 
 
-@kopf.on.create("daskcluster")
+@kopf.on.create("daskcluster.kubernetes.dask.org")
 async def daskcluster_create(name, namespace, logger, patch, **kwargs):
     """When DaskCluster resource is created set the status.phase.
 
@@ -217,7 +217,7 @@ async def daskcluster_create(name, namespace, logger, patch, **kwargs):
     patch.status["phase"] = "Created"
 
 
-@kopf.on.field("daskcluster", field="status.phase", new="Created")
+@kopf.on.field("daskcluster.kubernetes.dask.org", field="status.phase", new="Created")
 async def daskcluster_create_components(spec, name, namespace, logger, patch, **kwargs):
     """When the DaskCluster status.phase goes into Pending create the cluster components."""
     logger.info("Creating Dask cluster components.")
@@ -265,7 +265,7 @@ async def daskcluster_create_components(spec, name, namespace, logger, patch, **
     patch.status["phase"] = "Running"
 
 
-@kopf.on.create("daskworkergroup")
+@kopf.on.create("daskworkergroup.kubernetes.dask.org")
 async def daskworkergroup_create(spec, name, namespace, logger, **kwargs):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CustomObjectsApi(api_client)
@@ -371,7 +371,7 @@ async def get_desired_workers(scheduler_service_name, namespace, logger):
         ) from e
 
 
-@kopf.on.update("daskworkergroup")
+@kopf.on.update("daskworkergroup.kubernetes.dask.org")
 async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
     async with kubernetes.client.api_client.ApiClient() as api_client:
         api = kubernetes.client.CoreV1Api(api_client)
@@ -421,13 +421,15 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
             )
 
 
-@kopf.on.create("daskjob")
+@kopf.on.create("daskjob.kubernetes.dask.org")
 async def daskjob_create(name, namespace, logger, patch, **kwargs):
     logger.info(f"A DaskJob has been created called {name} in {namespace}.")
     patch.status["jobStatus"] = "JobCreated"
 
 
-@kopf.on.field("daskjob", field="status.jobStatus", new="JobCreated")
+@kopf.on.field(
+    "daskjob.kubernetes.dask.org", field="status.jobStatus", new="JobCreated"
+)
 async def daskjob_create_components(spec, name, namespace, logger, patch, **kwargs):
     logger.info("Creating Dask job components.")
     async with kubernetes.client.api_client.ApiClient() as api_client:
@@ -562,7 +564,7 @@ async def handle_runner_status_change_succeeded(meta, namespace, logger, **kwarg
         )
 
 
-@kopf.on.create("daskautoscaler")
+@kopf.on.create("daskautoscaler.kubernetes.dask.org")
 async def daskautoscaler_create(spec, name, namespace, logger, **kwargs):
     """When an autoscaler is created make it a child of the associated cluster for cascade deletion."""
     async with kubernetes.client.api_client.ApiClient() as api_client:
@@ -590,7 +592,7 @@ async def daskautoscaler_create(spec, name, namespace, logger, **kwargs):
         logger.info(f"Successfully adopted by {spec['cluster']}")
 
 
-@kopf.timer("daskautoscaler", interval=5.0)
+@kopf.timer("daskautoscaler.kubernetes.dask.org", interval=5.0)
 async def daskautoscaler_adapt(spec, name, namespace, logger, **kwargs):
     # Ask the scheduler for the desired number of worker
     try:

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -34,7 +34,9 @@ def gen_cluster(k8s_cluster):
 
         # Create cluster resource
         k8s_cluster.kubectl("apply", "-f", cluster_path)
-        while cluster_name not in k8s_cluster.kubectl("get", "daskclusters"):
+        while cluster_name not in k8s_cluster.kubectl(
+            "get", "daskclusters.kubernetes.dask.org"
+        ):
             await asyncio.sleep(0.1)
 
         try:
@@ -42,7 +44,9 @@ def gen_cluster(k8s_cluster):
         finally:
             # Test: remove the wait=True, because I think this is blocking the operator
             k8s_cluster.kubectl("delete", "-f", cluster_path)
-            while cluster_name in k8s_cluster.kubectl("get", "daskclusters"):
+            while cluster_name in k8s_cluster.kubectl(
+                "get", "daskclusters.kubernetes.dask.org"
+            ):
                 await asyncio.sleep(0.1)
 
     yield cm
@@ -60,7 +64,9 @@ def gen_job(k8s_cluster):
 
         # Create cluster resource
         k8s_cluster.kubectl("apply", "-f", job_path)
-        while job_name not in k8s_cluster.kubectl("get", "daskjobs"):
+        while job_name not in k8s_cluster.kubectl(
+            "get", "daskjobs.kubernetes.dask.org"
+        ):
             await asyncio.sleep(0.1)
 
         try:
@@ -68,7 +74,9 @@ def gen_job(k8s_cluster):
         finally:
             # Test: remove the wait=True, because I think this is blocking the operator
             k8s_cluster.kubectl("delete", "-f", job_path)
-            while job_name in k8s_cluster.kubectl("get", "daskjobs"):
+            while job_name in k8s_cluster.kubectl(
+                "get", "daskjobs.kubernetes.dask.org"
+            ):
                 await asyncio.sleep(0.1)
 
     yield cm
@@ -121,14 +129,14 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     k8s_cluster.kubectl(
                         "scale",
                         "--replicas=5",
-                        "daskworkergroup",
+                        "daskworkergroup.kubernetes.dask.org",
                         "simple-default",
                     )
                     await client.wait_for_workers(5)
                     k8s_cluster.kubectl(
                         "scale",
                         "--replicas=3",
-                        "daskworkergroup",
+                        "daskworkergroup.kubernetes.dask.org",
                         "simple-default",
                     )
                     await client.wait_for_workers(3)
@@ -224,7 +232,7 @@ def _get_job_status(k8s_cluster):
     return json.loads(
         k8s_cluster.kubectl(
             "get",
-            "daskjobs",
+            "daskjobs.kubernetes.dask.org",
             "-o",
             "jsonpath='{.items[0].status}'",
         )[1:-1]
@@ -275,14 +283,16 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
             runner_name = f"{job}-runner"
 
             # Assert that job was created
-            while job not in k8s_cluster.kubectl("get", "daskjobs"):
+            while job not in k8s_cluster.kubectl("get", "daskjobs.kubernetes.dask.org"):
                 await asyncio.sleep(0.1)
 
             job_status = _get_job_status(k8s_cluster)
             _assert_job_status_created(job_status)
 
             # Assert that cluster is created
-            while job not in k8s_cluster.kubectl("get", "daskclusters"):
+            while job not in k8s_cluster.kubectl(
+                "get", "daskclusters.kubernetes.dask.org"
+            ):
                 await asyncio.sleep(0.1)
 
             await asyncio.sleep(0.1)  # Wait for a short time, to avoid race condition
@@ -319,7 +329,7 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
                 await asyncio.sleep(0.1)
 
             # Assert cluster is removed on completion
-            while job in k8s_cluster.kubectl("get", "daskclusters"):
+            while job in k8s_cluster.kubectl("get", "daskclusters.kubernetes.dask.org"):
                 await asyncio.sleep(0.1)
 
             job_status = _get_job_status(k8s_cluster)
@@ -338,14 +348,16 @@ async def test_failed_job(k8s_cluster, kopf_runner, gen_job):
             runner_name = f"{job}-runner"
 
             # Assert that job was created
-            while job not in k8s_cluster.kubectl("get", "daskjobs"):
+            while job not in k8s_cluster.kubectl("get", "daskjobs.kubernetes.dask.org"):
                 await asyncio.sleep(0.1)
 
             job_status = _get_job_status(k8s_cluster)
             _assert_job_status_created(job_status)
 
             # Assert that cluster is created
-            while job not in k8s_cluster.kubectl("get", "daskclusters"):
+            while job not in k8s_cluster.kubectl(
+                "get", "daskclusters.kubernetes.dask.org"
+            ):
                 await asyncio.sleep(0.1)
 
             await asyncio.sleep(0.1)  # Wait for a short time, to avoid race condition
@@ -369,7 +381,7 @@ async def test_failed_job(k8s_cluster, kopf_runner, gen_job):
                 await asyncio.sleep(0.1)
 
             # Assert cluster is removed on completion
-            while job in k8s_cluster.kubectl("get", "daskclusters"):
+            while job in k8s_cluster.kubectl("get", "daskclusters.kubernetes.dask.org"):
                 await asyncio.sleep(0.1)
 
             job_status = _get_job_status(k8s_cluster)

--- a/doc/source/operator_extending.rst
+++ b/doc/source/operator_extending.rst
@@ -17,7 +17,7 @@ For example whenever a ``DaskCluster`` resource is created the controller sets t
 
 .. code-block:: python
 
-   @kopf.on.create("daskcluster")
+   @kopf.on.create("daskcluster.kubernetes.dask.org")
    async def daskcluster_create(name, namespace, logger, patch, **kwargs):
       """When DaskCluster resource is created set the status.phase.
 
@@ -31,7 +31,7 @@ This handler creates the ``Pod``, ``Service`` and ``DaskWorkerGroup`` subresourc
 
 .. code-block:: python
 
-   @kopf.on.field("daskcluster", field="status.phase", new="Created")
+   @kopf.on.field("daskcluster.kubernetes.dask.org", field="status.phase", new="Created")
    async def daskcluster_create_components(spec, name, namespace, logger, patch, **kwargs):
       """When the DaskCluster status.phase goes into Pending create the cluster components."""
       async with kubernetes.client.api_client.ApiClient() as api_client:


### PR DESCRIPTION
- Switch to using fully qualified resource names everywhere so that we don't collide with similarly named resources in dask-gateway.
- Install dask-gateway as a pytest session fixture so we ensure that all tests pass with gateway installed.

Closes #618 