### PR TITLE
Add extra config arguments into pods.  Helpful for taints, affinity, nodeSelector

### DIFF
--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -4,6 +4,7 @@ kubernetes:
 
   # Shared options
   name: "dask-{user}-{uuid}"
+  extra_pod_config: {}
   namespace: null
   env: {}
   count:

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -77,8 +77,8 @@ class KubeCluster(Cluster):
         Number of workers on initial launch.
         Use ``scale`` to change this number in the future
     resources: Dict[str, str]
-    node_extras: Dict[str, Dict[str, str] | List[Dict[str, str]]]
-        Tolerations, Affinities, and nodeSelectors
+    extra_pod_config: Dict[str, Dict[str, str] | List[Dict[str, str]]]
+        For setting additional configuration such as nodeSelector, tolerations, affinity
     env: List[dict] | Dict[str, str]
         List of environment variables to pass to worker pod.
         Can be a list of dicts using the same structure as k8s envs
@@ -166,7 +166,7 @@ class KubeCluster(Cluster):
         image=None,
         n_workers=None,
         resources=None,
-        node_extras=None,
+        extra_pod_config=None,
         env=None,
         worker_command=None,
         auth=ClusterAuth.DEFAULT,
@@ -196,8 +196,8 @@ class KubeCluster(Cluster):
         self.resources = dask.config.get(
             "kubernetes.resources", override_with=resources
         )
-        self.node_extras = dask.config.get(
-            "kubernetes.node_extras", override_with=node_extras
+        self.extra_pod_config = dask.config.get(
+            "kubernetes.extra_pod_config", override_with=extra_pod_config
         )
         self.env = dask.config.get("kubernetes.env", override_with=env)
         self.worker_command = dask.config.get(
@@ -329,7 +329,7 @@ class KubeCluster(Cluster):
                     name=self.name,
                     env=self.env,
                     resources=self.resources,
-                    node_extras=self.node_extras,
+                    extra_pod_config=self.extra_pod_config,
                     worker_command=self.worker_command,
                     n_workers=self.n_workers,
                     image=self.image,
@@ -617,7 +617,7 @@ class KubeCluster(Cluster):
         n_workers=3,
         image=None,
         resources=None,
-        node_extras=None,
+        extra_pod_config=None,
         worker_command=None,
         env=None,
         custom_spec=None,
@@ -637,8 +637,8 @@ class KubeCluster(Cluster):
         resources: Dict[str, str]
             Resources to be passed to the underlying pods.
             If ommitted will use the cluster default.
-        node_extras: Dict[str, Dict[str, str] | List[Dict[str, str]]]
-         Tolerations, Affinities, and nodeSelectors
+        extra_pod_config: Dict[str, Dict[str, str] | List[Dict[str, str]]]
+            For setting additional configuration such as nodeSelector, tolerations, affinity
         env: List[dict]
             List of environment variables to pass to worker pod.
             If ommitted will use the cluster default.
@@ -656,7 +656,7 @@ class KubeCluster(Cluster):
             n_workers=n_workers,
             image=image,
             resources=resources,
-            node_extras=node_extras,
+            extra_pod_config=extra_pod_config,
             worker_command=worker_command,
             env=env,
             custom_spec=custom_spec,
@@ -668,7 +668,7 @@ class KubeCluster(Cluster):
         n_workers=3,
         image=None,
         resources=None,
-        node_extras=None,
+        extra_pod_config=None,
         worker_command=None,
         env=None,
         custom_spec=None,
@@ -679,7 +679,7 @@ class KubeCluster(Cluster):
             spec = make_worker_spec(
                 env=env or self.env,
                 resources=resources or self.resources,
-                node_extras=node_extras,
+                extra_pod_config=extra_pod_config,
                 worker_command=worker_command or self.worker_command,
                 n_workers=n_workers or self.n_workers,
                 image=image or self.image,
@@ -887,7 +887,7 @@ def make_cluster_spec(
     image="ghcr.io/dask/dask:latest",
     n_workers=None,
     resources=None,
-    node_extras=None,
+    extra_pod_config=None,
     env=None,
     worker_command="dask-worker",
     scheduler_service_type="ClusterIP",
@@ -904,8 +904,8 @@ def make_cluster_spec(
         Container image to use for the scheduler and workers
     n_workers: int (optional)
         Number of workers in the default worker group
-    node_extras: dict (optional)
-        nodeSelector, tolerations, affinity
+    extra_pod_config: dict (optional)
+        For setting additional configuration such as nodeSelector, tolerations, affinity
     resources: dict (optional)
         Resource limits to set on scheduler and workers
     env: dict (optional)
@@ -921,7 +921,7 @@ def make_cluster_spec(
             "worker": make_worker_spec(
                 env=env,
                 resources=resources,
-                node_extras=node_extras,
+                extra_pod_config=extra_pod_config,
                 worker_command=worker_command,
                 n_workers=n_workers,
                 image=image,
@@ -930,7 +930,7 @@ def make_cluster_spec(
                 cluster_name=name,
                 env=env,
                 resources=resources,
-                node_extras=node_extras,
+                extra_pod_config=extra_pod_config,
                 image=image,
                 scheduler_service_type=scheduler_service_type,
             ),
@@ -942,7 +942,7 @@ def make_worker_spec(
     image="ghcr.io/dask/dask:latest",
     n_workers=3,
     resources=None,
-    node_extras={},
+    extra_pod_config={},
     env=None,
     worker_command="dask-worker",
 ):
@@ -966,7 +966,7 @@ def make_worker_spec(
     return {
         "replicas": n_workers,
         "spec": {
-            **node_extras,
+            **extra_pod_config,
             "containers": [
                 {
                     "name": "worker",
@@ -991,7 +991,7 @@ def make_scheduler_spec(
     cluster_name,
     env=None,
     resources=None,
-    node_extras={},
+    extra_pod_config={},
     image="ghcr.io/dask/dask:latest",
     scheduler_service_type="ClusterIP",
 ):
@@ -1005,7 +1005,7 @@ def make_scheduler_spec(
 
     return {
         "spec": {
-            **node_extras,
+            **extra_pod_config,
             "containers": [
                 {
                     "name": "scheduler",

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -954,7 +954,8 @@ def make_worker_spec(
 
     if isinstance(worker_command, str):
         worker_command = worker_command.split(" ")
-
+    if extra_pod_config is None:
+        extra_pod_config = {}
     args = worker_command + [
         "--name",
         "$(DASK_WORKER_NAME)",
@@ -1002,6 +1003,9 @@ def make_scheduler_spec(
     else:
         # If they gave us a list, assume its a list of dicts and already ready to go
         env = env
+
+    if extra_pod_config is None:
+        extra_pod_config = {}
 
     return {
         "spec": {

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -679,7 +679,7 @@ class KubeCluster(Cluster):
             spec = make_worker_spec(
                 env=env or self.env,
                 resources=resources or self.resources,
-                extra_pod_config=extra_pod_config or self.make_worker_spec,
+                extra_pod_config=extra_pod_config or self.extra_pod_config,
                 worker_command=worker_command or self.worker_command,
                 n_workers=n_workers or self.n_workers,
                 image=image or self.image,

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -887,7 +887,7 @@ def make_cluster_spec(
     image="ghcr.io/dask/dask:latest",
     n_workers=None,
     resources=None,
-    extra_pod_config=None,
+    extra_pod_config={},
     env=None,
     worker_command="dask-worker",
     scheduler_service_type="ClusterIP",
@@ -954,8 +954,7 @@ def make_worker_spec(
 
     if isinstance(worker_command, str):
         worker_command = worker_command.split(" ")
-    if extra_pod_config is None:
-        extra_pod_config = {}
+
     args = worker_command + [
         "--name",
         "$(DASK_WORKER_NAME)",
@@ -1003,9 +1002,6 @@ def make_scheduler_spec(
     else:
         # If they gave us a list, assume its a list of dicts and already ready to go
         env = env
-
-    if extra_pod_config is None:
-        extra_pod_config = {}
 
     return {
         "spec": {

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -679,7 +679,7 @@ class KubeCluster(Cluster):
             spec = make_worker_spec(
                 env=env or self.env,
                 resources=resources or self.resources,
-                extra_pod_config=extra_pod_config,
+                extra_pod_config=extra_pod_config or self.make_worker_spec,
                 worker_command=worker_command or self.worker_command,
                 n_workers=n_workers or self.n_workers,
                 image=image or self.image,


### PR DESCRIPTION
Currently I have to create a yaml file to enable taints, affinity, and nodeSelector, bypassing the convenience of the high-level python API.

This PR addresses this shortcoming by allowing a dictionary to be passed to the `extra_config_args` parameter. 