### PR TITLE
Add utility methods to kr8s objects

### DIFF
--- a/dask_kubernetes/operator/objects.py
+++ b/dask_kubernetes/operator/objects.py
@@ -1,4 +1,7 @@
-from kr8s.asyncio.objects import APIObject
+from __future__ import annotations
+from typing import List
+
+from kr8s.asyncio.objects import APIObject, Pod, Deployment, Service
 
 
 class DaskCluster(APIObject):
@@ -11,6 +14,61 @@ class DaskCluster(APIObject):
     scalable = True
     scalable_spec = "worker.replicas"
 
+    async def worker_groups(self) -> List[DaskWorkerGroup]:
+        return await self.api.get(
+            DaskWorkerGroup.endpoint,
+            label_selector=f"dask.org/cluster-name={self.name}",
+            namespace=self.namespace,
+        )
+
+    async def scheduler_pod(self) -> Pod:
+        pods = []
+        while not pods:
+            pods = await self.api.get(
+                Pod.endpoint,
+                label_selector=",".join(
+                    [
+                        f"dask.org/cluster-name={self.name}",
+                        "dask.org/component=scheduler",
+                    ]
+                ),
+                namespace=self.namespace,
+            )
+        assert len(pods) == 1
+        return pods[0]
+
+    async def scheduler_deployment(self) -> Deployment:
+        deployments = []
+        while not deployments:
+            deployments = await self.api.get(
+                Deployment.endpoint,
+                label_selector=",".join(
+                    [
+                        f"dask.org/cluster-name={self.name}",
+                        "dask.org/component=scheduler",
+                    ]
+                ),
+                namespace=self.namespace,
+            )
+        assert len(deployments) == 1
+        return deployments[0]
+
+    async def scheduler_service(self) -> Service:
+        services = []
+        while not services:
+            services = await self.api.get(
+                Service.endpoint,
+                label_selector=",".join(
+                    [
+                        f"dask.org/cluster-name={self.name}",
+                        "dask.org/component=scheduler",
+                    ]
+                ),
+                namespace=self.namespace,
+            )
+        assert len(services) == 1
+        return services[0]
+
 
 class DaskWorkerGroup(APIObject):
     version = "kubernetes.dask.org/v1"
@@ -21,6 +79,35 @@ class DaskWorkerGroup(APIObject):
     namespaced = True
     scalable = True
 
+    async def pods(self) -> List[Pod]:
+        return await self.api.get(
+            Pod.endpoint,
+            label_selector=",".join(
+                [
+                    f"dask.org/cluster-name={self.spec['cluster']}",
+                    "dask.org/component=worker",
+                    f"dask.org/workergroup-name={self.name}",
+                ]
+            ),
+            namespace=self.namespace,
+        )
+
+    async def deployments(self) -> List[Deployment]:
+        return await self.api.get(
+            Deployment.endpoint,
+            label_selector=",".join(
+                [
+                    f"dask.org/cluster-name={self.spec['cluster']}",
+                    "dask.org/component=worker",
+                    f"dask.org/workergroup-name={self.name}",
+                ]
+            ),
+            namespace=self.namespace,
+        )
+
+    async def cluster(self) -> DaskCluster:
+        return await DaskCluster.get(self.spec["cluster"], namespace=self.namespace)
+
 
 class DaskAutoscaler(APIObject):
     version = "kubernetes.dask.org/v1"
@@ -30,6 +117,9 @@ class DaskAutoscaler(APIObject):
     singular = "daskautoscaler"
     namespaced = True
 
+    async def cluster(self) -> DaskCluster:
+        return await DaskCluster.get(self.spec["cluster"], namespace=self.namespace)
+
 
 class DaskJob(APIObject):
     version = "kubernetes.dask.org/v1"
@@ -38,3 +128,22 @@ class DaskJob(APIObject):
     plural = "daskjobs"
     singular = "daskjob"
     namespaced = True
+
+    async def cluster(self) -> DaskCluster:
+        return await DaskCluster.get(self.name, namespace=self.namespace)
+
+    async def pod(self) -> Pod:
+        pods = []
+        while not pods:
+            pods = await self.api.get(
+                Pod.endpoint,
+                label_selector=",".join(
+                    [
+                        f"dask.org/cluster-name={self.name}",
+                        "dask.org/component=job-runner",
+                    ]
+                ),
+                namespace=self.namespace,
+            )
+        assert len(pods) == 1
+        return pods[0]


### PR DESCRIPTION
Added some useful utility methods to the kr8s `APIObject` subclasses we have in `dask_kubernetes.operator.objects`.

For example if you have a `DaskCluster` object you can quickly get a `Pod` object for the scheduler Pod.

```python
import asyncio
from dask_kubernetes.operator.objects import DaskCluster

async def main():
    cluster = await DaskCluster.get("foo")
    scheduler_pod = await cluster.scheduler_pod()

if __name__ == "__main__":
    asyncio.run(main())
```

Added methods are:
- `DaskCluster.worker_groups()`
- `DaskCluster.scheduler_pod()`
- `DaskCluster.scheduler_deployment()`
- `DaskCluster.scheduler_service()`
- `DaskWorkerGroup.pods()`
- `DaskWorkerGroup.deployments()`
- `DaskWorkerGroup.cluster()`
- `DaskAutoscaler.cluster()`
- `DaskJob.cluster()`
- `DaskJob.pod()`