### PR TITLE
Bump max Kubernetes in CI to 1.29 and minimum to 1.26

### DIFF
--- a/.github/workflows/helmcluster.yaml
+++ b/.github/workflows/helmcluster.yaml
@@ -29,14 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10"]
-        kubernetes-version: ["1.27.0"]
+        kubernetes-version: ["1.29.2"]
         include:
-        - python-version: "3.10"
-          kubernetes-version: "1.24.13"
-        - python-version: "3.10"
-          kubernetes-version: "1.25.9"
-        - python-version: "3.10"
-          kubernetes-version: "1.26.4"
+          - python-version: '3.10'
+            kubernetes-version: 1.28.7
+          - python-version: '3.10'
+            kubernetes-version: 1.27.11
+          - python-version: '3.10'
+            kubernetes-version: 1.26.14
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/.github/workflows/kubecluster.yaml
+++ b/.github/workflows/kubecluster.yaml
@@ -29,14 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10"]
-        kubernetes-version: ["1.27.0"]
+        kubernetes-version: ["1.29.2"]
         include:
-        - python-version: "3.10"
-          kubernetes-version: "1.24.13"
-        - python-version: "3.10"
-          kubernetes-version: "1.25.9"
-        - python-version: "3.10"
-          kubernetes-version: "1.26.4"
+          - python-version: '3.10'
+            kubernetes-version: 1.28.7
+          - python-version: '3.10'
+            kubernetes-version: 1.27.11
+          - python-version: '3.10'
+            kubernetes-version: 1.26.14
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -40,14 +40,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10"]
-        kubernetes-version: ["1.27.3"]
+        kubernetes-version: ["1.29.2"]
         include:
-        - python-version: "3.10"
-          kubernetes-version: "1.24.15"
-        - python-version: "3.10"
-          kubernetes-version: "1.25.11"
-        - python-version: "3.10"
-          kubernetes-version: "1.26.6"
+          - python-version: '3.10'
+            kubernetes-version: 1.28.7
+          - python-version: '3.10'
+            kubernetes-version: 1.27.11
+          - python-version: '3.10'
+            kubernetes-version: 1.26.14
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig


### PR DESCRIPTION
Seeing some CI failures on Kubernetes 1.24 because some charts installed in CI do not support it. Taking the opportunity to upgrade to more recent Kubernetes versions.