### PR TITLE
Add cool down period for autoscaling to reduce thrashing

### DIFF
--- a/dask_kubernetes/operator/__init__.py
+++ b/dask_kubernetes/operator/__init__.py
@@ -1,5 +1,3 @@
-from .controller import *
-
 from .kubecluster import (
     KubeCluster,
     make_cluster_spec,

--- a/dask_kubernetes/operator/__init__.py
+++ b/dask_kubernetes/operator/__init__.py
@@ -1,3 +1,5 @@
+from .controller import *
+
 from .kubecluster import (
     KubeCluster,
     make_cluster_spec,

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -128,7 +128,8 @@ def test_adapt(kopf_runner, docker_image):
         ) as cluster:
             cluster.adapt(minimum=0, maximum=1)
             with Client(cluster) as client:
-                assert client.submit(lambda x: x + 1, 10).result() == 11
+                f = client.submit(lambda x: x + 1, 10)
+                assert f.result() == 11
 
             # Need to clean up the DaskAutoscaler object
             # See https://github.com/dask/dask-kubernetes/issues/546


### PR DESCRIPTION
This PR is part of a two part set (#649 is the companion PR) that smooths out the autoscaling logic to reduce thrashing and hopefully smooth out autoscaling actions.   I've duplicated some of the context in both PRs so in case there are different reviewers. 

We've been using the dask operator for some long running workloads and have noticed that the autoscaling logic can result in thrashing in some of our workloads.  When this happened our we either experienced:
- A cluster left in an inconsistent state (no workers but work to be done and no actions to scale up being performed)
- Workers being spun up only to spin down, resulting in excessive data transfers and loss of work when the data could not be transferred within the pod termination grace period.

The second PR fixes a race condition in the worker group auto scaling process that should ensure that rapid updates to a worker group's scale will result in a consistent state for the worker group (no excess or missing workers).  With these two PRs combined, we've seen much smoother autoscaling and haven't run into missing workers (we've been running this in production for a couple weeks).

Some call outs:
- I've kept these two PRs separate as they can operate fully independently and are easier to grok independently but I'm happy to combine them if you'd prefer.
- I'm not sure where to store the "cooldown until" timestamp.  I'm currently using an annotation but I'm not sure what the best practice / recommended way to store this internal state is.  Happy to update this based on your feedback.  I've considered:
  - Annotations - went with this as it was the simplest way to get a PR open for feedback
  - Managed fields - not sure of operators are can (or are intended to) control these
  - A dedicated field in the CRD - seems like these are meant to be set by consumers and not used for internal state
  - Some kind of "replicas last updated at" field on the worker group - basically same thoughts as the above regarding where to store in the worker group object but this has the added benefit of being potentially useful state for other actors in the operator
- There are no tests yet, I'm opening this now to get feedback on the implementation / structure before adding tests.
- The autoscaling smoothing logic is pretty simple right now: it maintains a cooldown for scaling up and a cooldown for scaling down, the cooldown for scaling up is shorter, allowing for more aggressive scale ups and more conservative scale downs.
- I've added a max cool down rate of 25% of cluster size.  In one of our runs the scheduler scaled down from 6 to 1 instances right as the work was wrapping up and we ended up losing 75% of our computed work in the shutdown.  In addition to a cooldown, this would make sure that clusters scale down gradually to allow data to be rebalanced / work to be completed.
- These autoscaling patterns aren't perfect but I've seen them used successfully many times and I think they'll be a solid improvement on the existing autoscaling system.
- Added some other bug fixes and improvements that resolves errors we were seeing running the autoscaler in prod (ie missing scheduler or slow to spin up scheduler was throwing exceptions)
- Autoscaler stands down when it doesn't need to update replicas (resolves TODO)
- I bumped the autoscaler timer interval to 30 seconds as I don't think 5 seconds is necessary with the cooldowns