### PR TITLE
Fix pre commit flake8 config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         language_version: python3
         exclude: versioneer.py
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
Looks like `flake8` migrated to GitHub and deleted their GitLab repo so many pre-commit configs are broken. Fixing it here.