### PR TITLE
Update supported k8s versions badge in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Dask Kubernetes
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Python Support
 
-.. image:: https://img.shields.io/badge/Kubernetes%20support-1.22%7C1.23%7C1.24%7C1.25-blue
+.. image:: https://img.shields.io/badge/Kubernetes%20support-1.24%7C1.25%7C1.26%7C1.27-blue
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Kubernetes Support
 


### PR DESCRIPTION
Whoops looks like the docs index page Kubernetes versions badge didn't get updated in #718.