### PR TITLE
Raise SchedulerStartupError exception on scheduler CrashLoopBackOff during cluster creation

### DIFF
--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -10,7 +10,9 @@ from tornado.iostream import StreamClosedError
 
 from distributed.core import rpc
 
-from .utils import check_dependency
+from dask_kubernetes.common.utils import check_dependency
+from dask_kubernetes.aiopykube.objects import Pod
+from dask_kubernetes.exceptions import CrashLoopBackOffError
 
 
 async def get_internal_address_for_scheduler_service(
@@ -191,23 +193,34 @@ async def get_scheduler_address(
         return address
 
 
-async def wait_for_scheduler(cluster_name, namespace):
-    async with kubernetes.client.api_client.ApiClient() as api_client:
-        api = kubernetes.client.CoreV1Api(api_client)
-        watch = kubernetes.watch.Watch()
-        async for event in watch.stream(
-            func=api.list_namespaced_pod,
-            namespace=namespace,
-            label_selector=f"dask.org/cluster-name={cluster_name},dask.org/component=scheduler",
-            timeout_seconds=60,
-        ):
-            if event["object"].status.conditions:
-                conditions = {
-                    c.type: c.status for c in event["object"].status.conditions
-                }
-                if "Ready" in conditions and conditions["Ready"] == "True":
-                    watch.stop()
-            await asyncio.sleep(0.1)
+async def wait_for_scheduler(api, cluster_name, namespace, timeout=None):
+    pod_start_time = None
+    while True:
+        pod = await Pod.objects(api, namespace=namespace).get_by_name(
+            cluster_name + "-scheduler"
+        )
+        phase = pod.obj["status"]["phase"]
+        if phase == "Running":
+            if not pod_start_time:
+                pod_start_time = time.time()
+            conditions = {
+                c["type"]: c["status"] for c in pod.obj["status"]["conditions"]
+            }
+            if "Ready" in conditions and conditions["Ready"] == "True":
+                return
+            if "containerStatuses" in pod.obj["status"]:
+                for container in pod.obj["status"]["containerStatuses"]:
+                    if (
+                        "waiting" in container["state"]
+                        and container["state"]["waiting"]["reason"]
+                        == "CrashLoopBackOff"
+                        and timeout
+                        and pod_start_time + timeout < time.time()
+                    ):
+                        raise CrashLoopBackOffError(
+                            f"Scheduler in CrashLoopBackOff for more than {timeout} seconds."
+                        )
+        await asyncio.sleep(0.25)
 
 
 async def wait_for_scheduler_comm(address):

--- a/dask_kubernetes/exceptions.py
+++ b/dask_kubernetes/exceptions.py
@@ -1,0 +1,2 @@
+class CrashLoopBackOffError(Exception):
+    """Cluster got stuck in CrashLoopBackOff."""

--- a/dask_kubernetes/exceptions.py
+++ b/dask_kubernetes/exceptions.py
@@ -1,2 +1,6 @@
 class CrashLoopBackOffError(Exception):
     """Cluster got stuck in CrashLoopBackOff."""
+
+
+class SchedulerStartupError(Exception):
+    """Scheduler failed to start."""

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -121,12 +121,13 @@ def test_cluster_without_operator(docker_image):
 
 
 def test_cluster_crashloopbackoff(kopf_runner, docker_image):
-    with pytest.raises(SchedulerStartupError, match="Scheduler failed to start"):
-        spec = make_cluster_spec(name="foo", n_workers=1)
-        spec["spec"]["scheduler"]["spec"]["containers"][0]["args"][
-            0
-        ] = "dask-schmeduler"
-        KubeCluster(custom_cluster_spec=spec, resource_timeout=1)
+    with kopf_runner:
+        with pytest.raises(SchedulerStartupError, match="Scheduler failed to start"):
+            spec = make_cluster_spec(name="foo", n_workers=1)
+            spec["spec"]["scheduler"]["spec"]["containers"][0]["args"][
+                0
+            ] = "dask-schmeduler"
+            KubeCluster(custom_cluster_spec=spec, resource_timeout=1)
 
 
 def test_adapt(kopf_runner, docker_image):


### PR DESCRIPTION
Fixes #655 

- Rewritten `wait_for_scheduler` to use `dask_kubernete.aiopykube`.
- Updated `resource_timeout` kwarg docstring to allow reuse in other places.
- Created some new exceptions.
- If the scheduler Pod enters a `CrashLoopBackOff` phase for more than `resource_timeout` we raise and clean up the cluster.
- The exception is caught when creating the cluster and reraised with the scheduler Pod logs.

```python
In [2]: from dask_kubernetes.operator import KubeCluster, make_cluster_spec
   ...: spec = make_cluster_spec(name="foo", n_workers= 1)
   ...: spec['spec']['scheduler']['spec']['containers'][0]['args'][0] = "dask-schmeduler"
   ...: cluster = KubeCluster(custom_cluster_spec=spec)
---------------------------------------------------------------------------
CrashLoopBackOffError                     Traceback (most recent call last)
~/Projects/dask/dask-kubernetes/dask_kubernetes/operator/kubecluster/kubecluster.py in _create_cluster(self)
    309             try:
--> 310                 await wait_for_scheduler(
    311                     self.k8s_api,

~/Projects/dask/dask-kubernetes/dask_kubernetes/common/networking.py in wait_for_scheduler(api, cluster_name, namespace, timeout)
    219                     ):
--> 220                         raise CrashLoopBackOffError(
    221                             f"Scheduler in CrashLoopBackOff for more than {timeout} seconds."

CrashLoopBackOffError: Scheduler in CrashLoopBackOff for more than 60 seconds.

The above exception was the direct cause of the following exception:

SchedulerStartupError                     Traceback (most recent call last)
<ipython-input-2-c1db1b252a30> in <module>
      2 spec = make_cluster_spec(name="foo", n_workers= 1)
      3 spec['spec']['scheduler']['spec']['containers'][0]['args'][0] = "dask-schmeduler"
----> 4 cluster = KubeCluster(custom_cluster_spec=spec)

~/Projects/dask/dask-kubernetes/dask_kubernetes/operator/kubecluster/kubecluster.py in __init__(self, name, namespace, image, n_workers, resources, env, worker_command, auth, port_forward_cluster_ip, create_mode, shutdown_on_close, resource_timeout, scheduler_service_type, custom_cluster_spec, scheduler_forward_port, **kwargs)
    233         if not self.asynchronous:
    234             self._loop_runner.start()
--> 235             self.sync(self._start)
    236 
    237     @property

~/Projects/dask/distributed/distributed/utils.py in sync(self, func, asynchronous, callback_timeout, *args, **kwargs)
    336             return future
    337         else:
--> 338             return sync(
    339                 self.loop, func, *args, callback_timeout=callback_timeout, **kwargs
    340             )

~/Projects/dask/distributed/distributed/utils.py in sync(loop, func, callback_timeout, *args, **kwargs)
    403     if error:
    404         typ, exc, tb = error
--> 405         raise exc.with_traceback(tb)
    406     else:
    407         return result

~/Projects/dask/distributed/distributed/utils.py in f()
    376                 future = asyncio.wait_for(future, callback_timeout)
    377             future = asyncio.ensure_future(future)
--> 378             result = yield future
    379         except Exception:
    380             error = sys.exc_info()

~/.local/lib/python3.8/site-packages/tornado/gen.py in run(self)
    760 
    761                     try:
--> 762                         value = future.result()
    763                     except Exception:
    764                         exc_info = sys.exc_info()

~/Projects/dask/dask-kubernetes/dask_kubernetes/operator/kubecluster/kubecluster.py in _start(self)
    256             )
    257         else:
--> 258             await self._create_cluster()
    259 
    260         await super()._start()

~/Projects/dask/dask-kubernetes/dask_kubernetes/operator/kubecluster/kubecluster.py in _create_cluster(self)
    317                 logs = await self._get_logs()
    318                 await self._close()
--> 319                 raise SchedulerStartupError(
    320                     "Scheduler failed to start.",
    321                     "Scheduler Pod logs:",

SchedulerStartupError: ('Scheduler failed to start.', 'Scheduler Pod logs:', "+ '[' '' ']'\n+ '[' '' == true ']'\n+ CONDA_BIN=/opt/conda/bin/conda\n+ '[' -e /opt/app/environment.yml ']'\n+ echo 'no environment.yml'\nno environment.yml\n+ '[' '' ']'\n+ '[' '' ']'\n+ exec dask-schmeduler --host 0.0.0.0\n/usr/bin/prepare.sh: line 37: exec: dask-schmeduler: not found\n")
```