### PR TITLE
Add input validations for `resources` and `n_workers`

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -230,6 +230,19 @@ class KubeCluster(Cluster):
         if isinstance(self.worker_command, str):
             self.worker_command = self.worker_command.split(" ")
 
+        if self.n_workers is not None and not isinstance(self.n_workers, int):
+            raise TypeError(f"n_workers must be an integer, got {type(self.n_workers)}")
+
+        try:
+            # Validate input resources
+            assert "limits" in resources
+            assert isinstance(resources["limits"], dict)
+            assert "CPU" in resources["limits"]
+            assert isinstance(resources["limits"]["CPU"], str)
+        except AssertionError:
+            print("Invalid resource limits format")
+            raise
+
         name = name.format(
             user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ
         )

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -153,3 +153,22 @@ def test_custom_spec(kopf_runner, docker_image):
         with KubeCluster(custom_cluster_spec=spec, n_workers=1) as cluster:
             with Client(cluster) as client:
                 assert client.submit(lambda x: x + 1, 10).result() == 11
+
+
+def test_typo_resource_limits(kopf_runner):
+    with kopf_runner:
+        with pytest.raises(AssertionError):
+            KubeCluster(
+                name="foo",
+                resources={
+                    "limit": {  # <-- Typo, should be `limits`
+                        "CPU": "1",
+                    },
+                },
+            )
+
+
+def test_for_integer_n_workers(kopf_runner):
+    with kopf_runner:
+        with pytest.raises(TypeError, match="n_workers must be an integer"):
+            KubeCluster(name="foo", n_workers="1")


### PR DESCRIPTION
Fixes: https://github.com/dask/dask-kubernetes/issues/650