### PR TITLE
Use kr8s in common networking

### DIFF
--- a/dask_kubernetes/common/networking.py
+++ b/dask_kubernetes/common/networking.py
@@ -2,17 +2,14 @@ import asyncio
 from contextlib import suppress
 import random
 import socket
-import subprocess
 import time
-from weakref import finalize
-import kubernetes_asyncio as kubernetes
+import threading
 from tornado.iostream import StreamClosedError
 
 import kr8s
-from kr8s.asyncio.objects import Pod
+from kr8s.asyncio.objects import Pod, Service
 from distributed.core import rpc
 
-from dask_kubernetes.common.utils import check_dependency
 from dask_kubernetes.exceptions import CrashLoopBackOffError
 
 
@@ -48,7 +45,6 @@ async def get_internal_address_for_scheduler_service(
 
 
 async def get_external_address_for_scheduler_service(
-    core_api,
     service,
     port_forward_cluster_ip=None,
     service_name_resolution_retries=20,
@@ -65,8 +61,8 @@ async def get_external_address_for_scheduler_service(
         lb = service.status.load_balancer.ingress[0]
         host = lb.hostname or lb.ip
     elif service.spec.type == "NodePort":
-        nodes = await core_api.list_node()
-        host = nodes.items[0].status.addresses[0].address
+        nodes = await kr8s.asyncio.get("nodes")
+        host = nodes[0].status.addresses[0].address
     elif service.spec.type == "ClusterIP":
         if not port_forward_cluster_ip:
             with suppress(socket.gaierror):
@@ -122,30 +118,36 @@ def _random_free_port(low, high, retries=20):
 
 
 async def port_forward_service(service_name, namespace, remote_port, local_port=None):
-    check_dependency("kubectl")
     if not local_port:
         local_port = _random_free_port(49152, 65535)  # IANA suggested range
     elif _port_in_use(local_port):
         raise ConnectionError("Specified Port already in use.")
-    kproc = subprocess.Popen(
-        [
-            "kubectl",
-            "port-forward",
-            "--address",
-            "0.0.0.0",
-            "--namespace",
-            f"{namespace}",
-            f"service/{service_name}",
-            f"{local_port}:{remote_port}",
-        ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+    pf = threading.Thread(
+        name=f"DaskKubernetesPortForward ({namespace}/{service_name} {local_port}->{remote_port})",
+        target=run_port_forward,
+        args=(
+            service_name,
+            namespace,
+            remote_port,
+            local_port,
+        ),
+        daemon=True,
     )
-    finalize(kproc, kproc.kill)
+    pf.start()
 
     if await is_comm_open("localhost", local_port, retries=2000):
         return local_port
-    raise ConnectionError("kubectl port forward failed")
+    raise ConnectionError("port forward failed")
+
+
+def run_port_forward(service_name, namespace, remote_port, local_port):
+    async def _run():
+        svc = await Service.get(service_name, namespace=namespace)
+        async with svc.portforward(remote_port, local_port):
+            while True:
+                await asyncio.sleep(0.1)
+
+    asyncio.run(_run())
 
 
 async def is_comm_open(ip, port, retries=200):
@@ -173,25 +175,22 @@ async def get_scheduler_address(
     local_port=None,
     allow_external=True,
 ):
-    async with kubernetes.client.api_client.ApiClient() as api_client:
-        api = kubernetes.client.CoreV1Api(api_client)
-        service = await api.read_namespaced_service(service_name, namespace)
-        if allow_external:
-            address = await get_external_address_for_scheduler_service(
-                api,
-                service,
-                port_forward_cluster_ip=port_forward_cluster_ip,
-                port_name=port_name,
-                local_port=local_port,
-            )
-        else:
-            address = await get_internal_address_for_scheduler_service(
-                service,
-                port_forward_cluster_ip=port_forward_cluster_ip,
-                port_name=port_name,
-                local_port=local_port,
-            )
-        return address
+    service = await Service.get(service_name, namespace=namespace)
+    if allow_external:
+        address = await get_external_address_for_scheduler_service(
+            service,
+            port_forward_cluster_ip=port_forward_cluster_ip,
+            port_name=port_name,
+            local_port=local_port,
+        )
+    else:
+        address = await get_internal_address_for_scheduler_service(
+            service,
+            port_forward_cluster_ip=port_forward_cluster_ip,
+            port_name=port_name,
+            local_port=local_port,
+        )
+    return address
 
 
 async def wait_for_scheduler(cluster_name, namespace, timeout=None):

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -17,7 +17,7 @@ from dask_kubernetes.operator._objects import (
     DaskWorkerGroup,
     DaskJob,
 )
-from dask_kubernetes.common.networking import get_scheduler_address
+from dask_kubernetes.operator.networking import get_scheduler_address
 from distributed.core import rpc, clean_exception
 from distributed.protocol.pickle import dumps
 import dask.config

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -17,7 +17,6 @@ from dask_kubernetes.operator._objects import (
     DaskWorkerGroup,
     DaskJob,
 )
-from dask_kubernetes.common.auth import ClusterAuth
 from dask_kubernetes.common.networking import get_scheduler_address
 from distributed.core import rpc, clean_exception
 from distributed.protocol.pickle import dumps
@@ -246,9 +245,6 @@ def build_cluster_spec(name, worker_spec, scheduler_spec, annotations, labels):
 
 @kopf.on.startup()
 async def startup(settings: kopf.OperatorSettings, **kwargs):
-    # Authenticate with k8s
-    await ClusterAuth.load_first()
-
     # Set server and client timeouts to reconnect from time to time.
     # In rare occasions the connection might go idle we will no longer receive any events.
     # These timeouts should help in those cases.

--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -34,7 +34,6 @@ from distributed.utils import (
     format_dashboard_link,
 )
 
-from dask_kubernetes.common.auth import ClusterAuth
 from dask_kubernetes.common.networking import (
     get_scheduler_address,
     wait_for_scheduler,
@@ -86,9 +85,6 @@ class KubeCluster(Cluster):
         The command to use when starting the worker.
         If command consists of multiple words it should be passed as a list of strings.
         Defaults to ``"dask-worker"``.
-    auth: List[ClusterAuth] (optional)
-        Configuration methods to attempt in order.  Defaults to
-        ``[InCluster(), KubeConfig()]``.
     port_forward_cluster_ip: bool (optional)
         If the chart uses ClusterIP type services, forward the
         ports locally. If you are running it locally it should
@@ -172,7 +168,6 @@ class KubeCluster(Cluster):
         resources=None,
         env=None,
         worker_command=None,
-        auth=ClusterAuth.DEFAULT,
         port_forward_cluster_ip=None,
         create_mode=None,
         shutdown_on_close=None,
@@ -207,7 +202,6 @@ class KubeCluster(Cluster):
         self.worker_command = dask.config.get(
             "kubernetes.worker-command", override_with=worker_command
         )
-        self.auth = auth
         self.port_forward_cluster_ip = dask.config.get(
             "kubernetes.port-forward-cluster-ip", override_with=port_forward_cluster_ip
         )
@@ -301,7 +295,6 @@ class KubeCluster(Cluster):
             )
             if not self.quiet:
                 show_rich_output_task = asyncio.create_task(self._show_rich_output())
-            await ClusterAuth.load_first(self.auth)
             cluster = await DaskCluster(self.name, namespace=self.namespace)
             cluster_exists = await cluster.exists()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ kubernetes-asyncio>=12.0.1
 kopf>=1.35.3
 pykube-ng>=22.9.0
 rich>=12.5.1
-kr8s==0.8.15
+kr8s==0.8.16


### PR DESCRIPTION
- Instead of calling `kubectl port-forward` in a subprocess use a `kr8s` port forward in a thread.
- Use kr8s to list nodes when using `NodePort`.
- Use kr8s to get the scheduler Service information.
- Remove unused `kubernetes` authentication from the controller and KubeCluster.