### PR TITLE
fix duplicate env vars + ability to add custom address for scheduler

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -171,10 +171,8 @@ def build_worker_deployment_spec(
     for i in range(len(deployment_spec["spec"]["template"]["spec"]["containers"])):
         if "env" in deployment_spec["spec"]["template"]["spec"]["containers"][i]:
             existing_env_vars = deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"]
-            _consolidate_env_vars(existing_env_vars, env)
-            deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"].extend(
-                env
-            )
+            all_env_vars = _consolidate_env_vars(existing_env_vars, env)
+            deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"] = all_env_vars
         else:
             deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"] = env
     return deployment_spec
@@ -211,8 +209,8 @@ def build_job_pod_spec(job_name, cluster_name, namespace, spec, annotations, lab
     for i in range(len(pod_spec["spec"]["containers"])):
         if "env" in pod_spec["spec"]["containers"][i]:
             existing_env_vars = deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"]
-            _consolidate_env_vars(existing_env_vars, env)
-            pod_spec["spec"]["containers"][i]["env"].extend(env)
+            all_env_vars = _consolidate_env_vars(existing_env_vars, env)
+            pod_spec["spec"]["containers"][i]["env"] = all_env_vars
         else:
             pod_spec["spec"]["containers"][i]["env"] = env
     return pod_spec

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -64,6 +64,17 @@ def _get_labels(meta):
     }
 
 
+def _consolidate_env_vars(existing_env_vars, additional_env_vars):
+    existing_env_names = {d["name"] for d in existing_env_vars}
+    additional_env_names = {d["name"] for d in additional_env_vars}
+
+    overlapping_env_names = existing_env_names.intersection(additional_env_names)
+
+    additional_env_vars_to_keep = [d for d in additional_env_vars if d["name"] not in overlapping_env_names]
+
+    return [*existing_env_vars, *additional_env_vars_to_keep]
+
+
 def build_scheduler_deployment_spec(
     cluster_name, namespace, pod_spec, annotations, labels
 ):
@@ -159,6 +170,8 @@ def build_worker_deployment_spec(
     ]
     for i in range(len(deployment_spec["spec"]["template"]["spec"]["containers"])):
         if "env" in deployment_spec["spec"]["template"]["spec"]["containers"][i]:
+            existing_env_vars = deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"]
+            _consolidate_env_vars(existing_env_vars, env)
             deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"].extend(
                 env
             )
@@ -197,6 +210,8 @@ def build_job_pod_spec(job_name, cluster_name, namespace, spec, annotations, lab
     ]
     for i in range(len(pod_spec["spec"]["containers"])):
         if "env" in pod_spec["spec"]["containers"][i]:
+            existing_env_vars = deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"]
+            _consolidate_env_vars(existing_env_vars, env)
             pod_spec["spec"]["containers"][i]["env"].extend(env)
         else:
             pod_spec["spec"]["containers"][i]["env"] = env

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from collections import defaultdict
 from contextlib import suppress
+from copy import deepcopy
 from datetime import datetime
 from uuid import uuid4
 
@@ -208,7 +209,7 @@ def build_job_pod_spec(job_name, cluster_name, namespace, spec, annotations, lab
     ]
     for i in range(len(pod_spec["spec"]["containers"])):
         if "env" in pod_spec["spec"]["containers"][i]:
-            existing_env_vars = deployment_spec["spec"]["template"]["spec"]["containers"][i]["env"]
+            existing_env_vars = pod_spec["spec"]["template"]["spec"]["containers"][i]["env"]
             all_env_vars = _consolidate_env_vars(existing_env_vars, env)
             pod_spec["spec"]["containers"][i]["env"] = all_env_vars
         else:
@@ -594,7 +595,7 @@ async def daskworkergroup_replica_update(
                     namespace=namespace,
                     cluster_name=cluster_name,
                     uuid=uuid4().hex[:10],
-                    pod_spec=worker_spec["spec"],
+                    pod_spec=deepcopy(worker_spec["spec"]),
                     annotations=annotations,
                     labels=labels,
                 )


### PR DESCRIPTION
fixes:
- https://github.com/dask/dask-kubernetes/issues/841
- https://github.com/dask/dask-kubernetes/issues/842 which duplicates:
- https://github.com/dask/dask-kubernetes/issues/836
alternative to:
- https://github.com/dask/dask-kubernetes/pull/837

_why this approach_? 
I think it would be good to "prefer" the user set env vars (or env vars set from elsewhere), which is what the addition of `_consolidate_env_vars`  does
