### PR TITLE
Fix: KeyError on Building Scheduler Name in Replica Count Decrease

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -609,7 +609,9 @@ async def daskworkergroup_replica_update(
         if workers_needed < 0:
             worker_ids = await retire_workers(
                 n_workers=-workers_needed,
-                scheduler_service_name=SCHEDULER_NAME_TEMPLATE.format(cluster_name),
+                scheduler_service_name=SCHEDULER_NAME_TEMPLATE.format(
+                    cluster_name=cluster_name
+                ),
                 worker_group_name=name,
                 namespace=namespace,
                 logger=logger,


### PR DESCRIPTION
### Fix

I introduced a bug in https://github.com/dask/dask-kubernetes/pull/871 which will cause decreasing replicas in a worker group to fail on a key error because `format` requires `cluster_name` to be provided with a key.