### PR TITLE
Remove deprecated dask.compatibility.entry_points

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import aiohttp
 import kopf
 import kubernetes_asyncio as kubernetes
-from dask.compatibility import entry_points
+from importlib_metadata import entry_points
 from kubernetes_asyncio.client import ApiException
 
 from dask_kubernetes.common.auth import ClusterAuth


### PR DESCRIPTION
`dask.compatibility.entry_points` was deprecated in https://github.com/dask/dask/pull/10113. The whole of `dask.compatibility` is also [not intended to be used outside of `dask`](https://github.com/dask/dask/pull/10113#pullrequestreview-1354876683). Updating here to use `importlib_metadata` directly.