### PR TITLE
Run operator container as non-root

### DIFF
--- a/dask_kubernetes/operator/deployment/Dockerfile
+++ b/dask_kubernetes/operator/deployment/Dockerfile
@@ -10,6 +10,12 @@ WORKDIR /src/dask_kubernetes
 # Install dependencies
 RUN pip install .
 
+# Add non-root user
+RUN useradd -s /bin/bash dask
+
+# Run container as non-root
+USER 1000
+
 # Start operator
 ENTRYPOINT ["/usr/local/bin/kopf", "run", "-m", "dask_kubernetes.operator.controller"]
 CMD ["--liveness=http://0.0.0.0:8080/healthz", "--verbose", "--all-namespaces"]

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -24,7 +24,10 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `rbac.cluster` | Creates a ClusterRole if true, else create a namespaced Role | `true` |
 | `podAnnotations` | Extra annotations for the operator pod | `{}` |
 | `podSecurityContext` | Security context for the operator pod | `{}` |
-| `securityContext` | Security context for the operator container | `{}` |
+| `securityContext.capabilities.drop` |  | `["ALL"]` |
+| `securityContext.runAsNonRoot` |  | `true` |
+| `securityContext.runAsUser` |  | `1000` |
+| `securityContext.allowPrivilegeEscalation` |  | `false` |
 | `resources` | Resources for the operator pod | `{}` |
 | `volumes` | Volumes for the operator pod | `[]` |
 | `volumeMounts` | Volume mounts for the operator container | `[]` |

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -21,13 +21,14 @@ podAnnotations: {}  # Extra annotations for the operator pod
 podSecurityContext: {}  # Security context for the operator pod
   # fsGroup: 2000
 
-securityContext: {}  # Security context for the operator container
-  # capabilities:
-  #   drop:
-  #   - ALL
+securityContext:  # Security context for the operator container
+  capabilities:
+    drop:
+    - ALL
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 resources: {}  # Resources for the operator pod
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR updates the operator container `Dockerfile` and operator deployment manifest (via the values file) to run as non-root, i.e. user 1000 (username `toor`). 

Relevant [issue](https://github.com/dask/dask-kubernetes/issues/776).

I confirmed the image builds, shelled into the running container, and confirmed that I can execute the `kopf` binary as the `dask` user.