### PR TITLE
Migrate KubeCluster close to kr8s

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -33,10 +33,8 @@ from distributed.utils import (
     TimeoutError,
     format_dashboard_link,
 )
-from kubernetes_asyncio.client.exceptions import ApiException
 
 from dask_kubernetes.common.auth import ClusterAuth
-
 from dask_kubernetes.common.networking import (
     get_scheduler_address,
     wait_for_scheduler,
@@ -743,25 +741,15 @@ class KubeCluster(Cluster):
     async def _close(self, timeout=3600):
         await super()._close()
         if self.shutdown_on_close:
-            async with kubernetes.client.api_client.ApiClient() as api_client:
-                custom_objects_api = kubernetes.client.CustomObjectsApi(api_client)
-                try:
-                    await custom_objects_api.delete_namespaced_custom_object(
-                        group="kubernetes.dask.org",
-                        version="v1",
-                        plural="daskclusters",
-                        namespace=self.namespace,
-                        name=self.name,
-                    )
-                except ApiException as e:
-                    if e.reason == "Not Found":
-                        logger.warning(
-                            "Failed to delete DaskCluster, looks like it has already been deleted."
-                        )
-                    else:
-                        raise
+            cluster = await DaskCluster(self.name, namespace=self.namespace)
+            try:
+                await cluster.delete()
+            except kr8s.NotFoundError:
+                logger.warning(
+                    "Failed to delete DaskCluster, looks like it has already been deleted."
+                )
             start = time.time()
-            while (await self._get_cluster()) is not None:
+            while await cluster.exists():
                 if time.time() > start + timeout:
                     raise TimeoutError(
                         f"Timed out deleting cluster resource {self.name}"


### PR DESCRIPTION
Pulling out another chunk of #785. This one updates `KubeCluster._close()` to use `kr8s`.