### PR TITLE
Update LICENSE for 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, Yuvi Panda, Anaconda Inc
+Copyright (c) 2023, Dask Developers, Yuvi Panda, Anaconda Inc, NVIDIA
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Updated the license year to 2023 and added "Dask Developers" and "NVIDIA" to the list of copyright holders.

xref https://github.com/dask/community/issues/313

cc @yuvipanda 