### PR TITLE
Fix pod logs

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -383,7 +383,7 @@ class KubeCluster(Cluster):
             raise SchedulerStartupError(
                 "Scheduler failed to start.",
                 "Scheduler Pod logs:",
-                await scheduler_pod.logs(),
+                "\n".join([line async for line in scheduler_pod.logs()]),
             ) from e
         self._log("Waiting for scheduler service")
         await wait_for_service(f"{self.name}-scheduler", self.namespace)
@@ -579,7 +579,7 @@ class KubeCluster(Cluster):
                         raise ValueError(
                             f"Cannot get logs for pod with status {pod.status.phase}.",
                         )
-                    log = Log(await pod.logs())
+                    log = Log("\n".join([line async for line in pod.logs()]))
                 except ValueError:
                     log = Log(f"Cannot find logs. Pod is {pod.status.phase}.")
             logs[pod.name] = log

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ kubernetes-asyncio>=12.0.1
 kopf>=1.35.3
 pykube-ng>=22.9.0
 rich>=12.5.1
-kr8s>=0.8.19
+kr8s>=0.9.0


### PR DESCRIPTION
In kr8s 0.9.0 (https://github.com/kr8s-org/kr8s/pull/182) the `kr8s.asyncio.objects.Pod.logs()` method changed from returning a string of all the logs to being a generator of each log line. 

This PR tweaks our usage to work with that.