### PR TITLE
Configure liveness probe for operator controller

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -207,6 +207,13 @@ async def startup(**kwargs):
     await ClusterAuth.load_first()
 
 
+# There may be useful things for us to expose via the liveness probe
+# https://kopf.readthedocs.io/en/stable/probing/#probe-handlers
+@kopf.on.probe(id="now")
+def get_current_timestamp(**kwargs):
+    return datetime.utcnow().isoformat()
+
+
 @kopf.on.create("daskcluster.kubernetes.dask.org")
 async def daskcluster_create(name, namespace, logger, patch, **kwargs):
     """When DaskCluster resource is created set the status.phase.

--- a/dask_kubernetes/operator/deployment/Dockerfile
+++ b/dask_kubernetes/operator/deployment/Dockerfile
@@ -11,4 +11,4 @@ WORKDIR /src/dask_kubernetes
 RUN pip install .
 
 # Start operator
-CMD kopf run -m dask_kubernetes.operator.controller --verbose --all-namespaces
+CMD kopf run -m dask_kubernetes.operator.controller --liveness=http://0.0.0.0:8080/healthz --verbose --all-namespaces

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
xref #620 

Enabled the `kopf` liveness probe so that k8s can monitor controller health.