### PR TITLE
Don't include Terminating pods in scale down calculations

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -407,7 +407,9 @@ async def daskworkergroup_update(spec, name, namespace, logger, **kwargs):
             namespace=namespace,
             label_selector=f"dask.org/workergroup-name={name}",
         )
-        current_workers = len(workers.items)
+        current_workers = len(
+            [w for w in workers.items if w.status.phase != "Terminating"]
+        )
         desired_workers = spec["worker"]["replicas"]
         workers_needed = desired_workers - current_workers
         annotations = _get_dask_cluster_annotations(kwargs["meta"])


### PR DESCRIPTION
In #633 we are seeing a problem where the workers are thrashing when adaptively scaling.

I **think** the problem is that when the scheduler changes the desired number of workers it begins releasing worker processes which put the pod into a `Terminating` state. When the controller catches up on the next cycle it adjusts the desired number of workers which triggers a scale down. When scaling down the `Terminating` pods are included in the count of current pods which results in an over count and the controller attempts to scale down further by removing more pods. 

This means we scale lower than we should.

This PR excludes `Terminating` pods from the count. Testing locally shows things scaling correctly.