### PR TITLE
EXPERIMENT Reduce CI hangs

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -245,7 +245,9 @@ def build_cluster_spec(name, worker_spec, scheduler_spec, annotations, labels):
 
 
 @kopf.on.startup()
-async def startup(settings: kopf.OperatorSettings, **kwargs):
+async def startup(settings: kopf.OperatorSettings, logger, **kwargs):
+    logger.info("Starting Dask Kubernetes Operator")
+
     # Authenticate with k8s
     await ClusterAuth.load_first()
 

--- a/dask_kubernetes/operator/kubecluster/tests/conftest.py
+++ b/dask_kubernetes/operator/kubecluster/tests/conftest.py
@@ -6,9 +6,9 @@ from dask_kubernetes.operator import KubeCluster
 
 
 @pytest.fixture
-def cluster(kopf_runner, docker_image):
+async def cluster(kopf_runner, docker_image):
     with dask.config.set({"kubernetes.name": "foo-{uuid}"}):
-        with kopf_runner:
+        async with kopf_runner():
             with KubeCluster(image=docker_image, n_workers=1) as cluster:
                 yield cluster
 
@@ -16,7 +16,7 @@ def cluster(kopf_runner, docker_image):
 @pytest.fixture
 async def async_cluster(kopf_runner, docker_image):
     with dask.config.set({"kubernetes.name": "foo-{uuid}"}):
-        with kopf_runner:
+        async with kopf_runner():
             async with KubeCluster(
                 image=docker_image, n_workers=1, asynchronous=True
             ) as cluster:

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -16,7 +16,8 @@ def test_experimental_shim():
     assert ExperimentalKubeCluster is KubeCluster
 
 
-def test_kubecluster(cluster):
+@pytest.mark.anyio
+async def test_kubecluster(cluster):
     assert "foo" in cluster.name
 
     with Client(cluster) as client:
@@ -27,7 +28,7 @@ def test_kubecluster(cluster):
 
 @pytest.mark.anyio
 async def test_kubecluster_async(kopf_runner, docker_image, ns):
-    with kopf_runner:
+    async with kopf_runner():
         async with KubeCluster(
             name="async",
             image=docker_image,
@@ -39,8 +40,9 @@ async def test_kubecluster_async(kopf_runner, docker_image, ns):
                 assert await client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_custom_worker_command(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_custom_worker_command(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with KubeCluster(
             name="customworker",
             image=docker_image,
@@ -52,8 +54,9 @@ def test_custom_worker_command(kopf_runner, docker_image, ns):
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_multiple_clusters(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_multiple_clusters(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with KubeCluster(
             name="bar", image=docker_image, n_workers=1, namespace=ns
         ) as cluster1:
@@ -66,8 +69,9 @@ def test_multiple_clusters(kopf_runner, docker_image, ns):
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_clusters_with_custom_port_forward(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_clusters_with_custom_port_forward(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with KubeCluster(
             name="bar",
             image=docker_image,
@@ -80,8 +84,9 @@ def test_clusters_with_custom_port_forward(kopf_runner, docker_image, ns):
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_multiple_clusters_simultaneously(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_multiple_clusters_simultaneously(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with KubeCluster(
             name="fizz", image=docker_image, n_workers=1, namespace=ns
         ) as cluster1, KubeCluster(
@@ -93,8 +98,11 @@ def test_multiple_clusters_simultaneously(kopf_runner, docker_image, ns):
 
 
 @pytest.mark.skip(reason="Flaky and fails ~10% of the time.")
-def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_multiple_clusters_simultaneously_same_loop(
+    kopf_runner, docker_image, ns
+):
+    async with kopf_runner():
         with KubeCluster(
             name="fizz", image=docker_image, n_workers=1, namespace=ns
         ) as cluster1, KubeCluster(
@@ -112,7 +120,7 @@ def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image, n
 
 @pytest.mark.anyio
 async def test_cluster_from_name(kopf_runner, docker_image, ns):
-    with kopf_runner:
+    async with kopf_runner():
         async with KubeCluster(
             name="abc",
             namespace=ns,
@@ -128,16 +136,18 @@ async def test_cluster_from_name(kopf_runner, docker_image, ns):
             assert cluster.status["phase"] == "Running"
 
 
-def test_cluster_scheduler_info_updated(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_cluster_scheduler_info_updated(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with KubeCluster(name="abc", namespace=ns, image=docker_image) as firstcluster:
             with KubeCluster.from_name("abc", namespace=ns) as secondcluster:
                 firstcluster.scale(1)
                 assert firstcluster.scheduler_info == secondcluster.scheduler_info
 
 
-def test_additional_worker_groups(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_additional_worker_groups(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with KubeCluster(
             name="additionalgroups", n_workers=1, image=docker_image, namespace=ns
         ) as cluster:
@@ -159,8 +169,9 @@ def test_cluster_without_operator(docker_image, ns):
         )
 
 
-def test_cluster_crashloopbackoff(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_cluster_crashloopbackoff(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with pytest.raises(SchedulerStartupError, match="Scheduler failed to start"):
             spec = make_cluster_spec(name="crashloopbackoff", n_workers=1)
             spec["spec"]["scheduler"]["spec"]["containers"][0]["args"][
@@ -174,8 +185,9 @@ def test_cluster_crashloopbackoff(kopf_runner, docker_image, ns):
             )
 
 
-def test_adapt(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_adapt(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         with KubeCluster(
             name="adaptive",
             image=docker_image,
@@ -192,8 +204,9 @@ def test_adapt(kopf_runner, docker_image, ns):
             cluster.scale(0)
 
 
-def test_custom_spec(kopf_runner, docker_image, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_custom_spec(kopf_runner, docker_image, ns):
+    async with kopf_runner():
         spec = make_cluster_spec("customspec", image=docker_image)
         with KubeCluster(
             custom_cluster_spec=spec, n_workers=1, namespace=ns
@@ -202,8 +215,9 @@ def test_custom_spec(kopf_runner, docker_image, ns):
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_typo_resource_limits(kopf_runner, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_typo_resource_limits(kopf_runner, ns):
+    async with kopf_runner():
         with pytest.raises(ValueError):
             KubeCluster(
                 name="foo",
@@ -217,7 +231,8 @@ def test_typo_resource_limits(kopf_runner, ns):
 
 
 @pytest.mark.xfail(reason="Intermittently fails in CI")
-def test_invalid_kwargs_exception(kopf_runner, ns):
-    with kopf_runner:
+@pytest.mark.anyio
+async def test_invalid_kwargs_exception(kopf_runner, ns):
+    async with kopf_runner():
         with pytest.raises(kubernetes.client.ApiException):
             KubeCluster(name="foo", n_workers="1", namespace=ns)

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -26,56 +26,66 @@ def test_kubecluster(cluster):
 
 
 @pytest.mark.anyio
-async def test_kubecluster_async(kopf_runner, docker_image):
+async def test_kubecluster_async(kopf_runner, docker_image, ns):
     with kopf_runner:
         async with KubeCluster(
             name="async",
             image=docker_image,
             n_workers=1,
             asynchronous=True,
+            namespace=ns,
         ) as cluster:
             async with Client(cluster, asynchronous=True) as client:
                 assert await client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_custom_worker_command(kopf_runner, docker_image):
+def test_custom_worker_command(kopf_runner, docker_image, ns):
     with kopf_runner:
         with KubeCluster(
             name="customworker",
             image=docker_image,
             worker_command=["python", "-m", "distributed.cli.dask_worker"],
             n_workers=1,
+            namespace=ns,
         ) as cluster:
             with Client(cluster) as client:
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_multiple_clusters(kopf_runner, docker_image):
+def test_multiple_clusters(kopf_runner, docker_image, ns):
     with kopf_runner:
-        with KubeCluster(name="bar", image=docker_image, n_workers=1) as cluster1:
+        with KubeCluster(
+            name="bar", image=docker_image, n_workers=1, namespace=ns
+        ) as cluster1:
             with Client(cluster1) as client1:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
-        with KubeCluster(name="baz", image=docker_image, n_workers=1) as cluster2:
+        with KubeCluster(
+            name="baz", image=docker_image, n_workers=1, namespace=ns
+        ) as cluster2:
             with Client(cluster2) as client2:
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_clusters_with_custom_port_forward(kopf_runner, docker_image):
+def test_clusters_with_custom_port_forward(kopf_runner, docker_image, ns):
     with kopf_runner:
         with KubeCluster(
-            name="bar", image=docker_image, n_workers=1, scheduler_forward_port=8888
+            name="bar",
+            image=docker_image,
+            n_workers=1,
+            scheduler_forward_port=8888,
+            namespace=ns,
         ) as cluster1:
             assert cluster1.forwarded_dashboard_port == "8888"
             with Client(cluster1) as client1:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_multiple_clusters_simultaneously(kopf_runner, docker_image):
+def test_multiple_clusters_simultaneously(kopf_runner, docker_image, ns):
     with kopf_runner:
         with KubeCluster(
-            name="fizz", image=docker_image, n_workers=1
+            name="fizz", image=docker_image, n_workers=1, namespace=ns
         ) as cluster1, KubeCluster(
-            name="buzz", image=docker_image, n_workers=1
+            name="buzz", image=docker_image, n_workers=1, namespace=ns
         ) as cluster2:
             with Client(cluster1) as client1, Client(cluster2) as client2:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
@@ -83,12 +93,16 @@ def test_multiple_clusters_simultaneously(kopf_runner, docker_image):
 
 
 @pytest.mark.skip(reason="Flaky and fails ~10% of the time.")
-def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image):
+def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image, ns):
     with kopf_runner:
         with KubeCluster(
-            name="fizz", image=docker_image, n_workers=1
+            name="fizz", image=docker_image, n_workers=1, namespace=ns
         ) as cluster1, KubeCluster(
-            name="buzz", image=docker_image, loop=cluster1.loop, n_workers=1
+            name="buzz",
+            image=docker_image,
+            loop=cluster1.loop,
+            n_workers=1,
+            namespace=ns,
         ) as cluster2:
             with Client(cluster1) as client1, Client(cluster2) as client2:
                 assert cluster1.loop is cluster2.loop is client1.loop is client2.loop
@@ -122,10 +136,10 @@ def test_cluster_scheduler_info_updated(kopf_runner, docker_image, ns):
                 assert firstcluster.scheduler_info == secondcluster.scheduler_info
 
 
-def test_additional_worker_groups(kopf_runner, docker_image):
+def test_additional_worker_groups(kopf_runner, docker_image, ns):
     with kopf_runner:
         with KubeCluster(
-            name="additionalgroups", n_workers=1, image=docker_image
+            name="additionalgroups", n_workers=1, image=docker_image, namespace=ns
         ) as cluster:
             cluster.add_worker_group(name="more", n_workers=1)
             with Client(cluster) as client:
@@ -134,27 +148,39 @@ def test_additional_worker_groups(kopf_runner, docker_image):
             cluster.delete_worker_group(name="more")
 
 
-def test_cluster_without_operator(docker_image):
+def test_cluster_without_operator(docker_image, ns):
     with pytest.raises(TimeoutError, match="is the Dask Operator running"):
-        KubeCluster(name="noop", n_workers=1, image=docker_image, resource_timeout=1)
+        KubeCluster(
+            name="noop",
+            n_workers=1,
+            image=docker_image,
+            resource_timeout=1,
+            namespace=ns,
+        )
 
 
-def test_cluster_crashloopbackoff(kopf_runner, docker_image):
+def test_cluster_crashloopbackoff(kopf_runner, docker_image, ns):
     with kopf_runner:
         with pytest.raises(SchedulerStartupError, match="Scheduler failed to start"):
             spec = make_cluster_spec(name="crashloopbackoff", n_workers=1)
             spec["spec"]["scheduler"]["spec"]["containers"][0]["args"][
                 0
             ] = "dask-schmeduler"
-            KubeCluster(custom_cluster_spec=spec, resource_timeout=1, idle_timeout=2)
+            KubeCluster(
+                custom_cluster_spec=spec,
+                resource_timeout=1,
+                idle_timeout=2,
+                namespace=ns,
+            )
 
 
-def test_adapt(kopf_runner, docker_image):
+def test_adapt(kopf_runner, docker_image, ns):
     with kopf_runner:
         with KubeCluster(
             name="adaptive",
             image=docker_image,
             n_workers=0,
+            namespace=ns,
         ) as cluster:
             cluster.adapt(minimum=0, maximum=1)
             with Client(cluster) as client:
@@ -166,15 +192,17 @@ def test_adapt(kopf_runner, docker_image):
             cluster.scale(0)
 
 
-def test_custom_spec(kopf_runner, docker_image):
+def test_custom_spec(kopf_runner, docker_image, ns):
     with kopf_runner:
         spec = make_cluster_spec("customspec", image=docker_image)
-        with KubeCluster(custom_cluster_spec=spec, n_workers=1) as cluster:
+        with KubeCluster(
+            custom_cluster_spec=spec, n_workers=1, namespace=ns
+        ) as cluster:
             with Client(cluster) as client:
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_typo_resource_limits(kopf_runner):
+def test_typo_resource_limits(kopf_runner, ns):
     with kopf_runner:
         with pytest.raises(ValueError):
             KubeCluster(
@@ -184,11 +212,12 @@ def test_typo_resource_limits(kopf_runner):
                         "CPU": "1",
                     },
                 },
+                namespace=ns,
             )
 
 
 @pytest.mark.xfail(reason="Intermittently fails in CI")
-def test_invalid_kwargs_exception(kopf_runner):
+def test_invalid_kwargs_exception(kopf_runner, ns):
     with kopf_runner:
         with pytest.raises(kubernetes.client.ApiException):
-            KubeCluster(name="foo", n_workers="1")
+            KubeCluster(name="foo", n_workers="1", namespace=ns)


### PR DESCRIPTION
This PR tries two things to help reduce CI hangs:

- Run all KubeCluster tests in their own namespace
- Run the kopf controller on the same event loop instead of in a thread