### PR TITLE
Add Jupyter example to customizing cluster section

### DIFF
--- a/doc/source/operator_kubecluster.rst
+++ b/doc/source/operator_kubecluster.rst
@@ -129,7 +129,7 @@ You could also have the scheduler run a Jupyter server. With this configuration 
 
    from dask_kubernetes.operator import KubeCluster, make_cluster_spec
 
-   spec = make_cluster_spec(name="jupyter-example", n_workers=2, env={"EXTRA_PIP_PACKAGES": "jupyterlab"})
+   config = make_cluster_spec(name="jupyter-example", n_workers=2, env={"EXTRA_PIP_PACKAGES": "jupyterlab"})
    config["spec"]["scheduler"]["spec"]["containers"][0]["args"].append("--jupyter")
 
    cluster = KubeCluster(custom_cluster_spec=spec)

--- a/doc/source/operator_kubecluster.rst
+++ b/doc/source/operator_kubecluster.rst
@@ -123,6 +123,17 @@ You can also modify the spec before passing it to ``KubeCluster``, for example i
 
    cluster = KubeCluster(custom_cluster_spec=spec)
 
+You could also have the scheduler run a Jupyter server. With this configuration you can access a Jupyter server via the Dask dashboard.
+
+.. code-block:: python
+
+   from dask_kubernetes.operator import KubeCluster, make_cluster_spec
+
+   spec = make_cluster_spec(name="jupyter-example", n_workers=2, env={"EXTRA_PIP_PACKAGES": "jupyterlab"})
+   config["spec"]["scheduler"]["spec"]["containers"][0]["args"].append("--jupyter")
+
+   cluster = KubeCluster(custom_cluster_spec=spec)
+
 The ``cluster.add_worker_group()`` method also supports passing a ``custom_spec`` keyword argument which can be generated with :func:`make_worker_spec`.
 
 .. code-block:: python

--- a/doc/source/operator_kubecluster.rst
+++ b/doc/source/operator_kubecluster.rst
@@ -129,8 +129,8 @@ You could also have the scheduler run a Jupyter server. With this configuration 
 
    from dask_kubernetes.operator import KubeCluster, make_cluster_spec
 
-   config = make_cluster_spec(name="jupyter-example", n_workers=2, env={"EXTRA_PIP_PACKAGES": "jupyterlab"})
-   config["spec"]["scheduler"]["spec"]["containers"][0]["args"].append("--jupyter")
+   spec = make_cluster_spec(name="jupyter-example", n_workers=2, env={"EXTRA_PIP_PACKAGES": "jupyterlab"})
+   spec["spec"]["scheduler"]["spec"]["containers"][0]["args"].append("--jupyter")
 
    cluster = KubeCluster(custom_cluster_spec=spec)
 


### PR DESCRIPTION
You can get the Dask Scheduler to run Jupyter on the same port as the Dashboard. Instead of navigating to `/status` you can open `/jupyter/lab`. Adding a little example of doing this to the docs here.

```python
from dask_kubernetes.operator import KubeCluster, make_cluster_spec

spec = make_cluster_spec(name="jupyter-example", n_workers=2, env={"EXTRA_PIP_PACKAGES": "jupyterlab"})
spec["spec"]["scheduler"]["spec"]["containers"][0]["args"].append("--jupyter")

cluster = KubeCluster(custom_cluster_spec=spec)
```