### PR TITLE
Add batch worker provisioning capability to the Operator

### DIFF
--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -31,6 +31,12 @@ kubernetes:
   protocol: "tcp://"
   dashboard_address: ":8787"
 
+  # Dask Operator Controller options
+  controller:
+    worker-allocation:
+      batch-size: null
+      delay: null
+
   # Timeout to wait for the scheduler service to be up (in seconds)
   # Set it to 0 to wait indefinitely (not recommended)
   scheduler-service-wait-timeout: 30

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -635,7 +635,7 @@ async def daskworkergroup_replica_update(
 
             SIZE = dask.config.get("kubernetes.controller.worker-allocation.batch-size")
             DELAY = dask.config.get("kubernetes.controller.worker-allocation.delay")
-            batch_size = min(workers_needed, SIZE)
+            batch_size = min(workers_needed, SIZE) if SIZE else workers_needed
             if workers_needed > 0:
                 for _ in range(batch_size):
                     data = build_worker_deployment_spec(

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `metrics.worker.podMonitor.jobLabel` | The label to use to retrieve the job name from. | `""` |
 | `metrics.worker.podMonitor.podTargetLabels` | PodTargetLabels transfers labels on the Kubernetes Pod onto the target. | `["dask.org/cluster-name", "dask.org/workergroup-name"]` |
 | `metrics.worker.podMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
-| `workerAllocationSettings.size` |  | `5` |
+| `workerAllocationSettings.size` |  | `"5"` |
 | `workerAllocationSettings.delay` |  | `"1s"` |
 
 

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -48,8 +48,8 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `metrics.worker.podMonitor.jobLabel` | The label to use to retrieve the job name from. | `""` |
 | `metrics.worker.podMonitor.podTargetLabels` | PodTargetLabels transfers labels on the Kubernetes Pod onto the target. | `["dask.org/cluster-name", "dask.org/workergroup-name"]` |
 | `metrics.worker.podMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
-| `workerAllocationSettings.size` |  | `"5"` |
-| `workerAllocationSettings.delay` |  | `"1s"` |
+| `workerAllocationSettings.size` |  | `"nil"` |
+| `workerAllocationSettings.delay` |  | `"nil"` |
 
 
 

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -48,8 +48,8 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `metrics.worker.podMonitor.jobLabel` | The label to use to retrieve the job name from. | `""` |
 | `metrics.worker.podMonitor.podTargetLabels` | PodTargetLabels transfers labels on the Kubernetes Pod onto the target. | `["dask.org/cluster-name", "dask.org/workergroup-name"]` |
 | `metrics.worker.podMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
-| `workerAllocationSettings.size` |  | `"nil"` |
-| `workerAllocationSettings.delay` |  | `"nil"` |
+| `workerAllocation.size` |  | `"nil"` |
+| `workerAllocation.delay` |  | `"nil"` |
 
 
 

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -48,6 +48,8 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `metrics.worker.podMonitor.jobLabel` | The label to use to retrieve the job name from. | `""` |
 | `metrics.worker.podMonitor.podTargetLabels` | PodTargetLabels transfers labels on the Kubernetes Pod onto the target. | `["dask.org/cluster-name", "dask.org/workergroup-name"]` |
 | `metrics.worker.podMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
+| `workerAllocationSettings.size` |  | `5` |
+| `workerAllocationSettings.delay` |  | `"1s"` |
 
 
 

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -34,9 +34,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: WORKER_BATCH_SIZE
-              value: {{- toYaml .Values.workerAllocationSettings.size | nindent 14}}
+              value:
+                {{- toYaml .Values.workerAllocationSettings.size | nindent 16 }}
             - name: WORKER_DELAY
-              value: {{- toYaml .Values.workerAllocationSettings.delay | nindent 14}}
+              value:
+                {{- toYaml .Values.workerAllocationSettings.delay | nindent 16 }}
           args:
             - --liveness=http://0.0.0.0:8080/healthz
           {{- with .Values.kopfArgs }}

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -35,10 +35,10 @@ spec:
           env:
             - name: DASK_KUBERNETES__CONTROLLER__WORKER_ALLOCATION__BATCH_SIZE
               value:
-                {{- toYaml .Values.workerAllocationSettings.size | nindent 16 }}
+                {{- toYaml .Values.workerAllocation.size | nindent 16 }}
             - name: DASK_KUBERNETES__CONTROLLER__WORKER_ALLOCATION__DELAY
               value:
-                {{- toYaml .Values.workerAllocationSettings.delay | nindent 16 }}
+                {{- toYaml .Values.workerAllocation.delay | nindent 16 }}
           args:
             - --liveness=http://0.0.0.0:8080/healthz
           {{- with .Values.kopfArgs }}

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -33,10 +33,10 @@ spec:
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: WORKER_BATCH_SIZE
+            - name: DASK_KUBERNETES__CONTROLLER__WORKER_ALLOCATION__BATCH_SIZE
               value:
                 {{- toYaml .Values.workerAllocationSettings.size | nindent 16 }}
-            - name: WORKER_DELAY
+            - name: DASK_KUBERNETES__CONTROLLER__WORKER_ALLOCATION__DELAY
               value:
                 {{- toYaml .Values.workerAllocationSettings.delay | nindent 16 }}
           args:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: WORKER_BATCH_SIZE
+              value: {{- toYaml .Values.workerAllocationSettings.size | nindent 14}}
+            - name: WORKER_DELAY
+              value: {{- toYaml .Values.workerAllocationSettings.delay | nindent 14}}
           args:
             - --liveness=http://0.0.0.0:8080/healthz
           {{- with .Values.kopfArgs }}

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -87,5 +87,5 @@ metrics:
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
 
 workerAllocationSettings:
-  size: "5"
-  delay: 1s
+  size: nil
+  delay: nil

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -86,6 +86,6 @@ metrics:
         - dask.org/workergroup-name
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
 
-workerAllocationSettings:
+workerAllocation:
   size: nil
   delay: nil

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -87,5 +87,5 @@ metrics:
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
 
 workerAllocationSettings:
-  size: 5
+  size: "5"
   delay: 1s

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -85,3 +85,7 @@ metrics:
         - dask.org/cluster-name
         - dask.org/workergroup-name
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
+
+workerAllocationSettings:
+  size: 5
+  delay: 1s


### PR DESCRIPTION
Closes #733. This PR adds provides the ability for the operator deploy workers in batches of a given `size` with a cooldown `delay` between deployments.