### PR TITLE
Add `deployments` permission to role and clusterrole

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/clusterrole.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/clusterrole.yaml
@@ -38,6 +38,10 @@ rules:
     resources: [services, services/status]
     verbs: ["*"]
 
+  - apiGroups: ["apps"]
+    resources: [deployments, deployments/status]
+    verbs: ["*"]
+
   - apiGroups: ["", events.k8s.io]
     resources: [events]
     verbs: ["*"]

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/role.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/role.yaml
@@ -38,6 +38,10 @@ rules:
     resources: [services, services/status]
     verbs: ["*"]
 
+  - apiGroups: ["apps"]
+    resources: [deployments, deployments/status]
+    verbs: ["*"]
+
   - apiGroups: ["", events.k8s.io]
     resources: [events]
     verbs: ["*"]


### PR DESCRIPTION
This should fix #749 

@jacobtomlinson I've tested this on a fresh k8s cluster where I've helm-installed the operator.

The deployment for the scheduler has been created after I've added the permissions, however, once the scheduler started running I've seen the following exception: 
```
[2023-06-28 09:51:39,162] kopf.objects         [ERROR   ] [dask-ns/my-dask-cluster-scheduler] Handler 'handle_scheduler_service_status/status' failed with an exception. Will retry.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 276, in execute_handler_once
    result = await invoke_handler(
  File "/usr/local/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 371, in invoke_handler
    result = await invocation.invoke(
  File "/usr/local/lib/python3.10/site-packages/kopf/_core/actions/invocation.py", line 116, in invoke
    result = await fn(**kwargs)  # type: ignore
  File "/usr/local/lib/python3.10/site-packages/dask_kubernetes/operator/controller/controller.py", line 371, in handle_scheduler_service_status
    cluster = await DaskCluster.get(
  File "/usr/local/lib/python3.10/site-packages/kr8s/_objects.py", line 137, in get
    api = await kr8s.asyncio.api()
  File "/usr/local/lib/python3.10/site-packages/kr8s/asyncio/_api.py", line 31, in api
    return await _f(
  File "/usr/local/lib/python3.10/site-packages/kr8s/asyncio/_api.py", line 29, in _f
    return await _cls(**kwargs, bypass_factory=True)
  File "/usr/local/lib/python3.10/site-packages/kr8s/_api.py", line 53, in f
    await self.auth
  File "/usr/local/lib/python3.10/site-packages/kr8s/_auth.py", line 44, in f
    await self.reauthenticate()
  File "/usr/local/lib/python3.10/site-packages/kr8s/_auth.py", line 56, in reauthenticate
    raise ValueError("Unable to find valid credentials")
```

Not sure whether this is related

Closes #749