### PR TITLE
Default resource_timeout to 60

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -168,7 +168,7 @@ class KubeCluster(Cluster):
         create_mode: Optional[CreateMode] = None,
         shutdown_on_close: Optional[bool] = None,
         idle_timeout: Optional[int] = None,
-        resource_timeout: Optional[int] = None,
+        resource_timeout: int = 60,
         scheduler_service_type: Optional[str] = None,
         custom_cluster_spec: Optional[str | dict] = None,
         scheduler_forward_port: Optional[int] = None,

--- a/doc/source/kubecluster_migrating.rst
+++ b/doc/source/kubecluster_migrating.rst
@@ -21,7 +21,7 @@ Here are some reasons why we decided to make this change:
 - Simpler Python API
 - More powerful YAML API
   - Create, scale and delete clusters with ``kubectl``
-- Detatch and reattactch from running clusters
+- Detach and reattach from running clusters
 - New resource types like ``DaskJob``
 - Multiple worker groups
 - Autoscaling handled by the controller and not the cluster manager


### PR DESCRIPTION
This brings it into alignment with the docstring:

```
    resource_timeout: int (optional)
        Time in seconds to wait for Kubernetes resources to enter their expected state.
        Example: If the ``DaskCluster`` resource that gets created isn't moved into a known ``status.phase``
        by the controller then it is likely the controller isn't running or is malfunctioning and we time
        out and clean up with a useful error.
        Example 2: If the scheduler Pod enters a ``CrashBackoffLoop`` state for longer than this timeout we
        give up with a useful error.
        Defaults to ``60`` seconds.
```

It also resolves an exception I ran into on this line when it tried to add a float to None.