### PR TITLE
Add correct handling for invalid `KubeCluster` kwargs

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -230,6 +230,19 @@ class KubeCluster(Cluster):
         if isinstance(self.worker_command, str):
             self.worker_command = self.worker_command.split(" ")
 
+        if self.n_workers is not None and not isinstance(self.n_workers, int):
+            raise TypeError(f"n_workers must be an integer, got {type(self.n_workers)}")
+
+        try:
+            # Validate input resources
+            assert "limits" in resources
+            assert isinstance(resources["limits"], dict)
+            assert "CPU" in resources["limits"]
+            assert isinstance(resources["limits"]["CPU"], str)
+        except AssertionError:
+            print("Invalid resource limits format")
+            raise
+
         name = name.format(
             user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ
         )

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -233,15 +233,18 @@ class KubeCluster(Cluster):
         try:
             # Validate `resources` param is a dictionary whose
             # keys must either be 'limits' or 'requests'
-            assert isinstance(self.resources, dict)
-
+            assert isinstance(
+                self.resources, dict
+            ), f"resources must be dict type, found {type(resources)}"
             for field in self.resources:
                 if field in ("limits", "requests"):
-                    assert isinstance(self.resources[field], dict)
+                    assert isinstance(
+                        self.resources[field], dict
+                    ), f"key of '{field}' must be dict type"
                 else:
-                    raise ValueError(f"Unknown field '{field}' in resources")
-        except TypeError as e:
-            raise TypeError(f"invalid '{type(resources)}' for resources type") from e
+                    raise ValueError(f"resources has unknown field '{field}'")
+        except AssertionError as e:
+            raise e
 
         name = name.format(
             user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -243,9 +243,8 @@ class KubeCluster(Cluster):
                     assert isinstance(self.resources[field], dict)
                 else:
                     raise ValueError(f"Unknown field '{field}' in resources")
-        except TypeError:
-            print(f"invalid '{type(resources)}' for resources type")
-            raise
+        except TypeError as e:
+            raise TypeError(f"invalid '{type(resources)}' for resources type") from e
 
         name = name.format(
             user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -244,7 +244,7 @@ class KubeCluster(Cluster):
                 else:
                     raise ValueError(f"resources has unknown field '{field}'")
         except AssertionError as e:
-            raise e
+            raise TypeError from e
 
         name = name.format(
             user=getpass.getuser(), uuid=str(uuid.uuid4())[:10], **os.environ

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -234,13 +234,17 @@ class KubeCluster(Cluster):
             raise TypeError(f"n_workers must be an integer, got {type(self.n_workers)}")
 
         try:
-            # Validate input resources
-            assert "limits" in resources
-            assert isinstance(resources["limits"], dict)
-            assert "CPU" in resources["limits"]
-            assert isinstance(resources["limits"]["CPU"], str)
-        except AssertionError:
-            print("Invalid resource limits format")
+            # Validate `resources` param is a dictionary whose
+            # keys must either be 'limits' or 'requests'
+            assert isinstance(resources, dict)
+
+            for field in ("limits", "requests"):
+                if field in resources:
+                    assert isinstance(field, dict)
+                else:
+                    print("fields must either be 'limits' or 'requests'")
+        except ValueError:
+            print("Invalid resources field format")
             raise
 
         name = name.format(

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -339,11 +339,16 @@ class KubeCluster(Cluster):
                     body=data,
                 )
             except kubernetes.client.ApiException as e:
-                raise RuntimeError(
-                    "Failed to create DaskCluster resource. "
-                    "Are the Dask Custom Resource Definitions installed? "
-                    "https://kubernetes.dask.org/en/latest/operator.html#installing-the-operator"
-                ) from e
+                if e.status == 422:
+                    # unsure how to extract the value of the invalid kwarg
+                    # from the API response to populate below
+                    raise ValueError("unable to process invalid kwarg(s)")
+                elif e.status == 404:
+                    raise RuntimeError(
+                        "Failed to create DaskCluster resource. "
+                        "Are the Dask Custom Resource Definitions installed? "
+                        "https://kubernetes.dask.org/en/latest/operator.html#installing-the-operator"
+                    ) from e
 
             try:
                 self._log("Waiting for controller to action cluster")

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -244,7 +244,7 @@ class KubeCluster(Cluster):
                 else:
                     raise ValueError(f"Unknown field '{field}' in resources")
         except TypeError:
-            print(f"resources must be dict, got '{type(resources)}' type")
+            print(f"invalid '{type(resources)}' for resources type")
             raise
 
         name = name.format(

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -338,7 +338,7 @@ class KubeCluster(Cluster):
             except kubernetes.client.ApiException as e:
                 if e.status == 404:
                     raise RuntimeError(
-                        "Failed to create DaskCluster resource. "
+                        "Failed to create DaskCluster resource."
                         "Are the Dask Custom Resource Definitions installed? "
                         "https://kubernetes.dask.org/en/latest/operator.html#installing-the-operator"
                     ) from e

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -230,9 +230,6 @@ class KubeCluster(Cluster):
         if isinstance(self.worker_command, str):
             self.worker_command = self.worker_command.split(" ")
 
-        if self.n_workers is not None and not isinstance(self.n_workers, int):
-            raise TypeError(f"n_workers must be an integer, got {type(self.n_workers)}")
-
         try:
             # Validate `resources` param is a dictionary whose
             # keys must either be 'limits' or 'requests'
@@ -340,9 +337,8 @@ class KubeCluster(Cluster):
                 )
             except kubernetes.client.ApiException as e:
                 if e.status == 422:
-                    # unsure how to extract the value of the invalid kwarg
-                    # from the API response to populate below
-                    raise ValueError("unable to process invalid kwarg(s)")
+                    # unsure how to extract the invalid kwarg from the API response
+                    raise ValueError("unable to process invalid kwargs")
                 elif e.status == 404:
                     raise RuntimeError(
                         "Failed to create DaskCluster resource. "

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -238,13 +238,13 @@ class KubeCluster(Cluster):
             # keys must either be 'limits' or 'requests'
             assert isinstance(self.resources, dict)
 
-            for field in ("limits", "requests"):
-                if field in self.resources:
+            for field in self.resources:
+                if field in ("limits", "requests"):
                     assert isinstance(self.resources[field], dict)
-                elif field not in self.resources:
+                else:
                     raise ValueError(f"Unknown field '{field}' in resources")
         except TypeError:
-            print("Invalid resources type")
+            print(f"resources must be dict, got '{type(resources)}' type")
             raise
 
         name = name.format(

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -236,15 +236,15 @@ class KubeCluster(Cluster):
         try:
             # Validate `resources` param is a dictionary whose
             # keys must either be 'limits' or 'requests'
-            assert isinstance(resources, dict)
+            assert isinstance(self.resources, dict)
 
             for field in ("limits", "requests"):
-                if field in resources:
-                    assert isinstance(field, dict)
-                else:
-                    print("fields must either be 'limits' or 'requests'")
-        except ValueError:
-            print("Invalid resources field format")
+                if field in self.resources:
+                    assert isinstance(self.resources[field], dict)
+                elif field not in self.resources:
+                    raise ValueError(f"Unknown field '{field}' in resources")
+        except TypeError:
+            print("Invalid resources type")
             raise
 
         name = name.format(

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -336,15 +336,14 @@ class KubeCluster(Cluster):
                     body=data,
                 )
             except kubernetes.client.ApiException as e:
-                if e.status == 422:
-                    # unsure how to extract the invalid kwarg from the API response
-                    raise ValueError("unable to process invalid kwargs")
-                elif e.status == 404:
+                if e.status == 404:
                     raise RuntimeError(
                         "Failed to create DaskCluster resource. "
                         "Are the Dask Custom Resource Definitions installed? "
                         "https://kubernetes.dask.org/en/latest/operator.html#installing-the-operator"
                     ) from e
+                else:
+                    raise e
 
             try:
                 self._log("Waiting for controller to action cluster")

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -153,3 +153,22 @@ def test_custom_spec(kopf_runner, docker_image):
         with KubeCluster(custom_cluster_spec=spec, n_workers=1) as cluster:
             with Client(cluster) as client:
                 assert client.submit(lambda x: x + 1, 10).result() == 11
+
+
+def test_typo_resource_limits(kopf_runner):
+    with kopf_runner:
+        with pytest.raises(AssertionError):
+            KubeCluster(
+                name="foo",
+                resources={
+                    "limit": {  # <-- Typo, should be `limits`
+                        "CPU": "1",
+                    },
+                },
+            )
+
+
+def test_for_integer_n_workers(kopf_runner):
+    with kopf_runner:
+        with pytest.raises(TypeError, match="n_workers must be an integer"):
+            KubeCluster(name="foo", n_workers="1")

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -168,7 +168,7 @@ def test_typo_resource_limits(kopf_runner):
             )
 
 
-def test_handling_for_invalid_kwargs(kopf_runner):
+def test_handling_invalid_kwargs(kopf_runner):
     with kopf_runner:
         with pytest.raises(ValueError, match="unable to process invalid kwargs"):
             KubeCluster(name="foo", n_workers="1")

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -155,6 +155,12 @@ def test_custom_spec(kopf_runner, docker_image):
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
+def test_for_integer_n_workers(kopf_runner):
+    with kopf_runner:
+        with pytest.raises(TypeError, match="n_workers must be an integer"):
+            KubeCluster(name="foo", n_workers="1")
+
+
 def test_typo_resource_limits(kopf_runner):
     with kopf_runner:
         with pytest.raises(AssertionError):
@@ -166,9 +172,3 @@ def test_typo_resource_limits(kopf_runner):
                     },
                 },
             )
-
-
-def test_for_integer_n_workers(kopf_runner):
-    with kopf_runner:
-        with pytest.raises(TypeError, match="n_workers must be an integer"):
-            KubeCluster(name="foo", n_workers="1")

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -1,4 +1,5 @@
 import pytest
+import kubernetes_asyncio as kubernetes
 
 from dask.distributed import Client
 from distributed.utils import TimeoutError
@@ -170,5 +171,5 @@ def test_typo_resource_limits(kopf_runner):
 
 def test_handling_invalid_kwargs(kopf_runner):
     with kopf_runner:
-        with pytest.raises(ValueError, match="unable to process invalid kwargs"):
+        with pytest.raises(kubernetes.client.ApiException):
             KubeCluster(name="foo", n_workers="1")

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -1,8 +1,6 @@
 import pytest
 import kubernetes_asyncio as kubernetes
 
-from kubernetes_asyncio.client.api_client import ApiClient
-
 from dask.distributed import Client
 from distributed.utils import TimeoutError
 
@@ -175,20 +173,3 @@ def test_invalid_kwargs_exception(kopf_runner):
     with kopf_runner:
         with pytest.raises(kubernetes.client.ApiException):
             KubeCluster(name="foo", n_workers="1")
-
-
-def test_missing_custom_resources_definition(kopf_runner):
-
-    with kopf_runner:
-        with pytest.raises(
-            RuntimeError, match="Failed to create DaskCluster resource."
-        ):
-            api_client = ApiClient()
-            custom_objects_api = kubernetes.client.CustomObjectsApi(api_client)
-            custom_objects_api.create_namespaced_custom_object(
-                group="kubernetes.dask.org",
-                version="v1",
-                plural="daskclusters",
-                namespace="simple",
-                body="",
-            )

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -155,7 +155,7 @@ def test_custom_spec(kopf_runner, docker_image):
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_for_integer_n_workers(kopf_runner):
+def test_for_noninteger_n_workers(kopf_runner):
     with kopf_runner:
         with pytest.raises(TypeError, match="n_workers must be an integer"):
             KubeCluster(name="foo", n_workers="1")
@@ -163,7 +163,7 @@ def test_for_integer_n_workers(kopf_runner):
 
 def test_typo_resource_limits(kopf_runner):
     with kopf_runner:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             KubeCluster(
                 name="foo",
                 resources={

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -1,6 +1,8 @@
 import pytest
 import kubernetes_asyncio as kubernetes
 
+from kubernetes_asyncio.client.api_client import ApiClient
+
 from dask.distributed import Client
 from distributed.utils import TimeoutError
 
@@ -169,7 +171,24 @@ def test_typo_resource_limits(kopf_runner):
             )
 
 
-def test_handling_invalid_kwargs(kopf_runner):
+def test_invalid_kwargs_exception(kopf_runner):
     with kopf_runner:
         with pytest.raises(kubernetes.client.ApiException):
             KubeCluster(name="foo", n_workers="1")
+
+
+def test_missing_custom_resources_definition(kopf_runner):
+
+    with kopf_runner:
+        with pytest.raises(
+            RuntimeError, match="Failed to create DaskCluster resource."
+        ):
+            api_client = ApiClient()
+            custom_objects_api = kubernetes.client.CustomObjectsApi(api_client)
+            custom_objects_api.create_namespaced_custom_object(
+                group="kubernetes.dask.org",
+                version="v1",
+                plural="daskclusters",
+                namespace="simple",
+                body="",
+            )

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -155,12 +155,6 @@ def test_custom_spec(kopf_runner, docker_image):
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_for_noninteger_n_workers(kopf_runner):
-    with kopf_runner:
-        with pytest.raises(TypeError, match="n_workers must be an integer"):
-            KubeCluster(name="foo", n_workers="1")
-
-
 def test_typo_resource_limits(kopf_runner):
     with kopf_runner:
         with pytest.raises(ValueError):
@@ -172,3 +166,9 @@ def test_typo_resource_limits(kopf_runner):
                     },
                 },
             )
+
+
+def test_handling_for_invalid_kwargs(kopf_runner):
+    with kopf_runner:
+        with pytest.raises(ValueError, match="unable to process invalid kwargs"):
+            KubeCluster(name="foo", n_workers="1")


### PR DESCRIPTION
Fixes: https://github.com/dask/dask-kubernetes/issues/698

Tasks
 

- [x] Update error handling to only raise CRD error if CRDs are missing
- [x]  Update error to raise a helpful message when a 422 is returned to point the user towards which kwarg is invalid