### PR TITLE
Try and reduce timeouts to improve CI time-to-failure

### DIFF
--- a/.github/workflows/helmcluster.yaml
+++ b/.github/workflows/helmcluster.yaml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -37,7 +37,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ parentdir_prefix = dask-kubernetes-
 
 [tool:pytest]
 addopts = -v --keep-cluster --durations=10
-timeout = 300
-reruns = 5
+timeout = 60
+timeout_func_only = true
+reruns = 3
 asyncio_mode = strict


### PR DESCRIPTION
We are seeing lots of cancelled CI runs because tests are rerunning and taking a while to time out. This PR reduces the timeout and instructs `pytest-timeout` to not include fixtures in the timeout (so the initial creation of the `kind` cluster doesn't get timed out).