### PR TITLE
Update scheduler_info across cluster instances

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -792,7 +792,8 @@ class KubeCluster(Cluster):
                 body={"spec": {"replicas": n}},
             )
             for instance in self._instances:
-                instance.scheduler_info = self.scheduler_info
+                if instance.name == self.name:
+                    instance.scheduler_info = self.scheduler_info
 
     def adapt(self, minimum=None, maximum=None):
         """Turn on adaptivity

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -791,6 +791,8 @@ class KubeCluster(Cluster):
                 name=f"{self.name}-{worker_group}",
                 body={"spec": {"replicas": n}},
             )
+            for instance in self._instances:
+                instance.scheduler_info = self.scheduler_info
 
     def adapt(self, minimum=None, maximum=None):
         """Turn on adaptivity

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -104,6 +104,14 @@ def test_cluster_from_name(kopf_runner, docker_image, ns):
                 assert firstcluster == secondcluster
 
 
+def test_cluster_scheduler_info_updated(kopf_runner, docker_image, ns):
+    with kopf_runner:
+        with KubeCluster(name="abc", namespace=ns, image=docker_image) as firstcluster:
+            with KubeCluster.from_name("abc", namespace=ns) as secondcluster:
+                firstcluster.scale(1)
+                assert firstcluster.scheduler_info == secondcluster.scheduler_info
+
+
 def test_additional_worker_groups(kopf_runner, docker_image):
     with kopf_runner:
         with KubeCluster(


### PR DESCRIPTION
I noticed that the scheduler_info is not updated accross all cluster instances. So if you scale one `KubeCluster` instance, the other instances will not show the new number of workers. This PR updates all instances of `KubeCluster.scheduler_info` when it's scaled.