### PR TITLE
Add more deprecation warnings ahead of removing old code

### DIFF
--- a/dask_kubernetes/__init__.py
+++ b/dask_kubernetes/__init__.py
@@ -23,15 +23,6 @@ del get_versions
 
 def __getattr__(name):
     if name == "KubeCluster":
-        warn(
-            "It looks like you are using the classic implementation of KubeCluster. "
-            "Please consider migrating to the new operator based implementation "
-            "https://kubernetes.dask.org/en/latest/kubecluster_migrating.html. "
-            "To suppress this warning import KubeCluster directly from dask_kubernetes.classic. "
-            "But note this will be removed in the future. ",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         new_module = import_module("dask_kubernetes.classic")
         return getattr(new_module, name)
 

--- a/dask_kubernetes/classic/kubecluster.py
+++ b/dask_kubernetes/classic/kubecluster.py
@@ -452,6 +452,13 @@ class KubeCluster(SpecCluster):
         apply_default_affinity="preferred",
         **kwargs
     ):
+        warnings.warn(
+            "The classic KubeCluster is going away. "
+            "Please migrate to the new operator based implementation "
+            "https://kubernetes.dask.org/en/latest/kubecluster_migrating.html. ",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if isinstance(pod_template, str):
             with open(pod_template) as f:
                 pod_template = dask.config.expand_environment_variables(
@@ -561,7 +568,6 @@ class KubeCluster(SpecCluster):
         return pod_template
 
     async def _start(self):
-
         self.pod_template = self._get_pod_template(self.pod_template, pod_type="worker")
         self.scheduler_pod_template = self._get_pod_template(
             self.scheduler_pod_template, pod_type="scheduler"

--- a/dask_kubernetes/classic/tests/test_async.py
+++ b/dask_kubernetes/classic/tests/test_async.py
@@ -34,15 +34,6 @@ FAKE_KEY = os.path.join(TEST_DIR, "fake-key-file")
 FAKE_CA = os.path.join(TEST_DIR, "fake-ca-file")
 
 
-def test_deprecation_warning():
-    with pytest.deprecated_call():
-        from dask_kubernetes import KubeCluster as TLKubeCluster
-
-    from dask_kubernetes.classic import KubeCluster as ClassicKubeCluster
-
-    assert TLKubeCluster is ClassicKubeCluster
-
-
 @pytest.fixture
 def pod_spec(docker_image):
     yield clean_pod_template(

--- a/dask_kubernetes/helm/helmcluster.py
+++ b/dask_kubernetes/helm/helmcluster.py
@@ -92,6 +92,13 @@ class HelmCluster(Cluster):
         name=None,
         **kwargs,
     ):
+        warnings.warn(
+            "HelmCluster is going away. "
+            "Please migrate to the new operator based implementation "
+            "https://kubernetes.dask.org/en/latest/kubecluster_migrating.html. ",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.release_name = release_name
         self.namespace = namespace or get_current_namespace()
         if name is None:


### PR DESCRIPTION
For some time we've had a deprecation warning when users do `from dask_kubernetes import KubeCluster`. 

Now that the operator is more stable and is fully migrated to kr8s it's time for the classic `KubeCluster` and the `HelmCluster` to go away. This PR adds a more forceful deprecation warning to those classes ahead of full removal.