### PR TITLE
Create scheduler pod through a Deployment

### DIFF
--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -196,8 +196,8 @@ async def get_scheduler_address(
 async def wait_for_scheduler(api, cluster_name, namespace, timeout=None):
     pod_start_time = None
     while True:
-        pod = await Pod.objects(api, namespace=namespace).get_by_name(
-            cluster_name + "-scheduler"
+        pod = await Pod.objects(api, namespace=namespace).get(
+            **{"selector" : {"dask.org/component":"scheduler-deployment"}}
         )
         phase = pod.obj["status"]["phase"]
         if phase == "Running":


### PR DESCRIPTION
Closes #606. Currently, if the scheduler pod is lost, the user will lose all of their work because the Client will need to be connected. One way we can prevent this is by creating the scheduler pod through a deployment in stead of creating the pod directly. The advantage of a deployment is that we can define the number of replicas (1 replica/scheduler in this case) and Kubernetes will recreate the scheduler pod if it's lost. This, way, the workers can reconnect to the scheduler.