### PR TITLE
Update daskcluster_default_worker_group_replica_update to use kr8s

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -574,11 +574,9 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 async def daskcluster_default_worker_group_replica_update(
     name, namespace, old, new, **kwargs
 ):
-    if old is None:
-        return
-
-    wg = await DaskWorkerGroup.get(f"{name}-default", namespace=namespace)
-    await wg.scale(new)
+    if old is not None:
+        wg = await DaskWorkerGroup.get(f"{name}-default", namespace=namespace)
+        await wg.scale(new)
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -11,7 +11,7 @@ import kubernetes_asyncio as kubernetes
 from importlib_metadata import entry_points
 from kubernetes_asyncio.client import ApiException
 
-from dask_kubernetes.operator._objects import DaskCluster
+from dask_kubernetes.operator._objects import DaskCluster, DaskWorkerGroup
 from dask_kubernetes.common.auth import ClusterAuth
 from dask_kubernetes.common.networking import get_scheduler_address
 from distributed.core import rpc, clean_exception
@@ -572,25 +572,13 @@ worker_group_scale_locks = defaultdict(lambda: asyncio.Lock())
 
 @kopf.on.field("daskcluster.kubernetes.dask.org", field="spec.worker.replicas")
 async def daskcluster_default_worker_group_replica_update(
-    name, namespace, meta, spec, old, new, body, logger, **kwargs
+    name, namespace, old, new, **kwargs
 ):
     if old is None:
         return
-    worker_group_name = f"{name}-default"
 
-    async with kubernetes.client.api_client.ApiClient() as api_client:
-        custom_objects_api = kubernetes.client.CustomObjectsApi(api_client)
-        custom_objects_api.api_client.set_default_header(
-            "content-type", "application/merge-patch+json"
-        )
-        await custom_objects_api.patch_namespaced_custom_object_scale(
-            group="kubernetes.dask.org",
-            version="v1",
-            plural="daskworkergroups",
-            namespace=namespace,
-            name=worker_group_name,
-            body={"spec": {"replicas": new}},
-        )
+    wg = await DaskWorkerGroup.get(f"{name}-default", namespace=namespace)
+    await wg.patch({"spec": {"replicas": new}})
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -578,7 +578,7 @@ async def daskcluster_default_worker_group_replica_update(
         return
 
     wg = await DaskWorkerGroup.get(f"{name}-default", namespace=namespace)
-    await wg.patch({"spec": {"replicas": new}})
+    await wg.scale(new)
 
 
 @kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")


### PR DESCRIPTION
Replace `kubernetes_asyncio` with `kr8s` in `daskcluster_default_worker_group_replica_update`. Should functionally have no change.