### PR TITLE
Add sphinx theme workaround

### DIFF
--- a/doc/requirements-docs.txt
+++ b/doc/requirements-docs.txt
@@ -4,3 +4,13 @@ sphinx-reredirects
 sphinxcontrib-mermaid
 dask-sphinx-theme>=3.0.0
 frigate>=0.7.0
+
+# FIXME: This workaround is required until we have sphinx>=5, as enabled by
+#        dask-sphinx-theme no longer pinning sphinx-book-theme==0.2.0. This is
+#        tracked in https://github.com/dask/dask-sphinx-theme/issues/68.
+#
+sphinxcontrib-applehelp<1.0.5
+sphinxcontrib-devhelp<1.0.6
+sphinxcontrib-htmlhelp<2.0.5
+sphinxcontrib-serializinghtml<1.1.10
+sphinxcontrib-qthelp<1.0.7


### PR DESCRIPTION
Docs builds are failing here. Following the workaround from https://github.com/dask/dask-sphinx-theme/issues/68 for now.