### PR TITLE
Add the ability to install the operator controller into a single namespace

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -20,7 +20,8 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `serviceAccount.create` | Create a service account for the operator to use | `true` |
 | `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
 | `serviceAccount.name` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""` |
-| `rbac.create` | Create a cluster role needed by the operator and bind it to the service account | `true` |
+| `rbac.create` | Create a Role/ClusterRole needed by the operator and bind it to the service account | `true` |
+| `rbac.cluster` | Creates a ClusterRole if true, else create a namespaced Role | `true` |
 | `podAnnotations` | Extra annotations for the operator pod | `{}` |
 | `podSecurityContext` | Security context for the operator pod | `{}` |
 | `securityContext` | Security context for the operator container | `{}` |

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/clusterrolebinding.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.rbac.cluster }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/role.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/role.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.rbac.create .Values.rbac.cluster }}
+{{- if and .Values.rbac.create (not .Values.rbac.cluster) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}-role-cluster
+  name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}-role
 rules:
   # Framework: knowing which other operators are running (i.e. peering).
   - apiGroups: [kopf.dev]

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/rolebinding.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.rbac.create (not .Values.rbac.cluster) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dask_kubernetes_operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -13,7 +13,8 @@ serviceAccount:
   name: ""  # The name of the service account to use. If not set and create is true, a name is generated using the fullname template.
 
 rbac:
-  create: true # Create a cluster role needed by the operator and bind it to the service account
+  create: true # Create a Role/ClusterRole needed by the operator and bind it to the service account
+  cluster: true # Creates a ClusterRole if true, else create a namespaced Role
 
 podAnnotations: {}  # Extra annotations for the operator pod
 

--- a/doc/source/operator_installation.rst
+++ b/doc/source/operator_installation.rst
@@ -60,12 +60,12 @@ We can also check the operator pod is running:
 Single namespace
 ^^^^^^^^^^^^^^^^
 
-By default the controller is installed with a ``ClusterRole`` and watches all namespaced.
+By default the controller is installed with a ``ClusterRole`` and watches all namespaces.
 You can also just install it into a single namespace by setting the following options.
 
 .. code-block:: console
 
-    $ helm install -n my-namespace --generate-name dask/dask-kubernetes-operator --set rbac.cluster=false --set kopfArgs="{--namespace=my-namespace}"
+   $ helm install -n my-namespace --generate-name dask/dask-kubernetes-operator --set rbac.cluster=false --set kopfArgs="{--namespace=my-namespace}"
    NAME: dask-kubernetes-operator-1749875935
    NAMESPACE: my-namespace
    STATUS: deployed

--- a/doc/source/operator_installation.rst
+++ b/doc/source/operator_installation.rst
@@ -57,6 +57,23 @@ We can also check the operator pod is running:
     Please note that `Helm does not support updating or deleting CRDs. <https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations>`_ If updates
     are made to the CRD templates in future releases (to support future k8s releases, for example) you may have to manually update the CRDs or delete/reinstall the Dask Operator.
 
+Single namespace
+^^^^^^^^^^^^^^^^
+
+By default the controller is installed with a ``ClusterRole`` and watches all namespaced.
+You can also just install it into a single namespace by setting the following options.
+
+.. code-block:: console
+
+    $ helm install -n my-namespace --generate-name dask/dask-kubernetes-operator --set rbac.cluster=false --set kopfArgs="{--namespace=my-namespace}"
+   NAME: dask-kubernetes-operator-1749875935
+   NAMESPACE: my-namespace
+   STATUS: deployed
+   REVISION: 1
+   TEST SUITE: None
+   NOTES:
+   Operator has been installed successfully.
+
 Installing with Manifests
 -------------------------
 


### PR DESCRIPTION
Users can choose to set `rbac.cluster=false` to create a `Role` instead of a `ClusterRole` and `kopfArgs="{--namespace=my-namespace}"` to ensure the controller only watches that namespace.

```
$ helm install -n my-namespace --generate-name dask/dask-kubernetes-operator --set rbac.cluster=false --set kopfArgs="{--namespace=my-namespace}"
NAME: dask-kubernetes-operator-1749875935
NAMESPACE: my-namespace
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Operator has been installed successfully.
```