### PR TITLE
Automatically rescale to recover from pod deletion

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -461,8 +461,12 @@ async def get_desired_workers(scheduler_service_name, namespace, logger):
 worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 
+def resource_is_deleted(event, **_):
+    return event['type'] == 'DELETED'
+
+
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
-@kopf.on.delete("pod", labels={"dask.org/component": "worker"}, optional=True)
+@kopf.on.event("", "v1", "pod", when=resource_is_deleted, labels={"dask.org/component": "worker"})
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs
 ):

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -462,7 +462,7 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
-@kopf.on.delete(labels={"dask.org/component": "worker"})
+@kopf.on.delete("pod", labels={"dask.org/component": "worker"})
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs
 ):

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -462,7 +462,7 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
-@kopf.on.timer("daskworkergroup.kubernetes.dask.org", interval=30.0)
+@kopf.on.delete("pod", labels={"dask.org/component": "worker"}, optional=True)
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs
 ):

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -462,7 +462,7 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
-@kopf.on.delete("pod", labels={"dask.org/component": "worker"})
+@kopf.on.timer("daskworkergroup.kubernetes.dask.org", interval=30.0)
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs
 ):

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -462,6 +462,7 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
+@kopf.on.delete(labels={"dask.org/component": "worker"})
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs
 ):

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -467,7 +467,7 @@ def resource_is_deleted(event, **_):
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
 @kopf.on.event(
-    "", "v1", "pod", when=resource_is_deleted, labels={"dask.org/component": "worker"}
+    kind="pod", when=resource_is_deleted, labels={"dask.org/component": "worker"}
 )
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -462,11 +462,13 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 
 def resource_is_deleted(event, **_):
-    return event['type'] == 'DELETED'
+    return event["type"] == "DELETED"
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
-@kopf.on.event("", "v1", "pod", when=resource_is_deleted, labels={"dask.org/component": "worker"})
+@kopf.on.event(
+    "", "v1", "pod", when=resource_is_deleted, labels={"dask.org/component": "worker"}
+)
 async def daskworkergroup_replica_update(
     name, namespace, meta, spec, new, body, logger, **kwargs
 ):

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -146,8 +146,10 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "pod",
                         "-l",
                         "dask.org/component=worker",
+                        "--grace-period=0",
+                        "--force",
                     )
-                    await client.wait_for_workers(0, timeout=60)  # initial deletion
+                    assert scheduler_pod_name not in k8s_cluster.kubectl("get", "pods")
                     await client.wait_for_workers(3, timeout=120)  # recovery
 
 

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -147,7 +147,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "-l",
                         "dask.org/component=worker",
                     )
-                    assert scheduler_pod_name not in k8s_cluster.kubectl("get", "pods")
+                    assert worker_pod_name not in k8s_cluster.kubectl("get", "pods")
                     await client.wait_for_workers(3, timeout=120)  # recovery
 
 

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -141,6 +141,14 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "simple-default",
                     )
                     await client.wait_for_workers(3)
+                    k8s_cluster.kubectl(
+                        "delete",
+                        "pod",
+                        "-l",
+                        "dask.org/component=worker",
+                    )
+                    await client.wait_for_workers(0)  # initial deletion
+                    await client.wait_for_workers(3)  # recovery
 
 
 @pytest.mark.timeout(180)

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -146,8 +146,6 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "pod",
                         "-l",
                         "dask.org/component=worker",
-                        "--grace-period=0",
-                        "--force",
                     )
                     assert scheduler_pod_name not in k8s_cluster.kubectl("get", "pods")
                     await client.wait_for_workers(3, timeout=120)  # recovery

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -148,7 +148,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "dask.org/component=worker",
                     )
                     assert worker_pod_name not in k8s_cluster.kubectl("get", "pods")
-                    await client.wait_for_workers(3, timeout=120)  # recovery
+                    await client.wait_for_workers(3)  # recovery
 
 
 @pytest.mark.timeout(180)

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -147,8 +147,8 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                         "-l",
                         "dask.org/component=worker",
                     )
-                    await client.wait_for_workers(0)  # initial deletion
-                    await client.wait_for_workers(3)  # recovery
+                    await client.wait_for_workers(0, timeout=60)  # initial deletion
+                    await client.wait_for_workers(3, timeout=120)  # recovery
 
 
 @pytest.mark.timeout(180)

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,5 +38,5 @@ parentdir_prefix = dask-kubernetes-
 [tool:pytest]
 addopts = -v --keep-cluster --durations=10 -s
 timeout = 300
-# reruns = 5
+reruns = 5
 asyncio_mode = strict

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tag_prefix =
 parentdir_prefix = dask-kubernetes-
 
 [tool:pytest]
-addopts = -v --keep-cluster --durations=10
+addopts = -v --keep-cluster --durations=10 -s
 timeout = 300
-reruns = 5
+# reruns = 5
 asyncio_mode = strict

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tag_prefix =
 parentdir_prefix = dask-kubernetes-
 
 [tool:pytest]
-addopts = -v --keep-cluster --durations=10 -s
+addopts = -v --keep-cluster --durations=10
 timeout = 300
 reruns = 5
 asyncio_mode = strict


### PR DESCRIPTION
Fixes #603 (hopefully!), ping @kwohlfahrt whose idea this is

This is useful in a couple of cases:
- When running on a cloud deployment (especially on something like AWS spot) the node underlying your pod can suddenly disappear, taking down the pod
- When you want to restart a faulty pod (we've seen things like CUDA errors on long-running pods), you can just `kubectl delete` the pod and let Dask recover it.

I wasn't able to get the test running locally; I saw the following error and stack trace

```
Error: UPGRADE FAILED: "dask-gateway" has no deployed releases
```

```python
    @pytest.fixture(scope="session", autouse=True)
    def install_gateway(k8s_cluster):
        check_dependency("helm")
        # To ensure the operator can coexist with Gateway
>       subprocess.run(
            [
                "helm",
                "upgrade",
                "dask-gateway",
                "dask-gateway",
                "--install",
                "--repo=https://helm.dask.org",
                "--create-namespace",
                "--namespace",
                "dask-gateway",
            ],
            check=True,
            env={**os.environ},
        )
```