### PR TITLE
set dask workergroup owner during creation

### DIFF
--- a/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
@@ -3,6 +3,8 @@ kind: DaskCluster
 metadata:
   name: simple
   namespace: default
+  labels:
+    test-label: "label-value"
   annotations:
     test-annotation: "annotation-value"
     "kopf.zalando.org/foobar": "should-not-be-propagated"


### PR DESCRIPTION
- Sets the dask workergroup owner during its creation instead of during `daskworkergroup_create` kopf call
- This allows labels to propagate correctly from the dask workergroup to the dask worker pod

closes #623 