### PR TITLE
Add priorityClassName value to operator deployment

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -35,6 +35,7 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `nodeSelector` | Node selector | `{}` |
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity | `{}` |
+| `priorityClassName` | Priority class | `null` |
 | `kopfArgs` | Command line flags to pass to kopf on start up | `["--all-namespaces"]` |
 | `metrics.scheduler.enabled` | Enable scheduler metrics. Pip package [prometheus-client](https://pypi.org/project/prometheus-client/) should be present on scheduler. | `false` |
 | `metrics.scheduler.serviceMonitor.enabled` | Enable scheduler servicemonitor. | `false` |

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -68,3 +68,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote  }}
+      {{- end }}

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -52,6 +52,8 @@ tolerations: []  # Tolerations
 
 affinity: {}  # Affinity
 
+priorityClassName: null  # Priority class
+
 kopfArgs: # Command line flags to pass to kopf on start up
   - --all-namespaces
 


### PR DESCRIPTION
In https://github.com/dask/dask-kubernetes/issues/684 we were discussing that adding `priorityClassName` might help with configurability of dask kubernetes operator. Especially, settings [priority class](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) to some high priority class might help operator being unable to start after restart because of other resources. Tested manually locally both with `priorityClassName` set and left out.