### PR TITLE
Prepend user env vars

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -159,9 +159,9 @@ def build_worker_deployment_spec(
     ]
     for i in range(len(deployment_spec["spec"]["template"]["spec"]["containers"])):
         if "env" in deployment_spec["spec"]["template"]["spec"]["containers"][i]:
-            deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"].extend(
-                env
-            )
+            deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"][
+                :0
+            ] = env
         else:
             deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"] = env
     return deployment_spec
@@ -197,7 +197,7 @@ def build_job_pod_spec(job_name, cluster_name, namespace, spec, annotations, lab
     ]
     for i in range(len(pod_spec["spec"]["containers"])):
         if "env" in pod_spec["spec"]["containers"][i]:
-            pod_spec["spec"]["containers"][i]["env"].extend(env)
+            pod_spec["spec"]["containers"][i]["env"][:0] = env
         else:
             pod_spec["spec"]["containers"][i]["env"] = env
     return pod_spec


### PR DESCRIPTION
In #836 we see the default scheduler address is overriding the one supplied by the user. This happens because we extend the list of user-supplied env vars with the defaults, which Kubernetes then interprets as overriding.

This PR prepends the defaults instead so that the user-supplied env vars with the same name take precedent.