### PR TITLE
Migrate KubeCluster create resource to kr8s

### DIFF
--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -18,7 +18,7 @@ check_dependency("helm")
 check_dependency("kubectl")
 check_dependency("docker")
 
-for mod in ("httpx", "httpcore"):
+for mod in ("httpx", "httpcore", "httpcore.http11"):
     logging.getLogger().setLevel(logging.WARNING)
 
 

--- a/dask_kubernetes/conftest.py
+++ b/dask_kubernetes/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+import logging
 import pathlib
 import os
 import subprocess
@@ -16,6 +17,9 @@ DIR = pathlib.Path(__file__).parent.absolute()
 check_dependency("helm")
 check_dependency("kubectl")
 check_dependency("docker")
+
+for mod in ("httpx", "httpcore"):
+    logging.getLogger().setLevel(logging.WARNING)
 
 
 @pytest.fixture()

--- a/dask_kubernetes/operator/_objects.py
+++ b/dask_kubernetes/operator/_objects.py
@@ -3,6 +3,8 @@ from typing import List
 
 from kr8s.asyncio.objects import APIObject, Pod, Deployment, Service
 
+WAIT_TIMEOUT = 30
+
 
 class DaskCluster(APIObject):
     version = "kubernetes.dask.org/v1"
@@ -115,7 +117,9 @@ class DaskWorkerGroup(APIObject):
         )
 
     async def cluster(self) -> DaskCluster:
-        return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
+        return await DaskCluster.get(
+            self.spec.cluster, namespace=self.namespace, timeout=WAIT_TIMEOUT
+        )
 
 
 class DaskAutoscaler(APIObject):
@@ -127,7 +131,9 @@ class DaskAutoscaler(APIObject):
     namespaced = True
 
     async def cluster(self) -> DaskCluster:
-        return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
+        return await DaskCluster.get(
+            self.spec.cluster, namespace=self.namespace, timeout=WAIT_TIMEOUT
+        )
 
 
 class DaskJob(APIObject):
@@ -139,7 +145,9 @@ class DaskJob(APIObject):
     namespaced = True
 
     async def cluster(self) -> DaskCluster:
-        return await DaskCluster.get(self.name, namespace=self.namespace)
+        return await DaskCluster.get(
+            self.name, namespace=self.namespace, timeout=WAIT_TIMEOUT
+        )
 
     async def pod(self) -> Pod:
         pods = []

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -1008,7 +1008,7 @@ def make_scheduler_spec(
 
 async def wait_for_service(service_name, namespace):
     """Block until service is available."""
-    service = await Service.get(service_name, namespace)
+    service = await Service.get(service_name, namespace=namespace)
     while not await service.ready():
         await asyncio.sleep(0.1)
 

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -139,14 +139,19 @@ def test_cluster_without_operator(docker_image):
         KubeCluster(name="noop", n_workers=1, image=docker_image, resource_timeout=1)
 
 
-def test_cluster_crashloopbackoff(kopf_runner, docker_image):
+def test_cluster_crashloopbackoff(kopf_runner, docker_image, ns):
     with kopf_runner:
         with pytest.raises(SchedulerStartupError, match="Scheduler failed to start"):
             spec = make_cluster_spec(name="crashloopbackoff", n_workers=1)
             spec["spec"]["scheduler"]["spec"]["containers"][0]["args"][
                 0
             ] = "dask-schmeduler"
-            KubeCluster(custom_cluster_spec=spec, resource_timeout=1, idle_timeout=2)
+            KubeCluster(
+                custom_cluster_spec=spec,
+                namespace=ns,
+                resource_timeout=1,
+                idle_timeout=2,
+            )
 
 
 def test_adapt(kopf_runner, docker_image):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ kubernetes-asyncio>=12.0.1
 kopf>=1.35.3
 pykube-ng>=22.9.0
 rich>=12.5.1
-kr8s==0.8.9
+kr8s==0.8.10


### PR DESCRIPTION
Pulling out another chunk of #785. This one updates `KubeCluster._create_cluster()` to use `kr8s`.