### PR TITLE
Switch pytest-asyncio to use anyio

### DIFF
--- a/dask_kubernetes/aiopykube/tests/test_pykube_objects.py
+++ b/dask_kubernetes/aiopykube/tests/test_pykube_objects.py
@@ -7,7 +7,7 @@ from dask_kubernetes.aiopykube import HTTPClient, KubeConfig
 from dask_kubernetes.aiopykube.objects import Pod
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_create_and_delete(docker_image, k8s_cluster):
     api = HTTPClient(KubeConfig.from_env())
     name = "test-" + uuid.uuid4().hex[:10]

--- a/dask_kubernetes/aiopykube/tests/test_query.py
+++ b/dask_kubernetes/aiopykube/tests/test_query.py
@@ -5,14 +5,14 @@ from dask_kubernetes.aiopykube.query import Query
 from dask_kubernetes.aiopykube.objects import Pod
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_query(k8s_cluster):
     api = HTTPClient(KubeConfig.from_env())
     async for pod in Query(api, Pod, namespace="kube-system"):
         assert isinstance(pod, Pod)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_objects(k8s_cluster):
     api = HTTPClient(KubeConfig.from_env())
     async for pod in Pod.objects(api).filter(namespace="kube-system"):

--- a/dask_kubernetes/classic/tests/test_async.py
+++ b/dask_kubernetes/classic/tests/test_async.py
@@ -1,4 +1,3 @@
-import pytest_asyncio
 import asyncio
 import base64
 import getpass
@@ -68,19 +67,19 @@ def user_env():
 cluster_kwargs = {"asynchronous": True}
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def cluster(k8s_cluster, pod_spec):
     async with KubeCluster(pod_spec, **cluster_kwargs) as cluster:
         yield cluster
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def remote_cluster(k8s_cluster, pod_spec):
     async with KubeCluster(pod_spec, deploy_mode="remote", **cluster_kwargs) as cluster:
         yield cluster
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def client(cluster):
     async with Client(cluster, asynchronous=True) as client:
         yield client

--- a/dask_kubernetes/classic/tests/test_async.py
+++ b/dask_kubernetes/classic/tests/test_async.py
@@ -86,18 +86,18 @@ async def client(cluster):
         yield client
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_fixtures(client):
     """An initial test to get all the fixtures to run and check the cluster is usable."""
     assert client
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_versions(client):
     await client.get_versions(check=True)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cluster_create(cluster):
     cluster.scale(1)
     await cluster
@@ -106,7 +106,7 @@ async def test_cluster_create(cluster):
         assert result == 11
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_basic(cluster, client):
     cluster.scale(2)
     future = client.submit(lambda x: x + 1, 10)
@@ -122,7 +122,7 @@ async def test_basic(cluster, client):
     assert all((await client.has_what()).values())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_logs(remote_cluster):
     cluster = remote_cluster
     cluster.scale(2)
@@ -141,14 +141,14 @@ async def test_logs(remote_cluster):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_dask_worker_name_env_variable(k8s_cluster, pod_spec, user_env):
     with dask.config.set({"kubernetes.name": "foo-{USER}-{uuid}"}):
         async with KubeCluster(pod_spec, **cluster_kwargs) as cluster:
             assert "foo-" + getpass.getuser() in cluster.name
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_diagnostics_link_env_variable(k8s_cluster, pod_spec, user_env):
     pytest.importorskip("bokeh")
     with dask.config.set({"distributed.dashboard.link": "foo-{USER}-{port}"}):
@@ -161,7 +161,7 @@ async def test_diagnostics_link_env_variable(k8s_cluster, pod_spec, user_env):
 
 
 @pytest.mark.skip(reason="Cannot run two closers locally as loadbalancer ports collide")
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_namespace(k8s_cluster, pod_spec):
     async with KubeCluster(pod_spec, **cluster_kwargs) as cluster:
         assert "dask" in cluster.name
@@ -174,7 +174,7 @@ async def test_namespace(k8s_cluster, pod_spec):
                 await asyncio.sleep(0.1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_adapt(cluster):
     cluster.adapt()
     async with Client(cluster, asynchronous=True) as client:
@@ -184,7 +184,7 @@ async def test_adapt(cluster):
 
 
 @pytest.mark.xfail(reason="The widget has changed upstream")
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_ipython_display(cluster):
     ipywidgets = pytest.importorskip("ipywidgets")
     cluster.scale(1)
@@ -201,7 +201,7 @@ async def test_ipython_display(cluster):
         await asyncio.sleep(0.5)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_env(k8s_cluster, pod_spec):
     async with KubeCluster(pod_spec, env={"ABC": "DEF"}, **cluster_kwargs) as cluster:
         cluster.scale(1)
@@ -212,7 +212,7 @@ async def test_env(k8s_cluster, pod_spec):
             assert all(v["ABC"] == "DEF" for v in env.values())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_from_yaml(k8s_cluster, docker_image):
     test_yaml = {
         "kind": "Pod",
@@ -254,7 +254,7 @@ async def test_pod_from_yaml(k8s_cluster, docker_image):
                 assert all((await client.has_what()).values())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_expand_env_vars(k8s_cluster, docker_image):
     try:
         os.environ["FOO_IMAGE"] = docker_image
@@ -288,7 +288,7 @@ async def test_pod_expand_env_vars(k8s_cluster, docker_image):
         del os.environ["FOO_IMAGE"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_template_dict(docker_image):
     spec = {
         "metadata": {},
@@ -330,7 +330,7 @@ async def test_pod_template_dict(docker_image):
             assert all((await client.has_what()).values())
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_template_minimal_dict(k8s_cluster, docker_image):
     spec = {
         "spec": {
@@ -361,7 +361,7 @@ async def test_pod_template_minimal_dict(k8s_cluster, docker_image):
             assert result == 11
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_template_from_conf(docker_image):
     spec = {
         "spec": {
@@ -377,7 +377,7 @@ async def test_pod_template_from_conf(docker_image):
             )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_pod_template_with_custom_container_name(docker_image):
     container_name = "my-custom-container"
     spec = {"spec": {"containers": [{"name": container_name, "image": docker_image}]}}
@@ -387,7 +387,7 @@ async def test_pod_template_with_custom_container_name(docker_image):
             assert cluster.pod_template.spec.containers[0].name == container_name
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_constructor_parameters(k8s_cluster, pod_spec):
     env = {"FOO": "BAR", "A": 1}
     async with KubeCluster(
@@ -405,7 +405,7 @@ async def test_constructor_parameters(k8s_cluster, pod_spec):
         assert pod.metadata.generate_name == "myname"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_reject_evicted_workers(cluster):
     cluster.scale(1)
     await cluster
@@ -440,7 +440,7 @@ async def test_reject_evicted_workers(cluster):
         await asyncio.sleep(0.1)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scale_up_down(cluster, client):
     np = pytest.importorskip("numpy")
     cluster.scale(2)
@@ -471,7 +471,7 @@ async def test_scale_up_down(cluster, client):
 @pytest.mark.xfail(
     reason="The delay between scaling up, starting a worker, and then scale down causes issues"
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scale_up_down_fast(cluster, client):
     cluster.scale(1)
     await cluster
@@ -508,7 +508,7 @@ async def test_scale_up_down_fast(cluster, client):
 
 
 @pytest.mark.xfail(reason="scaling has some unfortunate state")
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scale_down_pending(cluster, client, cleanup_namespaces):
     # Try to scale the cluster to use more pods than available
     nodes = (await cluster.core_api.list_node()).items
@@ -571,7 +571,7 @@ async def test_scale_down_pending(cluster, client, cleanup_namespaces):
         assert time() < start + 60
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_automatic_startup(k8s_cluster, docker_image):
     test_yaml = {
         "kind": "Pod",
@@ -600,7 +600,7 @@ async def test_automatic_startup(k8s_cluster, docker_image):
                 assert cluster.pod_template.metadata.labels["foo"] == "bar"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_repr(cluster):
     for text in [repr(cluster), str(cluster)]:
         assert "Box" not in text
@@ -610,7 +610,7 @@ async def test_repr(cluster):
         )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_escape_username(k8s_cluster, pod_spec, monkeypatch):
     monkeypatch.setenv("LOGNAME", "Foo!._")
 
@@ -622,13 +622,13 @@ async def test_escape_username(k8s_cluster, pod_spec, monkeypatch):
         assert "foo" in cluster.pod_template.metadata.labels["user"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_escape_name(k8s_cluster, pod_spec):
     async with KubeCluster(pod_spec, name="foo@bar", **cluster_kwargs) as cluster:
         assert "@" not in str(cluster.pod_template)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_maximum(cluster):
     with dask.config.set({"kubernetes.count.max": 1}):
         with captured_logger("dask_kubernetes") as logger:
@@ -703,7 +703,7 @@ def test_default_toleration_preserved(docker_image):
     } in tolerations
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auth_missing(k8s_cluster, pod_spec):
     with pytest.raises(kubernetes.config.ConfigException) as info:
         await KubeCluster(pod_spec, auth=[], **cluster_kwargs)
@@ -711,7 +711,7 @@ async def test_auth_missing(k8s_cluster, pod_spec):
     assert "No authorization methods were provided" in str(info.value)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auth_tries_all_methods(k8s_cluster, pod_spec):
     fails = {"count": 0}
 
@@ -730,7 +730,7 @@ async def test_auth_tries_all_methods(k8s_cluster, pod_spec):
 @pytest.mark.xfail(
     reason="Updating the default client configuration is broken in kubernetes"
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auth_kubeconfig_with_filename():
     await KubeConfig(config_file=CONFIG_DEMO).load()
 
@@ -745,7 +745,7 @@ async def test_auth_kubeconfig_with_filename():
 @pytest.mark.xfail(
     reason="Updating the default client configuration is broken in kubernetes"
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auth_kubeconfig_with_context():
     await KubeConfig(config_file=CONFIG_DEMO, context="exp-scratch").load()
 
@@ -760,7 +760,7 @@ async def test_auth_kubeconfig_with_context():
 @pytest.mark.xfail(
     reason="Updating the default client configuration is broken in async kubernetes"
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_auth_explicit():
     await KubeAuth(
         host="https://9.8.7.6", username="abc", password="some-password"
@@ -775,14 +775,14 @@ async def test_auth_explicit():
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_start_with_workers(k8s_cluster, pod_spec):
     async with KubeCluster(pod_spec, n_workers=2, **cluster_kwargs) as cluster:
         async with Client(cluster, asynchronous=True) as client:
             await client.wait_for_workers(2)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.xfail(reason="Flaky in CI and classic is deprecated anyway")
 async def test_adapt_delete(cluster, ns):
     """
@@ -825,7 +825,7 @@ async def test_adapt_delete(cluster, ns):
     assert len(cluster.scheduler_info["workers"]) == 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.xfail(reason="Failing in CI with FileNotFoundError")
 async def test_auto_refresh(cluster):
     config = {

--- a/dask_kubernetes/common/tests/test_kind.py
+++ b/dask_kubernetes/common/tests/test_kind.py
@@ -11,7 +11,7 @@ def test_config_detection(k8s_cluster):
     assert b"pytest-kind" in check_output(["kubectl", "config", "current-context"])
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.xfail(reason="Has asyncio issues on CI")
 async def test_auth(k8s_cluster):
     await ClusterAuth.load_first(ClusterAuth.DEFAULT)

--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -128,3 +128,8 @@ def customresources(k8s_cluster):
     yield
     k8s_cluster.kubectl("delete", "--wait=false", "-f", temp_dir.name)
     temp_dir.cleanup()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/dask_kubernetes/helm/tests/test_helm.py
+++ b/dask_kubernetes/helm/tests/test_helm.py
@@ -154,7 +154,7 @@ def test_raises_on_non_existant_release(k8s_cluster):
         HelmCluster(release_name="nosuchrelease", namespace="default")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_create_helm_cluster(cluster, release_name):
     assert cluster.status == Status.running
     assert cluster.release_name == release_name
@@ -168,7 +168,7 @@ def test_create_sync_helm_cluster(sync_cluster, release_name):
     assert "id" in cluster.scheduler_info
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scale_cluster(cluster):
     # Scale up
     await cluster.scale(4)
@@ -197,7 +197,7 @@ async def test_scale_cluster(cluster):
         await cluster.scale(2, worker_group="bar")
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_logs(cluster):
     from distributed.utils import Logs
 
@@ -211,13 +211,13 @@ async def test_logs(cluster):
     assert "Scheduler at:" in scheduler_logs
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_adaptivity_warning(cluster):
     with pytest.raises(NotImplementedError):
         await cluster.adapt(minimum=3, maximum=3)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.xfail(reason="Has asyncio issues on CI")
 async def test_discovery(release, release_name):
     discovery = "helmcluster"

--- a/dask_kubernetes/helm/tests/test_helm.py
+++ b/dask_kubernetes/helm/tests/test_helm.py
@@ -1,5 +1,4 @@
 import pytest
-import pytest_asyncio
 
 import subprocess
 import os.path
@@ -95,7 +94,7 @@ def release(k8s_cluster, chart_name, test_namespace, release_name, config_path):
     subprocess.run(["helm", "delete", "-n", test_namespace, release_name], check=True)
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def cluster(k8s_cluster, release, test_namespace):
     from dask_kubernetes import HelmCluster
 

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -103,7 +103,7 @@ def test_operator_plugins(kopf_runner):
 
 
 @pytest.mark.timeout(180)
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as (cluster_name, ns):
@@ -247,7 +247,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             assert "worker-sublabel" in workergroup_labels
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as (cluster_name, ns):
@@ -292,7 +292,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
                     await client.wait_for_workers(3)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_scalesimplecluster_from_cluster_spec(
     k8s_cluster, kopf_runner, gen_cluster
 ):
@@ -339,7 +339,7 @@ async def test_scalesimplecluster_from_cluster_spec(
                     await client.wait_for_workers(3)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_recreate_scheduler_pod(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as (cluster_name, ns):
@@ -377,7 +377,7 @@ async def test_recreate_scheduler_pod(k8s_cluster, kopf_runner, gen_cluster):
             )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_recreate_worker_pods(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as (cluster_name, ns):
@@ -406,7 +406,7 @@ async def test_recreate_worker_pods(k8s_cluster, kopf_runner, gen_cluster):
             )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_simplecluster_batched_worker_deployments(
     k8s_cluster, kopf_runner, gen_cluster
 ):
@@ -492,7 +492,7 @@ def _assert_final_job_status(job, job_status, expected_status):
     }
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_job(k8s_cluster, kopf_runner, gen_job):
     with kopf_runner as runner:
         async with gen_job("simplejob.yaml") as (job, ns):
@@ -563,7 +563,7 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
     assert "Job succeeded, deleting Dask cluster." in runner.stdout
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_failed_job(k8s_cluster, kopf_runner, gen_job):
     with kopf_runner as runner:
         async with gen_job("failedjob.yaml") as (job, ns):
@@ -621,7 +621,7 @@ async def test_failed_job(k8s_cluster, kopf_runner, gen_job):
     assert "Job failed, deleting Dask cluster." in runner.stdout
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_object_dask_cluster(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as (cluster_name, ns):
@@ -645,7 +645,7 @@ async def test_object_dask_cluster(k8s_cluster, kopf_runner, gen_cluster):
             assert isinstance(scheduler_service, Service)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_object_dask_worker_group(k8s_cluster, kopf_runner, gen_cluster):
     with kopf_runner as runner:
         async with gen_cluster() as (cluster_name, ns):
@@ -674,7 +674,7 @@ async def test_object_dask_worker_group(k8s_cluster, kopf_runner, gen_cluster):
             assert (await wg.cluster()).name == cluster.name
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.skip(reason="Flaky in CI")
 async def test_object_dask_job(k8s_cluster, kopf_runner, gen_job):
     with kopf_runner as runner:

--- a/dask_kubernetes/operator/kubecluster/tests/conftest.py
+++ b/dask_kubernetes/operator/kubecluster/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import pytest_asyncio
 
 import dask.config
 
@@ -14,7 +13,7 @@ def cluster(kopf_runner, docker_image):
                 yield cluster
 
 
-@pytest_asyncio.fixture
+@pytest.fixture
 async def async_cluster(kopf_runner, docker_image):
     with dask.config.set({"kubernetes.name": "foo-{uuid}"}):
         with kopf_runner:

--- a/dask_kubernetes/operator/kubecluster/tests/test_discovery.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_discovery.py
@@ -5,7 +5,7 @@ from dask_kubernetes.operator import KubeCluster
 from dask_kubernetes.operator import discover
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_discovery(async_cluster):
     clusters = [name async for name, _ in discover()]
     assert async_cluster.name in clusters

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -25,7 +25,7 @@ def test_kubecluster(cluster):
         assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_kubecluster_async(kopf_runner, docker_image):
     with kopf_runner:
         async with KubeCluster(
@@ -96,7 +96,7 @@ def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image):
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_cluster_from_name(kopf_runner, docker_image, ns):
     with kopf_runner:
         async with KubeCluster(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,10 +2,10 @@ flake8>=3.7
 black>=18.9b0
 dask-ctl>=2021.3.0
 pytest>=7.1
-pytest-asyncio>=0.17
 git+https://codeberg.org/hjacobs/pytest-kind.git
 pytest-timeout
 pytest-rerunfailures
 git+https://github.com/elemental-lf/k8s-crd-resolver@v0.14.0
 jsonschema==4.17.3
 dask[complete]
+anyio

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,3 @@ addopts = -v -x --keep-cluster --durations=10
 timeout = 60
 timeout_func_only = true
 reruns = 3
-asyncio_mode = strict


### PR DESCRIPTION
In https://github.com/dask/distributed/issues/7984 @fjetter and @graingert suggested moving away from `pytest-asyncio`.

This PR updates all tests to use `anyio` but with just the `asyncio` backend.