### PR TITLE
Tell pytest to fail fast

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -67,6 +67,6 @@ jobs:
           TEST_ISTIO: "true"
           TEST_DASK_GATEWAY: "true"
         run: pytest dask_kubernetes/common dask_kubernetes/operator dask_kubernetes/aiopykube
-      - name: Debug k8s resources
+      - name: Debug kubernetes resources
         if: always()
         run: kubectl get all -A

--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -107,7 +107,6 @@ def install_gateway(k8s_cluster):
 
 @pytest.fixture(scope="session", autouse=True)
 def customresources(k8s_cluster):
-
     temp_dir = tempfile.TemporaryDirectory()
     crd_path = os.path.join(DIR, "operator", "customresources")
 
@@ -127,5 +126,5 @@ def customresources(k8s_cluster):
 
     k8s_cluster.kubectl("apply", "-f", temp_dir.name)
     yield
-    k8s_cluster.kubectl("delete", "-f", temp_dir.name)
+    k8s_cluster.kubectl("delete", "--wait=false", "-f", temp_dir.name)
     temp_dir.cleanup()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tag_prefix =
 parentdir_prefix = dask-kubernetes-
 
 [tool:pytest]
-addopts = -v --keep-cluster --durations=10
+addopts = -v -x --keep-cluster --durations=10
 timeout = 60
 timeout_func_only = true
 reruns = 3


### PR DESCRIPTION
We keep seeing hanging CI and it's hard to debug what is going on. Many of these runs have many test failures before locking up. This PR adds the `-x` flag to pytest which will cause it to exit after the first failure. Hopefully this should help get to the bottom of the hangs.