### PR TITLE
Add CLI utilities

### DIFF
--- a/dask_kubernetes/cli/__init__.py
+++ b/dask_kubernetes/cli/__init__.py
@@ -1,0 +1,1 @@
+from .cli import main

--- a/dask_kubernetes/cli/cli.py
+++ b/dask_kubernetes/cli/cli.py
@@ -1,0 +1,72 @@
+import click
+import yaml
+import json
+
+from dask_kubernetes.operator import make_cluster_spec
+
+
+class NoAliasDumper(yaml.SafeDumper):
+    def ignore_aliases(self, data):
+        return True
+
+
+@click.group(
+    name="kubernetes",
+    help="Utilities for working with Dask Kubernetes",
+    context_settings=dict(ignore_unknown_options=True),
+)
+def main():
+    pass
+
+
+@main.group(help="Generate Kubernetes specs for Dask resources")
+def gen():
+    pass
+
+
+@gen.command(
+    help="Generate a DaskCluster spec, see ``dask_kubernetes.operator.make_cluster_spec``."
+)
+@click.option("--name", type=str, required=True, help="Name of the DaskCluster")
+@click.option(
+    "--image",
+    type=str,
+    default=None,
+    help="Container image to use (default 'ghcr.io/dask/dask:latest')",
+)
+@click.option("--n-workers", type=int, default=3, help="Number of workers")
+@click.option("--resources", type=str, default=None, help="Resource constraints")
+@click.option(
+    "--env", "-e", type=str, default=None, multiple=True, help="Environment variables"
+)
+@click.option(
+    "--worker-command",
+    type=str,
+    default=None,
+    help="Worker command (default 'dask-worker')",
+)
+@click.option(
+    "--scheduler-service-type",
+    type=str,
+    default=None,
+    help="Service type for scheduler (default 'ClusterIP')",
+)
+def cluster(**kwargs):
+    if "resources" in kwargs and kwargs["resources"] is not None:
+        kwargs["resources"] = json.loads(kwargs["resources"])
+
+    if "env" in kwargs:
+        tmp = {}
+        for item in kwargs["env"]:
+            key, val = item.split("=")
+            tmp[key] = val
+        kwargs["env"] = tmp
+
+    filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
+    click.echo(
+        yaml.dump(
+            make_cluster_spec(**filtered_kwargs),
+            Dumper=NoAliasDumper,
+        )
+    )

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,7 @@ setup(
         kubecluster=dask_kubernetes.operator:discover
         [dask_operator_plugin]
         noop=dask_kubernetes.operator.controller.plugins.noop
+        [dask_cli]
+        kubernetes=dask_kubernetes.cli:main
       """,
 )


### PR DESCRIPTION
Added a small CLI utility that hooks into the `dask` CLI extension API. This allows us to extend the `dask kubernetes` CLI and add useful things.

The first useful thing is a command to generate the same `DaskCluster` YAML that `KubeCluster` does under the hood.


```console
$ dask kubernetes gen cluster --name foo                                      
apiVersion: kubernetes.dask.org/v1
kind: DaskCluster
metadata:
  name: foo
spec:
  scheduler:
    service:
      ports:
      - name: tcp-comm
        port: 8786
        protocol: TCP
        targetPort: tcp-comm
      - name: http-dashboard
        port: 8787
        protocol: TCP
        targetPort: http-dashboard
      selector:
        dask.org/cluster-name: foo
        dask.org/component: scheduler
      type: ClusterIP
    spec:
      containers:
      - args:
        - dask-scheduler
        - --host
        - 0.0.0.0
        env: []
        image: ghcr.io/dask/dask:latest
        livenessProbe:
          httpGet:
            path: /health
            port: http-dashboard
          initialDelaySeconds: 15
          periodSeconds: 20
        name: scheduler
        ports:
        - containerPort: 8786
          name: tcp-comm
          protocol: TCP
        - containerPort: 8787
          name: http-dashboard
          protocol: TCP
        readinessProbe:
          httpGet:
            path: /health
            port: http-dashboard
          initialDelaySeconds: 0
          periodSeconds: 1
          timeoutSeconds: 300
        resources: null
  worker:
    replicas: 3
    spec:
      containers:
      - args:
        - dask-worker
        - --name
        - $(DASK_WORKER_NAME)
        - --dashboard
        - --dashboard-address
        - '8788'
        env: []
        image: ghcr.io/dask/dask:latest
        name: worker
        ports:
        - containerPort: 8788
          name: http-dashboard
          protocol: TCP
        resources: null
```

This makes it nice to create clusters quickly from Bash.

```console
$ dask kubernetes gen cluster --name foo --scheduler-service-type LoadBalancer | kubectl apply -f -
daskcluster.kubernetes.dask.org/foo created
```

It basically wraps `make_cluster_spec` and exposes the kwargs as CLI flags.

https://github.com/dask/dask-kubernetes/blob/62209cbafb2476a3980050280c7361b75a6b137d/dask_kubernetes/operator/kubecluster/kubecluster.py#L868-L876

```console
$ dask kubernetes gen cluster --help                                                               
Usage: dask kubernetes gen cluster [OPTIONS]

  Generate a DaskCluster spec, see ``dask_kubernetes.operator.make_cluster_spec``.

Options:
  --name TEXT                    Name of the DaskCluster  [required]
  --image TEXT                   Container image to use (default
                                 'ghcr.io/dask/dask:latest')
  --n-workers INTEGER            Number of workers
  --resources TEXT               Resource constraints
  -e, --env TEXT                 Environment variables
  --worker-command TEXT          Worker command (default 'dask-worker')
  --scheduler-service-type TEXT  Service type for scheduler (default 'ClusterIP')
  -h, --help                     Show this message and exit.
```