### PR TITLE
Replace aiopykube with kr8s in controller

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -46,11 +46,8 @@ class DaskCluster(APIObject):
     plural = "daskclusters"
     singular = "daskcluster"
     namespaced = True
-
-    # TODO make scalable
-    # scalable = True
-    # # Dot notation not yet supported in kr8s
-    # scalable_spec = "worker.replicas"
+    scalable = True
+    scalable_spec = "worker.replicas"
 
 
 class DaskWorkerGroup(APIObject):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ kubernetes-asyncio>=12.0.1
 kopf>=1.35.3
 pykube-ng>=22.9.0
 rich>=12.5.1
-kr8s==0.4.1
+kr8s==0.5.1


### PR DESCRIPTION
Taking a more methodical approach to #696 and replacing one thing at a time.

This first PR adds `kr8s` as a dependency, defines the custom resource objects in the controller and updates `handle_scheduler_service_status()` to use `kr8s` for setting the `DaskCluster` status.