### PR TITLE
Add services/status in the ClusterRole

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/serviceaccount.yaml
@@ -46,7 +46,7 @@ rules:
     verbs: ["*"]
 
   - apiGroups: [""]
-    resources: [services]
+    resources: [services, services/status]
     verbs: ["*"]
 
   - apiGroups: ["", events.k8s.io]


### PR DESCRIPTION
This PR adds the missing `services/status` role in the `ClusterRole` resource to avoid errors like the following:
```
User "system:serviceaccount:dask:dask-kubernetes-operator" cannot patch resource "services/status" in API group ""
```