### PR TITLE
Add more additional printer columns to resources

### DIFF
--- a/dask_kubernetes/operator/customresources/daskautoscaler.yaml
+++ b/dask_kubernetes/operator/customresources/daskautoscaler.yaml
@@ -13,6 +13,20 @@ spec:
     - name: v1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - name: Cluster
+          type: string
+          description: Cluster to autoscale
+          jsonPath: .spec.cluster
+        - name: Minimum
+          type: integer
+          jsonPath: .spec.minimum
+        - name: Maximum
+          type: integer
+          jsonPath: .spec.maximum
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           type: object

--- a/dask_kubernetes/operator/customresources/daskcluster.yaml
+++ b/dask_kubernetes/operator/customresources/daskcluster.yaml
@@ -16,6 +16,14 @@ spec:
     - name: v1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - name: Workers
+          type: integer
+          description: The number of desired worker Pods
+          jsonPath: .spec.worker.replicas
+        - name: Status
+          type: string
+          jsonPath: .status.phase
       schema:
         openAPIV3Schema:
           $ref: 'python://dask_kubernetes/operator/customresources/templates.yaml#/definitions/dask.k8s.api.v1.DaskCluster'

--- a/dask_kubernetes/operator/customresources/daskcluster.yaml
+++ b/dask_kubernetes/operator/customresources/daskcluster.yaml
@@ -24,10 +24,12 @@ spec:
         - name: Status
           type: string
           jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           $ref: 'python://dask_kubernetes/operator/customresources/templates.yaml#/definitions/dask.k8s.api.v1.DaskCluster'
-
       subresources:
         scale:
           specReplicasPath: .spec.worker.replicas

--- a/dask_kubernetes/operator/customresources/daskjob.yaml
+++ b/dask_kubernetes/operator/customresources/daskjob.yaml
@@ -15,6 +15,16 @@ spec:
     - name: v1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - name: Status
+          type: string
+          jsonPath: .status.jobStatus
+        - name: Number Of Workers
+          type: integer
+          jsonPath: .spec.cluster.spec.worker.replicas
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           type: object
@@ -57,10 +67,3 @@ spec:
                   $ref: 'python://dask_kubernetes/operator/customresources/templates.yaml#/definitions/dask.k8s.api.v1.DaskCluster'
       subresources:
         status: {}
-      additionalPrinterColumns:
-        - jsonPath: .status.jobStatus
-          name: Status
-          type: string
-        - jsonPath: .spec.cluster.spec.worker.replicas
-          name: Number Of Workers
-          type: integer

--- a/dask_kubernetes/operator/customresources/daskworkergroup.yaml
+++ b/dask_kubernetes/operator/customresources/daskworkergroup.yaml
@@ -15,6 +15,11 @@ spec:
     - name: v1
       served: true
       storage: true
+      additionalPrinterColumns:
+        - name: Workers
+          type: integer
+          description: The number of desired worker Pods
+          jsonPath: .spec.worker.replicas
       schema:
         openAPIV3Schema:
           type: object

--- a/dask_kubernetes/operator/customresources/daskworkergroup.yaml
+++ b/dask_kubernetes/operator/customresources/daskworkergroup.yaml
@@ -20,6 +20,9 @@ spec:
           type: integer
           description: The number of desired worker Pods
           jsonPath: .spec.worker.replicas
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           type: object

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskautoscaler.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskautoscaler.yaml
@@ -10,7 +10,21 @@ spec:
     singular: daskautoscaler
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Cluster to autoscale
+      jsonPath: .spec.cluster
+      name: Cluster
+      type: string
+    - jsonPath: .spec.minimum
+      name: Minimum
+      type: integer
+    - jsonPath: .spec.maximum
+      name: Maximum
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
@@ -13,7 +13,15 @@ spec:
     singular: daskcluster
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The number of desired worker Pods
+      jsonPath: .spec.worker.replicas
+      name: Workers
+      type: integer
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         properties:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskcluster.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskjob.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .spec.cluster.spec.worker.replicas
       name: Number Of Workers
       type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskworkergroup.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskworkergroup.yaml
@@ -17,6 +17,9 @@ spec:
       jsonPath: .spec.worker.replicas
       name: Workers
       type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskworkergroup.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/crds/daskworkergroup.yaml
@@ -12,7 +12,12 @@ spec:
     singular: daskworkergroup
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The number of desired worker Pods
+      jsonPath: .spec.worker.replicas
+      name: Workers
+      type: integer
+    name: v1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
Some minor changes to show more useful information about `DaskCluster` and `DaskWorkerGroup` resources when listing with `kubectl`.

```python
# Create a demo cluster
from dask_kubernetes.operator import KubeCluster
cluster = KubeCluster(name="foo", n_workers=5)
cluster.adapt(minimum=5, maximum=10)
```

```console
$ kubectl get daskclusters
NAME   WORKERS   STATUS    AGE
foo    5         Running   102s

$ kubectl get daskworkergroups
NAME          WORKERS   AGE
foo-default   5         102s

$ kubectl get daskautoscalers
NAME   CLUSTER   MINIMUM   MAXIMUM   AGE
foo    foo       5         10        102s
```