### PR TITLE
Replace `nil` with `null` in helm chart

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -50,8 +50,8 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `metrics.worker.podMonitor.jobLabel` | The label to use to retrieve the job name from. | `""` |
 | `metrics.worker.podMonitor.podTargetLabels` | PodTargetLabels transfers labels on the Kubernetes Pod onto the target. | `["dask.org/cluster-name", "dask.org/workergroup-name"]` |
 | `metrics.worker.podMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
-| `workerAllocation.size` |  | `"nil"` |
-| `workerAllocation.delay` |  | `"nil"` |
+| `workerAllocation.size` |  | `null` |
+| `workerAllocation.delay` |  | `null` |
 
 
 

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -91,5 +91,5 @@ metrics:
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
 
 workerAllocation:
-  size: nil
-  delay: nil
+  size: null
+  delay: null


### PR DESCRIPTION
We've just tried to deploy the `2022.7.0` version of the helm chart and ran into: 

```
Handler 'daskworkergroup_replica_update/spec.worker.replicas' failed with an exception. Will retry.
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 276, in execute_handler_once
    result = await invoke_handler(
  File "/usr/local/lib/python3.10/site-packages/kopf/_core/actions/execution.py", line 371, in invoke_handler
    result = await invocation.invoke(
  File "/usr/local/lib/python3.10/site-packages/kopf/_core/actions/invocation.py", line 116, in invoke
    result = await fn(**kwargs)  # type: ignore
  File "/usr/local/lib/python3.10/site-packages/dask_kubernetes/operator/controller/controller.py", line 639, in daskworkergroup_replica_update
    batch_size = min(workers_needed, SIZE) if SIZE else workers_needed
TypeError: '<' not supported between instances of 'str' and 'int'
```

We're currently testing whether settings things to `null` fixes this. cc @dyu-bot 