### PR TITLE
Fix port number when use NodePort (#806)

### DIFF
--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -24,11 +24,7 @@ async def get_internal_address_for_scheduler_service(
     local_port=None,
 ):
     """Take a service object and return the scheduler address."""
-    [port] = [
-        port.port
-        for port in service.spec.ports
-        if port.name == service.metadata.name or port.name == port_name
-    ]
+    port = _get_port(service, port_name)
     if not port_forward_cluster_ip:
         with suppress(socket.gaierror):
             # Try to resolve the service name. If we are inside the cluster this should succeed.
@@ -57,15 +53,15 @@ async def get_external_address_for_scheduler_service(
 ):
     """Take a service object and return the scheduler address."""
     if service.spec.type == "LoadBalancer":
-        port = _get_port(service)
+        port = _get_port(service, port_name)
         lb = service.status.load_balancer.ingress[0]
         host = lb.hostname or lb.ip
     elif service.spec.type == "NodePort":
-        port = _get_port(service, is_node_port=True)
+        port = _get_port(service, port_name, is_node_port=True)
         nodes = await core_api.list_node()
         host = nodes.items[0].status.addresses[0].address
     elif service.spec.type == "ClusterIP":
-        port = _get_port(service)
+        port = _get_port(service, port_name)
         if not port_forward_cluster_ip:
             with suppress(socket.gaierror):
                 # Try to resolve the service name. If we are inside the cluster this should succeed.


### PR DESCRIPTION
Here is an explanation why we have to use `node_port` instead of `port` when service type is `NodePort`: https://stackoverflow.com/a/41510604/983577