### PR TITLE
Fix pod templates external references updates

### DIFF
--- a/dask_kubernetes/classic/kubecluster.py
+++ b/dask_kubernetes/classic/kubecluster.py
@@ -467,8 +467,8 @@ class KubeCluster(SpecCluster):
         if isinstance(scheduler_pod_template, dict):
             scheduler_pod_template = make_pod_from_dict(scheduler_pod_template)
 
-        self.pod_template = pod_template
-        self.scheduler_pod_template = scheduler_pod_template
+        self.pod_template = copy.deepcopy(pod_template)
+        self.scheduler_pod_template = copy.deepcopy(scheduler_pod_template)
         self.apply_default_affinity = apply_default_affinity
         self._generate_name = dask.config.get("kubernetes.name", override_with=name)
         self.namespace = dask.config.get(

--- a/dask_kubernetes/classic/tests/test_sync.py
+++ b/dask_kubernetes/classic/tests/test_sync.py
@@ -244,7 +244,9 @@ def test_scheduler_pod_template_spec_are_copied(docker_image):
     scheduler_spec = make_pod_spec(docker_image)
     scheduler_spec.spec.containers[0].args[0] = "fake-scheduler-cmd"
 
-    with KubeCluster(pod_template=make_pod_spec(docker_image), scheduler_pod_template=scheduler_spec):
+    with KubeCluster(
+        pod_template=make_pod_spec(docker_image), scheduler_pod_template=scheduler_spec
+    ):
         assert scheduler_spec.spec.containers[0].args[0] == "fake-scheduler-cmd"
 
 

--- a/dask_kubernetes/classic/tests/test_sync.py
+++ b/dask_kubernetes/classic/tests/test_sync.py
@@ -232,6 +232,22 @@ def test_pod_template_minimal_dict(docker_image):
             assert result == 11
 
 
+def test_worker_pod_template_spec_are_copied(docker_image):
+    worker_spec = make_pod_spec(docker_image)
+    worker_spec.spec.containers[0].args[0] = "fake-worker-cmd"
+
+    with KubeCluster(pod_template=worker_spec):
+        assert worker_spec.spec.containers[0].args[0] == "fake-worker-cmd"
+
+
+def test_scheduler_pod_template_spec_are_copied(docker_image):
+    scheduler_spec = make_pod_spec(docker_image)
+    scheduler_spec.spec.containers[0].args[0] = "fake-scheduler-cmd"
+
+    with KubeCluster(pod_template=make_pod_spec(docker_image), scheduler_pod_template=scheduler_spec):
+        assert scheduler_spec.spec.containers[0].args[0] == "fake-scheduler-cmd"
+
+
 def test_pod_template_from_conf(docker_image):
     spec = {
         "spec": {


### PR DESCRIPTION
## Description

This PR keeps copies of Pod templates for workers and/or schedulers when they are provided instead of references.

When keeping a reference to a Pod template spec outside of the `classic.KubeCluster` class, those external references could be updated if provided as `pod_template` or `scheduler_pod_template` args.

For example, this [line](https://github.com/dask/dask-kubernetes/blob/a24a3f9284043248e94816432abb9ece8e9be746/dask_kubernetes/classic/kubecluster.py#L584) updates an external reference of `pod_template.spec.containers[0].args[0]` to `dask-scheduler` because we have:
- [self.scheduler_pod_template that references base_pod_template](https://github.com/dask/dask-kubernetes/blob/a24a3f9284043248e94816432abb9ece8e9be746/dask_kubernetes/classic/kubecluster.py#L583)
- [base_pod_template that references self.pod_template](https://github.com/dask/dask-kubernetes/blob/a24a3f9284043248e94816432abb9ece8e9be746/dask_kubernetes/classic/kubecluster.py#L575)
- [self.pod_template that could references an external pod_template if provided](https://github.com/dask/dask-kubernetes/blob/a24a3f9284043248e94816432abb9ece8e9be746/dask_kubernetes/classic/kubecluster.py#L470)

## Reproducible example

```
from dask_kubernetes.classic.kubecluster import KubeCluster
from dask_kubernetes import make_pod_spec

worker_spec = make_pod_spec("dask-kubernetes:dev")
worker_spec.spec.containers[0].args[0] = "fake-worker-cmd"

with KubeCluster(pod_template=worker_spec):
    print(worker_spec.spec.containers[0].args[0])
```

Expected output: `fake-worker-cmd`
Actual output: `dask-scheduler`