### PR TITLE
Add support for kopf CLI arguments in operator deployment

### DIFF
--- a/dask_kubernetes/operator/deployment/Dockerfile
+++ b/dask_kubernetes/operator/deployment/Dockerfile
@@ -11,4 +11,5 @@ WORKDIR /src/dask_kubernetes
 RUN pip install .
 
 # Start operator
-CMD kopf run -m dask_kubernetes.operator.controller --liveness=http://0.0.0.0:8080/healthz --verbose --all-namespaces
+ENTRYPOINT ["/usr/local/bin/kopf", "run", "-m", "dask_kubernetes.operator.controller"]
+CMD ["--liveness=http://0.0.0.0:8080/healthz", "--verbose", "--all-namespaces"]

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -27,6 +27,7 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `nodeSelector` | Node selector | `{}` |
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity | `{}` |
+| `kopfArgs` | Command line flags to pass to kopf on start up | `["--all-namespaces"]` |
 
 
 

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --liveness=http://0.0.0.0:8080/healthz
+          {{- with .Values.kopfArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -42,3 +42,6 @@ nodeSelector: {}  # Node selector
 tolerations: []  # Tolerations
 
 affinity: {}  # Affinity
+
+kopfArgs: # Command line flags to pass to kopf on start up
+  - --all-namespaces


### PR DESCRIPTION
Adds the ability to provide kopf CLI arguments via the Helm values.yaml file.  

Some callouts:
- I split the container `CMD` out into an `ENTRYPOINT` and `CMD` to make the `args` definition cleaner (allows consumers to just specify CLI args there and not worry about properly starting up container) 
- I kept the container default args the same for backwards compatibility and opted to override the default args via the helm chart
- I've updated the default helm deploy to remove the `--verbose` flag
- I've left the `--all-namespaces` flag as a `CMD` flag, so if users override this they'll need to include the `--all-namespaces` flag again.  I figure this provides the most flexibility (if we hard code it like we do liveness probe users can't change it because its a boolean flag).
- I tested both the docker container and the helm chart locally but haven't written any tests as I don't see any tests for this in the repo, let me know if I've missed anything here. I've outline what I've tested below.

**Tests:**
All tests were run with a local build of the included Dockerfile, run against minikube.

values.yml
```
kopfArgs: []
```

```
kopfArgs:
  - '--verbose'
  - --log-format
  - json
```

```
kopfArgs:
  - '--verbose'
  - --log-format
  - json
```

```
kopfArgs: [ '--verbose ']
```

Addresses https://github.com/dask/dask-kubernetes/issues/641