### PR TITLE
Expose the worker dashboard consistently on a port

### DIFF
--- a/dask_kubernetes/operator/controller/tests/resources/failedjob.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/failedjob.yaml
@@ -28,6 +28,13 @@ spec:
                 - dask-worker
                 - --name
                 - $(DASK_WORKER_NAME)
+                - --dashboard
+                - --dashboard-address
+                - "8788"
+              ports:
+                - name: http-dashboard
+                  containerPort: 8787
+                  protocol: TCP
       scheduler:
         spec:
           containers:

--- a/dask_kubernetes/operator/controller/tests/resources/failedjob.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/failedjob.yaml
@@ -33,7 +33,7 @@ spec:
                 - "8788"
               ports:
                 - name: http-dashboard
-                  containerPort: 8787
+                  containerPort: 8788
                   protocol: TCP
       scheduler:
         spec:

--- a/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
@@ -26,7 +26,7 @@ spec:
             - "8788"
           ports:
             - name: http-dashboard
-              containerPort: 8787
+              containerPort: 8788
               protocol: TCP
           env:
             - name: WORKER_ENV

--- a/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplecluster.yaml
@@ -21,6 +21,13 @@ spec:
             - dask-worker
             - --name
             - $(DASK_WORKER_NAME)
+            - --dashboard
+            - --dashboard-address
+            - "8788"
+          ports:
+            - name: http-dashboard
+              containerPort: 8787
+              protocol: TCP
           env:
             - name: WORKER_ENV
               value: hello-world # We don't test the value, just the name

--- a/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
@@ -37,7 +37,7 @@ spec:
                 - "8788"
               ports:
                 - name: http-dashboard
-                  containerPort: 8787
+                  containerPort: 8788
                   protocol: TCP
               env:
                 - name: WORKER_ENV

--- a/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simplejob.yaml
@@ -32,6 +32,13 @@ spec:
                 - dask-worker
                 - --name
                 - $(DASK_WORKER_NAME)
+                - --dashboard
+                - --dashboard-address
+                - "8788"
+              ports:
+                - name: http-dashboard
+                  containerPort: 8787
+                  protocol: TCP
               env:
                 - name: WORKER_ENV
                   value: hello-world # We dont test the value, just the name

--- a/dask_kubernetes/operator/controller/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simpleworkergroup.yaml
@@ -19,7 +19,7 @@ spec:
             - "8788"
           ports:
             - name: http-dashboard
-              containerPort: 8787
+              containerPort: 8788
               protocol: TCP
           env:
             - name: WORKER_ENV

--- a/dask_kubernetes/operator/controller/tests/resources/simpleworkergroup.yaml
+++ b/dask_kubernetes/operator/controller/tests/resources/simpleworkergroup.yaml
@@ -14,6 +14,13 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - dask-worker
+            - --dashboard
+            - --dashboard-address
+            - "8788"
+          ports:
+            - name: http-dashboard
+              containerPort: 8787
+              protocol: TCP
           env:
             - name: WORKER_ENV
               value: hello-world # We dont test the value, just the name

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -916,7 +916,13 @@ def make_worker_spec(
     if isinstance(worker_command, str):
         worker_command = worker_command.split(" ")
 
-    args = worker_command + ["--name", "$(DASK_WORKER_NAME)"]
+    args = worker_command + [
+        "--name",
+        "$(DASK_WORKER_NAME)",
+        "--dashboard",
+        "--dashboard-address",
+        "8788",
+    ]
 
     return {
         "replicas": n_workers,
@@ -928,6 +934,13 @@ def make_worker_spec(
                     "args": args,
                     "env": env,
                     "resources": resources,
+                    "ports": [
+                        {
+                            "name": "http-dashboard",
+                            "containerPort": 8788,
+                            "protocol": "TCP",
+                        },
+                    ],
                 }
             ]
         },

--- a/doc/source/operator_resources.rst
+++ b/doc/source/operator_resources.rst
@@ -69,7 +69,7 @@ Let's create an example called ``cluster.yaml`` with the following configuration
               - "8788"
             ports:
               - name: http-dashboard
-                containerPort: 8787
+                containerPort: 8788
                 protocol: TCP
       scheduler:
         spec:
@@ -276,7 +276,7 @@ Let's create an example called ``highmemworkers.yaml`` with the following config
               - "8788"
             ports:
               - name: http-dashboard
-                containerPort: 8787
+                containerPort: 8788
                 protocol: TCP
 
 The main thing we need to ensure is that the ``cluster`` option matches the name of the cluster we created earlier. This will cause
@@ -382,6 +382,13 @@ Let's create an example called ``job.yaml`` with the following configuration:
                     - dask-worker
                     - --name
                     - $(DASK_WORKER_NAME)
+                    - --dashboard
+                    - --dashboard-address
+                    - "8788"
+                  ports:
+                    - name: http-dashboard
+                      containerPort: 8788
+                      protocol: TCP
                   env:
                     - name: WORKER_ENV
                       value: hello-world # We dont test the value, just the name

--- a/doc/source/operator_resources.rst
+++ b/doc/source/operator_resources.rst
@@ -64,6 +64,13 @@ Let's create an example called ``cluster.yaml`` with the following configuration
               - dask-worker
               - --name
               - $(DASK_WORKER_NAME)
+              - --dashboard
+              - --dashboard-address
+              - "8788"
+            ports:
+              - name: http-dashboard
+                containerPort: 8787
+                protocol: TCP
       scheduler:
         spec:
           containers:
@@ -264,6 +271,13 @@ Let's create an example called ``highmemworkers.yaml`` with the following config
               - $(DASK_WORKER_NAME)
               - --resources
               - MEMORY=32e9
+              - --dashboard
+              - --dashboard-address
+              - "8788"
+            ports:
+              - name: http-dashboard
+                containerPort: 8787
+                protocol: TCP
 
 The main thing we need to ensure is that the ``cluster`` option matches the name of the cluster we created earlier. This will cause
 the workers to join that cluster.


### PR DESCRIPTION
Updated the worker pod spec generation in `dask_kubernetes.operator.KubeCluster` to put the worker dashboard on port `8788` and create a port called `http-dashboard` on the Pod. Also updated all the YAML docs examples and test manifests to do the same.

xref #687 as this is required for a `PodMonitor` to scrape prometheus metrics from a worker