### PR TITLE
Add port-forward CLI utility

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -275,7 +275,8 @@ class KubeCluster(Cluster):
             watch_component_status_task = asyncio.create_task(
                 self._watch_component_status()
             )
-            show_rich_output_task = asyncio.create_task(self._show_rich_output())
+            if not self.quiet:
+                show_rich_output_task = asyncio.create_task(self._show_rich_output())
             await ClusterAuth.load_first(self.auth)
             cluster_exists = (await self._get_cluster()) is not None
 
@@ -299,7 +300,8 @@ class KubeCluster(Cluster):
             self._log(f"Ready, dashboard available at {self.dashboard_link}")
         finally:
             watch_component_status_task.cancel()
-            show_rich_output_task.cancel()
+            if not self.quiet:
+                show_rich_output_task.cancel()
 
     def __await__(self):
         async def _():


### PR DESCRIPTION
One of the improvements that the operator has vs the classic dask-kubernetes is that you can create Dask clusters via `kubectl` if you would prefer.

In #712 I added a small CLI utility which allows you to generate the YAML resource that `KubeCluster` does and print it out, this can then be piped into `kubectl`.

```console
$ dask kubernetes gen cluster --name foo | kubectl apply -f -
daskcluster.kubernetes.dask.org/foo created
```

The downside of doing this is that you don't get the nice value-add features that `KubeCluster` provides such as automatic port-forwarding.

This PR adds another utility to make it quick and easy to port-forward both the scheduler and dashboard.

```console
$ dask kubernetes port-forward foo
Scheduler at: tcp://localhost:50429
Dashboard at: http://localhost:54159/status
Press ctrl+c to exit
^C
Shutting down port-forward
```

This is effectively the same as running the following `kubectl` command. Just easier to remember and with nicer output.

```console
$ kubectl port-forward $(kubectl get svc -l dask.org/cluster-name=foo -o name) 0:8786 0:8787
Forwarding from 127.0.0.1:37131 -> 8786
Forwarding from 127.0.0.1:39727 -> 8787
```