### PR TITLE
Change autoscaler adoption to use kr8s

### DIFF
--- a/dask_kubernetes/operator/_objects.py
+++ b/dask_kubernetes/operator/_objects.py
@@ -85,7 +85,7 @@ class DaskWorkerGroup(APIObject):
             Pod.endpoint,
             label_selector=",".join(
                 [
-                    f"dask.org/cluster-name={self.spec['cluster']}",
+                    f"dask.org/cluster-name={self.spec.cluster}",
                     "dask.org/component=worker",
                     f"dask.org/workergroup-name={self.name}",
                 ]
@@ -98,7 +98,7 @@ class DaskWorkerGroup(APIObject):
             Deployment.endpoint,
             label_selector=",".join(
                 [
-                    f"dask.org/cluster-name={self.spec['cluster']}",
+                    f"dask.org/cluster-name={self.spec.cluster}",
                     "dask.org/component=worker",
                     f"dask.org/workergroup-name={self.name}",
                 ]
@@ -107,7 +107,7 @@ class DaskWorkerGroup(APIObject):
         )
 
     async def cluster(self) -> DaskCluster:
-        return await DaskCluster.get(self.spec["cluster"], namespace=self.namespace)
+        return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
 
 
 class DaskAutoscaler(APIObject):
@@ -119,7 +119,7 @@ class DaskAutoscaler(APIObject):
     namespaced = True
 
     async def cluster(self) -> DaskCluster:
-        return await DaskCluster.get(self.spec["cluster"], namespace=self.namespace)
+        return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
 
 
 class DaskJob(APIObject):

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -831,10 +831,10 @@ async def handle_runner_status_change_succeeded(meta, namespace, logger, **kwarg
 
 
 @kopf.on.create("daskautoscaler.kubernetes.dask.org")
-async def daskautoscaler_create(body, namespace, logger, **kwargs):
+async def daskautoscaler_create(body, logger, **_):
     """When an autoscaler is created make it a child of the associated cluster for cascade deletion."""
     autoscaler = await DaskAutoscaler(body)
-    cluster = await DaskCluster.get(autoscaler.spec.cluster, namespace=namespace)
+    cluster = await autoscaler.cluster()
     await cluster.adopt(autoscaler)
     logger.info(f"Autoscaler {autoscaler.name} adopted by cluster {cluster.name}")
 

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -831,14 +831,12 @@ async def handle_runner_status_change_succeeded(meta, namespace, logger, **kwarg
 
 
 @kopf.on.create("daskautoscaler.kubernetes.dask.org")
-async def daskautoscaler_create(name, body, namespace, logger, **kwargs):
+async def daskautoscaler_create(body, namespace, logger, **kwargs):
     """When an autoscaler is created make it a child of the associated cluster for cascade deletion."""
     autoscaler = await DaskAutoscaler(body)
     cluster = await DaskCluster.get(autoscaler.spec.cluster, namespace=namespace)
     await cluster.adopt(autoscaler)
-    logger.info(
-        f"Autoscaler {name} successfully adopted by cluster {autoscaler.spec.cluster}"
-    )
+    logger.info(f"Autoscaler {autoscaler.name} adopted by cluster {cluster.name}")
 
 
 @kopf.timer("daskautoscaler.kubernetes.dask.org", interval=5.0)

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -831,11 +831,14 @@ async def handle_runner_status_change_succeeded(meta, namespace, logger, **kwarg
 
 
 @kopf.on.create("daskautoscaler.kubernetes.dask.org")
-async def daskautoscaler_create(name, spec, namespace, logger, patch, **kwargs):
+async def daskautoscaler_create(name, body, namespace, logger, **kwargs):
     """When an autoscaler is created make it a child of the associated cluster for cascade deletion."""
-    cluster = await DaskCluster.get(spec["cluster"], namespace=namespace)
-    kopf.adopt(patch, owner=cluster.raw)
-    logger.info(f"Autoscaler {name} successfully adopted by cluster {spec['cluster']}")
+    autoscaler = await DaskAutoscaler(body)
+    cluster = await DaskCluster.get(autoscaler.spec.cluster, namespace=namespace)
+    await cluster.adopt(autoscaler)
+    logger.info(
+        f"Autoscaler {name} successfully adopted by cluster {autoscaler.spec.cluster}"
+    )
 
 
 @kopf.timer("daskautoscaler.kubernetes.dask.org", interval=5.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ kubernetes-asyncio>=12.0.1
 kopf>=1.35.3
 pykube-ng>=22.9.0
 rich>=12.5.1
-kr8s==0.8.4
+kr8s==0.8.5


### PR DESCRIPTION
`kr8s` 0.8.5 supports objects adopting other objects. This PR switches the autoscaler adoption to use kr8s to make the code a little more readable. This is also a bit of a test run before using it in other places.