### PR TITLE
Auto shutdown idle clusters

### DIFF
--- a/dask_kubernetes/operator/customresources/templates.yaml
+++ b/dask_kubernetes/operator/customresources/templates.yaml
@@ -43,6 +43,10 @@ definitions:
         - scheduler
         - worker
         properties:
+          autoCleanupTimeout:
+            type: integer
+            description: Delete cluster if scheduler is idle for longer than this timeout. Set to 0 to never auto cleanup.
+            default: 0
           scheduler:
             $ref: 'python://dask_kubernetes/operator/customresources/templates.yaml#/definitions/dask.k8s.api.v1.DaskScheduler'
           worker:

--- a/dask_kubernetes/operator/customresources/templates.yaml
+++ b/dask_kubernetes/operator/customresources/templates.yaml
@@ -43,7 +43,7 @@ definitions:
         - scheduler
         - worker
         properties:
-          autoCleanupTimeout:
+          idleTimeout:
             type: integer
             description: Delete cluster if scheduler is idle for longer than this timeout. Set to 0 to never auto cleanup.
             default: 0

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
@@ -19,7 +19,7 @@ spec:
         properties:
           spec:
             properties:
-              autoCleanupTimeout:
+              idleTimeout:
                 default: 0
                 type: integer
               scheduler:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
@@ -19,6 +19,9 @@ spec:
         properties:
           spec:
             properties:
+              autoCleanupTimeout:
+                default: 0
+                type: integer
               scheduler:
                 properties:
                   service:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
@@ -29,6 +29,9 @@ spec:
                 properties:
                   spec:
                     properties:
+                      autoCleanupTimeout:
+                        default: 0
+                        type: integer
                       scheduler:
                         properties:
                           service:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
@@ -29,7 +29,7 @@ spec:
                 properties:
                   spec:
                     properties:
-                      autoCleanupTimeout:
+                      idleTimeout:
                         default: 0
                         type: integer
                       scheduler:

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -727,7 +727,7 @@ class KubeCluster(Cluster):
         """Delete the dask cluster"""
         return self.sync(self._close, timeout=timeout)
 
-    async def _close(self, timeout=None):
+    async def _close(self, timeout=3600):
         await super()._close()
         if self.shutdown_on_close:
             async with kubernetes.client.api_client.ApiClient() as api_client:

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -893,7 +893,7 @@ def make_cluster_spec(
         "kind": "DaskCluster",
         "metadata": {"name": name},
         "spec": {
-            "autoCleanupTimeout": idle_timeout,
+            "idleTimeout": idle_timeout,
             "worker": make_worker_spec(
                 env=env,
                 resources=resources,

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -102,6 +102,9 @@ class KubeCluster(Cluster):
     shutdown_on_close: bool (optional)
         Whether or not to delete the cluster resource when this object is closed.
         Defaults to ``True`` when creating a cluster and ``False`` when connecting to an existing one.
+    idle_timeout: int (optional)
+        If set Kubernetes will delete the cluster automatically if the scheduler is idle for longer than
+        this timeout in seconds.
     resource_timeout: int (optional)
         Time in seconds to wait for Kubernetes resources to enter their expected state.
         Example: If the ``DaskCluster`` resource that gets created isn't moved into a known ``status.phase``
@@ -170,6 +173,7 @@ class KubeCluster(Cluster):
         port_forward_cluster_ip=None,
         create_mode=None,
         shutdown_on_close=None,
+        idle_timeout=None,
         resource_timeout=None,
         scheduler_service_type=None,
         custom_cluster_spec=None,
@@ -219,6 +223,9 @@ class KubeCluster(Cluster):
         )
         self.scheduler_forward_port = dask.config.get(
             "kubernetes.scheduler-forward-port", override_with=scheduler_forward_port
+        )
+        self.idle_timeout = dask.config.get(
+            "kubernetes.idle-timeout", override_with=idle_timeout
         )
 
         if self._custom_cluster_spec:
@@ -310,6 +317,7 @@ class KubeCluster(Cluster):
                     n_workers=self.n_workers,
                     image=self.image,
                     scheduler_service_type=self.scheduler_service_type,
+                    idle_timeout=self.idle_timeout,
                 )
             else:
                 data = self._custom_cluster_spec
@@ -857,6 +865,7 @@ def make_cluster_spec(
     env=None,
     worker_command="dask-worker",
     scheduler_service_type="ClusterIP",
+    idle_timeout=0,
 ):
     """Generate a ``DaskCluster`` kubernetes resource.
 
@@ -876,12 +885,15 @@ def make_cluster_spec(
         Environment variables to set on scheduler and workers
     worker_command: str (optional)
         Worker command to use when starting the workers
+    idle_timeout: int (optional)
+        Timeout to cleanup idle cluster
     """
     return {
         "apiVersion": "kubernetes.dask.org/v1",
         "kind": "DaskCluster",
         "metadata": {"name": name},
         "spec": {
+            "autoCleanupTimeout": idle_timeout,
             "worker": make_worker_spec(
                 env=env,
                 resources=resources,

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -127,7 +127,7 @@ def test_cluster_crashloopbackoff(kopf_runner, docker_image):
             spec["spec"]["scheduler"]["spec"]["containers"][0]["args"][
                 0
             ] = "dask-schmeduler"
-            KubeCluster(custom_cluster_spec=spec, resource_timeout=1)
+            KubeCluster(custom_cluster_spec=spec, resource_timeout=1, idle_timeout=2)
 
 
 def test_adapt(kopf_runner, docker_image):

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -123,7 +123,7 @@ def test_cluster_without_operator(docker_image):
 def test_cluster_crashloopbackoff(kopf_runner, docker_image):
     with kopf_runner:
         with pytest.raises(SchedulerStartupError, match="Scheduler failed to start"):
-            spec = make_cluster_spec(name="foo", n_workers=1)
+            spec = make_cluster_spec(name="crashloopbackoff", n_workers=1)
             spec["spec"]["scheduler"]["spec"]["containers"][0]["args"][
                 0
             ] = "dask-schmeduler"


### PR DESCRIPTION
Adds an optional `idleTimeout ` config option to the `DaskCluster` spec which instructs the controller to delete idle clusters after a certain timeout.

```yaml
apiVersion: kubernetes.dask.org/v1
kind: DaskCluster
metadata:
  name: foo
spec:
  idleTimeout: 60
  scheduler:
    ...
  worker:
    ...
```

Exposed via the Python API as the `idle_timeout` kwarg.

```python
from dask_kubernetes.operator import KubeCluster
cluster = KubeCluster(name="foo", n_workers=1, idle_timeout=60)
```

In the above examples if the scheduler is idle for more than 60 seconds the `DaskCluster` resource will be deleted automatically by the controller. This is regardless of whether the `KubeCluster` object still exists in Python.

~There is a challenge with this implementation which means I don't want to merge it in its current state~ Solved with https://github.com/dask/distributed/pull/7642

Closes #667 