### PR TITLE
Expose --jupyter on the scheduler

### DIFF
--- a/dask_kubernetes/cli/cli.py
+++ b/dask_kubernetes/cli/cli.py
@@ -97,9 +97,7 @@ def port_forward(cluster):
         console.print(f"Scheduler at: [magenta][not bold]{kcluster.scheduler_address}")
         console.print(f"Dashboard at: [cyan][not bold]{kcluster.dashboard_link}")
         if kcluster.jupyter:
-            console.print(
-                f"Jupyter at: [orange3][not bold]{kcluster.dashboard_link.replace('/status', '/jupyter/lab')}"
-            )
+            console.print(f"Jupyter at: [orange3][not bold]{kcluster.jupyter_link}")
         console.print("Press ctrl+c to exit", style="bright_black")
         while True:
             time.sleep(0.1)

--- a/dask_kubernetes/cli/cli.py
+++ b/dask_kubernetes/cli/cli.py
@@ -55,6 +55,13 @@ def gen():
     default=None,
     help="Service type for scheduler (default 'ClusterIP')",
 )
+@click.option(
+    "--jupyter",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Start Jupyter on the scheduler (default 'False')",
+)
 def cluster(**kwargs):
     if "resources" in kwargs and kwargs["resources"] is not None:
         kwargs["resources"] = json.loads(kwargs["resources"])
@@ -89,6 +96,10 @@ def port_forward(cluster):
     try:
         console.print(f"Scheduler at: [magenta][not bold]{kcluster.scheduler_address}")
         console.print(f"Dashboard at: [cyan][not bold]{kcluster.dashboard_link}")
+        if kcluster.jupyter:
+            console.print(
+                f"Jupyter at: [orange3][not bold]{kcluster.dashboard_link.replace('/status', '/jupyter/lab')}"
+            )
         console.print("Press ctrl+c to exit", style="bright_black")
         while True:
             time.sleep(0.1)

--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -21,6 +21,7 @@ kubernetes:
   resource-timeout: 60
   custom-cluster-spec: null
   scheduler-forward-port: null
+  scheduler-jupyter: false
 
   # Classic KubeCluster options
   host: "0.0.0.0"

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -818,6 +818,12 @@ class KubeCluster(Cluster):
             **kwargs,
         )
 
+    @property
+    def jupyter_link(self):
+        if self.jupyter:
+            return self.dashboard_link.replace("/status", "/jupyter/lab")
+        raise RuntimeError("KubeCluster not started with jupyter enabled")
+
 
 def make_cluster_spec(
     name,


### PR DESCRIPTION
If you set `--jupyter` on the `dask scheduler` command it will start Jupyter on the same web server as the dashboard. This PR exposes that easily via `KubeCluster` and the `dask kubernetes gen` CLI.

```python
dask_kubernetes.operator import KubeCluster

# NOTE: The image must have Jupyter installed
cluster = KubeCluster(name="dask-jupyter", image="ghcr.io/dask/dask-notebook:latest", jupyter=True)

# You can quickly get the Jupyter link with
print(cluster.jupyter_link)
```

This is also with with `dask kubernetes gen cluster`.

```console
$ dask kubernetes gen cluster --name dask-jupyter --image ghcr.io/dask/dask-notebook:latest --jupyter
```

And the link is listed in the `dask kubernetes port-forward` output.

```console
$ dask kubernetes port-forward dask-jupyter
Scheduler at: tcp://localhost:50457
Dashboard at: http://localhost:62546/status
Jupyter at: http://localhost:62546/jupyter/lab
Press ctrl+c to exit
```
