### PR TITLE
Draft: Introduce typehints in controller

### DIFF
--- a/dask_kubernetes/operator/__init__.py
+++ b/dask_kubernetes/operator/__init__.py
@@ -5,3 +5,11 @@ from .kubecluster import (
     make_worker_spec,
     discover,
 )
+
+__all__ = [
+    "KubeCluster",
+    "make_cluster_spec",
+    "make_scheduler_spec",
+    "make_worker_spec",
+    "discover",
+]

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -40,9 +40,9 @@ _LABEL_NAMESPACES_TO_IGNORE: Final[tuple[str, ...]] = ()
 
 KUBERNETES_DATETIME_FORMAT: Final[str] = "%Y-%m-%dT%H:%M:%SZ"
 
-DASK_AUTOSCALER_COOLDOWN_UNTIL_ANNOTATION: Final[str] = (
-    "kubernetes.dask.org/cooldown-until"
-)
+DASK_AUTOSCALER_COOLDOWN_UNTIL_ANNOTATION: Final[
+    str
+] = "kubernetes.dask.org/cooldown-until"
 
 # Load operator plugins from other packages
 PLUGINS: list[Any] = []

--- a/dask_kubernetes/operator/controller/plugins/noop/noop.py
+++ b/dask_kubernetes/operator/controller/plugins/noop/noop.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 import kopf
 
 
 @kopf.on.startup()
-async def noop_startup(logger, **kwargs):
+async def noop_startup(logger: kopf.Logger, **__: Any) -> None:
     logger.info(
         "Plugin 'noop' running. This does nothing. "
         "See https://kubernetes.dask.org/en/latest/operator_extending.html "

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -1,15 +1,26 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import os.path
 import pathlib
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncContextManager,
+    AsyncIterator,
+    Callable,
+    Final,
+    Iterator,
+)
 
 import dask.config
 import pytest
 import yaml
 from dask.distributed import Client
-from kr8s.asyncio.objects import Deployment, Pod, Service
+from kr8s.asyncio.objects import Deployment, Pod, Service  # type: ignore[import-untyped]
 
 from dask_kubernetes.constants import MAX_CLUSTER_NAME_LEN
 from dask_kubernetes.operator._objects import DaskCluster, DaskJob, DaskWorkerGroup
@@ -18,16 +29,20 @@ from dask_kubernetes.operator.controller import (
     get_job_runner_pod_name,
 )
 
-DIR = pathlib.Path(__file__).parent.absolute()
+if TYPE_CHECKING:
+    from kopf.testing import KopfRunner
+    from pytest_kind.cluster import KindCluster  # type: ignore[import-untyped]
 
-_EXPECTED_ANNOTATIONS = {"test-annotation": "annotation-value"}
-_EXPECTED_LABELS = {"test-label": "label-value"}
-DEFAULT_CLUSTER_NAME = "simple"
+DIR: Final[pathlib.Path] = pathlib.Path(__file__).parent.absolute()
+
+_EXPECTED_ANNOTATIONS: Final[dict[str, str]] = {"test-annotation": "annotation-value"}
+_EXPECTED_LABELS: Final[dict[str, str]] = {"test-label": "label-value"}
+DEFAULT_CLUSTER_NAME: Final[str] = "simple"
 
 
 @pytest.fixture()
-def gen_cluster_manifest(tmp_path):
-    def factory(cluster_name=DEFAULT_CLUSTER_NAME):
+def gen_cluster_manifest(tmp_path: pathlib.Path) -> Callable[..., pathlib.Path]:
+    def factory(cluster_name: str = DEFAULT_CLUSTER_NAME) -> pathlib.Path:
         original_manifest_path = os.path.join(DIR, "resources", "simplecluster.yaml")
         with open(original_manifest_path, "r") as original_manifest_file:
             manifest = yaml.safe_load(original_manifest_file)
@@ -41,52 +56,60 @@ def gen_cluster_manifest(tmp_path):
 
 
 @pytest.fixture()
-def gen_cluster(k8s_cluster, ns, gen_cluster_manifest):
+def gen_cluster(
+    k8s_cluster: KindCluster,
+    namespace: str,
+    gen_cluster_manifest: Callable[..., pathlib.Path],
+) -> Iterator[Callable[..., AsyncContextManager[tuple[str, str]]]]:
     """Yields an instantiated context manager for creating/deleting a simple cluster."""
 
     @asynccontextmanager
-    async def cm(cluster_name=DEFAULT_CLUSTER_NAME):
+    async def cm(
+        cluster_name: str = DEFAULT_CLUSTER_NAME,
+    ) -> AsyncIterator[tuple[str, str]]:
         cluster_path = gen_cluster_manifest(cluster_name)
         # Create cluster resource
-        k8s_cluster.kubectl("apply", "-n", ns, "-f", cluster_path)
+        k8s_cluster.kubectl("apply", "-n", namespace, "-f", str(cluster_path))
         while cluster_name not in k8s_cluster.kubectl(
-            "get", "daskclusters.kubernetes.dask.org", "-n", ns
+            "get", "daskclusters.kubernetes.dask.org", "-n", namespace
         ):
             await asyncio.sleep(0.1)
 
         try:
-            yield cluster_name, ns
+            yield cluster_name, namespace
         finally:
             # Test: remove the wait=True, because I think this is blocking the operator
-            k8s_cluster.kubectl("delete", "-n", ns, "-f", cluster_path)
+            k8s_cluster.kubectl("delete", "-n", namespace, "-f", str(cluster_path))
 
     yield cm
 
 
 @pytest.fixture()
-def gen_job(k8s_cluster, ns):
+def gen_job(
+    k8s_cluster: KindCluster, namespace: str
+) -> Iterator[Callable[[str], AsyncContextManager[tuple[str, str]]]]:
     """Yields an instantiated context manager for creating/deleting a simple job."""
 
     @asynccontextmanager
-    async def cm(job_file):
+    async def cm(job_file: str) -> AsyncIterator[tuple[str, str]]:
         job_path = os.path.join(DIR, "resources", job_file)
         with open(job_path) as f:
             job_name = yaml.load(f, yaml.Loader)["metadata"]["name"]
 
         # Create cluster resource
-        k8s_cluster.kubectl("apply", "-n", ns, "-f", job_path)
+        k8s_cluster.kubectl("apply", "-n", namespace, "-f", job_path)
         while job_name not in k8s_cluster.kubectl(
-            "get", "daskjobs.kubernetes.dask.org", "-n", ns
+            "get", "daskjobs.kubernetes.dask.org", "-n", namespace
         ):
             await asyncio.sleep(0.1)
 
         try:
-            yield job_name, ns
+            yield job_name, namespace
         finally:
             # Test: remove the wait=True, because I think this is blocking the operator
-            k8s_cluster.kubectl("delete", "-n", ns, "-f", job_path)
+            k8s_cluster.kubectl("delete", "-n", namespace, "-f", job_path)
             while job_name in k8s_cluster.kubectl(
-                "get", "daskjobs.kubernetes.dask.org", "-n", ns
+                "get", "daskjobs.kubernetes.dask.org", "-n", namespace
             ):
                 await asyncio.sleep(0.1)
 
@@ -94,42 +117,44 @@ def gen_job(k8s_cluster, ns):
 
 
 @pytest.fixture()
-def gen_worker_group(k8s_cluster, ns):
+def gen_worker_group(
+    k8s_cluster: KindCluster, namespace: str
+) -> Iterator[Callable[[str], AsyncContextManager[tuple[str, str]]]]:
     """Yields an instantiated context manager for creating/deleting a worker group."""
 
     @asynccontextmanager
-    async def cm(worker_group_file):
+    async def cm(worker_group_file: str) -> AsyncIterator[tuple[str, str]]:
         worker_group_path = os.path.join(DIR, "resources", worker_group_file)
         with open(worker_group_path) as f:
             worker_group_name = yaml.load(f, yaml.Loader)["metadata"]["name"]
 
         # Create cluster resource
-        k8s_cluster.kubectl("apply", "-n", ns, "-f", worker_group_path)
+        k8s_cluster.kubectl("apply", "-n", namespace, "-f", worker_group_path)
         while worker_group_name not in k8s_cluster.kubectl(
-            "get", "daskworkergroups.kubernetes.dask.org", "-n", ns
+            "get", "daskworkergroups.kubernetes.dask.org", "-n", namespace
         ):
             await asyncio.sleep(0.1)
 
         try:
-            yield worker_group_name, ns
+            yield worker_group_name, namespace
         finally:
             # Test: remove the wait=True, because I think this is blocking the operator
-            k8s_cluster.kubectl("delete", "-n", ns, "-f", worker_group_path)
+            k8s_cluster.kubectl("delete", "-n", namespace, "-f", worker_group_path)
             while worker_group_name in k8s_cluster.kubectl(
-                "get", "daskworkergroups.kubernetes.dask.org", "-n", ns
+                "get", "daskworkergroups.kubernetes.dask.org", "-n", namespace
             ):
                 await asyncio.sleep(0.1)
 
     yield cm
 
 
-def test_customresources(k8s_cluster):
+def test_customresources(k8s_cluster: KindCluster) -> None:
     assert "daskclusters.kubernetes.dask.org" in k8s_cluster.kubectl("get", "crd")
     assert "daskworkergroups.kubernetes.dask.org" in k8s_cluster.kubectl("get", "crd")
     assert "daskjobs.kubernetes.dask.org" in k8s_cluster.kubectl("get", "crd")
 
 
-def test_operator_runs(kopf_runner):
+def test_operator_runs(kopf_runner: KopfRunner) -> None:
     with kopf_runner as runner:
         pass
 
@@ -137,7 +162,7 @@ def test_operator_runs(kopf_runner):
     assert runner.exception is None
 
 
-def test_operator_plugins(kopf_runner):
+def test_operator_plugins(kopf_runner: KopfRunner) -> None:
     with kopf_runner as runner:
         pass
 
@@ -148,7 +173,11 @@ def test_operator_plugins(kopf_runner):
 
 @pytest.mark.timeout(180)
 @pytest.mark.anyio
-async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
+async def test_simplecluster(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_cluster() as (cluster_name, ns):
             scheduler_deployment_name = "simple-scheduler"
@@ -167,7 +196,7 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
             with k8s_cluster.port_forward(
                 f"service/{service_name}", 8786, "-n", ns
             ) as port:
-                async with Client(
+                async with Client(  # type: ignore[no-untyped-call]
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
                     await client.wait_for_workers(2)
@@ -292,7 +321,11 @@ async def test_simplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
 
 @pytest.mark.anyio
-async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
+async def test_scalesimplecluster(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_cluster() as (cluster_name, ns):
             scheduler_deployment_name = "simple-scheduler"
@@ -310,7 +343,7 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
             with k8s_cluster.port_forward(
                 f"service/{service_name}", 8786, "-n", ns
             ) as port:
-                async with Client(
+                async with Client(  # type: ignore[no-untyped-call]
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
                     k8s_cluster.kubectl(
@@ -338,8 +371,10 @@ async def test_scalesimplecluster(k8s_cluster, kopf_runner, gen_cluster):
 
 @pytest.mark.anyio
 async def test_scalesimplecluster_from_cluster_spec(
-    k8s_cluster, kopf_runner, gen_cluster
-):
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_cluster() as (cluster_name, ns):
             scheduler_deployment_name = "simple-scheduler"
@@ -357,7 +392,7 @@ async def test_scalesimplecluster_from_cluster_spec(
             with k8s_cluster.port_forward(
                 f"service/{service_name}", 8786, "-n", ns
             ) as port:
-                async with Client(
+                async with Client(  # type: ignore[no-untyped-call]
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
                     k8s_cluster.kubectl(
@@ -384,7 +419,11 @@ async def test_scalesimplecluster_from_cluster_spec(
 
 
 @pytest.mark.anyio
-async def test_recreate_scheduler_pod(k8s_cluster, kopf_runner, gen_cluster):
+async def test_recreate_scheduler_pod(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_cluster() as (cluster_name, ns):
             scheduler_deployment_name = "simple-scheduler"
@@ -423,7 +462,11 @@ async def test_recreate_scheduler_pod(k8s_cluster, kopf_runner, gen_cluster):
 
 @pytest.mark.anyio
 @pytest.mark.skip(reason="Flaky in CI")
-async def test_recreate_worker_pods(k8s_cluster, kopf_runner, gen_cluster):
+async def test_recreate_worker_pods(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_cluster() as (cluster_name, ns):
             cluster = await DaskCluster.get(cluster_name, namespace=ns)
@@ -453,8 +496,10 @@ async def test_recreate_worker_pods(k8s_cluster, kopf_runner, gen_cluster):
 
 @pytest.mark.anyio
 async def test_simplecluster_batched_worker_deployments(
-    k8s_cluster, kopf_runner, gen_cluster
-):
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         with dask.config.set(
             {
@@ -480,7 +525,7 @@ async def test_simplecluster_batched_worker_deployments(
                 with k8s_cluster.port_forward(
                     f"service/{service_name}", 8786, "-n", ns
                 ) as port:
-                    async with Client(
+                    async with Client(  # type: ignore[no-untyped-call]
                         f"tcp://localhost:{port}", asynchronous=True
                     ) as client:
                         await client.wait_for_workers(2)
@@ -489,8 +534,8 @@ async def test_simplecluster_batched_worker_deployments(
                         assert (await total) == sum(map(lambda x: x + 1, range(10)))
 
 
-def _get_job_status(k8s_cluster, ns):
-    return json.loads(
+def _get_job_status(k8s_cluster: KindCluster, ns: str) -> dict[str, Any]:
+    return json.loads(  # type: ignore[no-any-return]
         k8s_cluster.kubectl(
             "get",
             "-n",
@@ -502,17 +547,17 @@ def _get_job_status(k8s_cluster, ns):
     )
 
 
-def _assert_job_status_created(job_status):
+def _assert_job_status_created(job_status: dict[str, Any]) -> None:
     assert "jobStatus" in job_status
 
 
-def _assert_job_status_cluster_created(job, job_status):
+def _assert_job_status_cluster_created(job: str, job_status: dict[str, Any]) -> None:
     assert "jobStatus" in job_status
     assert job_status["clusterName"] == job
     assert job_status["jobRunnerPodName"] == get_job_runner_pod_name(job)
 
 
-def _assert_job_status_running(job, job_status):
+def _assert_job_status_running(job: str, job_status: dict[str, Any]) -> None:
     assert "jobStatus" in job_status
     assert job_status["clusterName"] == job
     assert job_status["jobRunnerPodName"] == get_job_runner_pod_name(job)
@@ -520,7 +565,9 @@ def _assert_job_status_running(job, job_status):
     assert datetime.utcnow() > start_time > (datetime.utcnow() - timedelta(seconds=10))
 
 
-def _assert_final_job_status(job, job_status, expected_status):
+def _assert_final_job_status(
+    job: str, job_status: dict[str, Any], expected_status: str
+) -> None:
     assert job_status["jobStatus"] == expected_status
     assert job_status["clusterName"] == job
     assert job_status["jobRunnerPodName"] == get_job_runner_pod_name(job)
@@ -538,7 +585,11 @@ def _assert_final_job_status(job, job_status, expected_status):
 
 
 @pytest.mark.anyio
-async def test_job(k8s_cluster, kopf_runner, gen_job):
+async def test_job(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_job: Callable[[str], AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner as runner:
         async with gen_job("simplejob.yaml") as (job, ns):
             assert job
@@ -609,7 +660,11 @@ async def test_job(k8s_cluster, kopf_runner, gen_job):
 
 
 @pytest.mark.anyio
-async def test_failed_job(k8s_cluster, kopf_runner, gen_job):
+async def test_failed_job(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_job: Callable[[str], AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner as runner:
         async with gen_job("failedjob.yaml") as (job, ns):
             assert job
@@ -667,12 +722,16 @@ async def test_failed_job(k8s_cluster, kopf_runner, gen_job):
 
 
 @pytest.mark.anyio
-async def test_object_dask_cluster(k8s_cluster, kopf_runner, gen_cluster):
+async def test_object_dask_cluster(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_cluster() as (cluster_name, ns):
             cluster = await DaskCluster.get(cluster_name, namespace=ns)
 
-            worker_groups = []
+            worker_groups: list[DaskWorkerGroup] = []
             while not worker_groups:
                 worker_groups = await cluster.worker_groups()
                 await asyncio.sleep(0.1)
@@ -700,8 +759,11 @@ async def test_object_dask_cluster(k8s_cluster, kopf_runner, gen_cluster):
 
 @pytest.mark.anyio
 async def test_object_dask_worker_group(
-    k8s_cluster, kopf_runner, gen_cluster, gen_worker_group
-):
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+    gen_worker_group: Callable[[str], AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with (
             gen_cluster() as (cluster_name, ns),
@@ -715,7 +777,7 @@ async def test_object_dask_worker_group(
                 additional_workergroup_name, namespace=ns
             )
 
-            worker_groups = []
+            worker_groups: list[DaskWorkerGroup] = []
             while not worker_groups:
                 worker_groups = await cluster.worker_groups()
                 await asyncio.sleep(0.1)
@@ -725,13 +787,13 @@ async def test_object_dask_worker_group(
             for wg in worker_groups:
                 assert isinstance(wg, DaskWorkerGroup)
 
-                deployments = []
+                deployments: list[Deployment] = []
                 while not deployments:
                     deployments = await wg.deployments()
                     await asyncio.sleep(0.1)
                 assert all([isinstance(d, Deployment) for d in deployments])
 
-                pods = []
+                pods: list[Pod] = []
                 while not pods:
                     pods = await wg.pods()
                     await asyncio.sleep(0.1)
@@ -756,7 +818,11 @@ async def test_object_dask_worker_group(
 
 @pytest.mark.anyio
 @pytest.mark.skip(reason="Flaky in CI")
-async def test_object_dask_job(k8s_cluster, kopf_runner, gen_job):
+async def test_object_dask_job(
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_job: Callable[[str], AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_job("simplejob.yaml") as (job_name, ns):
             job = await DaskJob.get(job_name, namespace=ns)
@@ -768,13 +834,15 @@ async def test_object_dask_job(k8s_cluster, kopf_runner, gen_job):
             assert isinstance(cluster, DaskCluster)
 
 
-async def _get_cluster_status(k8s_cluster, ns, cluster_name):
+async def _get_cluster_status(
+    k8s_cluster: KindCluster, ns: str, cluster_name: str
+) -> str:
     """
     Will loop infinitely in search of non-falsey cluster status.
     Make sure there is a timeout on any test which calls this.
     """
     while True:
-        cluster_status = k8s_cluster.kubectl(
+        cluster_status: str = k8s_cluster.kubectl(
             "get",
             "-n",
             ns,
@@ -799,8 +867,12 @@ async def _get_cluster_status(k8s_cluster, ns, cluster_name):
     ],
 )
 async def test_create_cluster_validates_name(
-    cluster_name, expected_status, k8s_cluster, kopf_runner, gen_cluster
-):
+    cluster_name: str,
+    expected_status: str,
+    k8s_cluster: KindCluster,
+    kopf_runner: KopfRunner,
+    gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
+) -> None:
     with kopf_runner:
         async with gen_cluster(cluster_name=cluster_name) as (_, ns):
             actual_status = await _get_cluster_status(k8s_cluster, ns, cluster_name)

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -20,7 +20,7 @@ import dask.config
 import pytest
 import yaml
 from dask.distributed import Client
-from kr8s.asyncio.objects import Deployment, Pod, Service  # type: ignore[import-untyped]
+from kr8s.asyncio.objects import Deployment, Pod, Service
 
 from dask_kubernetes.constants import MAX_CLUSTER_NAME_LEN
 from dask_kubernetes.operator._objects import DaskCluster, DaskJob, DaskWorkerGroup
@@ -31,7 +31,7 @@ from dask_kubernetes.operator.controller import (
 
 if TYPE_CHECKING:
     from kopf.testing import KopfRunner
-    from pytest_kind.cluster import KindCluster  # type: ignore[import-untyped]
+    from pytest_kind.cluster import KindCluster
 
 DIR: Final[pathlib.Path] = pathlib.Path(__file__).parent.absolute()
 
@@ -196,7 +196,7 @@ async def test_simplecluster(
             with k8s_cluster.port_forward(
                 f"service/{service_name}", 8786, "-n", ns
             ) as port:
-                async with Client(  # type: ignore[no-untyped-call]
+                async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
                     await client.wait_for_workers(2)
@@ -343,7 +343,7 @@ async def test_scalesimplecluster(
             with k8s_cluster.port_forward(
                 f"service/{service_name}", 8786, "-n", ns
             ) as port:
-                async with Client(  # type: ignore[no-untyped-call]
+                async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
                     k8s_cluster.kubectl(
@@ -392,7 +392,7 @@ async def test_scalesimplecluster_from_cluster_spec(
             with k8s_cluster.port_forward(
                 f"service/{service_name}", 8786, "-n", ns
             ) as port:
-                async with Client(  # type: ignore[no-untyped-call]
+                async with Client(
                     f"tcp://localhost:{port}", asynchronous=True
                 ) as client:
                     k8s_cluster.kubectl(
@@ -525,7 +525,7 @@ async def test_simplecluster_batched_worker_deployments(
                 with k8s_cluster.port_forward(
                     f"service/{service_name}", 8786, "-n", ns
                 ) as port:
-                    async with Client(  # type: ignore[no-untyped-call]
+                    async with Client(
                         f"tcp://localhost:{port}", asynchronous=True
                     ) as client:
                         await client.wait_for_workers(2)

--- a/dask_kubernetes/operator/kubecluster/__init__.py
+++ b/dask_kubernetes/operator/kubecluster/__init__.py
@@ -5,3 +5,11 @@ from .kubecluster import (
     make_worker_spec,
 )
 from .discovery import discover
+
+__all__ = [
+    "KubeCluster",
+    "make_cluster_spec",
+    "make_scheduler_spec",
+    "make_worker_spec",
+    "discover",
+]

--- a/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/tests/test_kubecluster.py
@@ -7,10 +7,10 @@ from dask_kubernetes.exceptions import SchedulerStartupError, ValidationError
 from dask_kubernetes.operator import KubeCluster, make_cluster_spec
 
 
-def test_kubecluster(kopf_runner, docker_image, ns):
+def test_kubecluster(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with KubeCluster(
-            name="cluster", namespace=ns, image=docker_image, n_workers=1
+            name="cluster", namespace=namespace, image=docker_image, n_workers=1
         ) as cluster:
             with Client(cluster) as client:
                 client.scheduler_info()
@@ -18,11 +18,11 @@ def test_kubecluster(kopf_runner, docker_image, ns):
 
 
 @pytest.mark.anyio
-async def test_kubecluster_async(kopf_runner, docker_image, ns):
+async def test_kubecluster_async(kopf_runner, docker_image, namespace):
     with kopf_runner:
         async with KubeCluster(
             name="async",
-            namespace=ns,
+            namespace=namespace,
             image=docker_image,
             n_workers=1,
             asynchronous=True,
@@ -31,55 +31,55 @@ async def test_kubecluster_async(kopf_runner, docker_image, ns):
                 assert await client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_custom_worker_command(kopf_runner, docker_image, ns):
+def test_custom_worker_command(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with KubeCluster(
             name="customworker",
             image=docker_image,
             worker_command=["python", "-m", "distributed.cli.dask_worker"],
             n_workers=1,
-            namespace=ns,
+            namespace=namespace,
         ) as cluster:
             with Client(cluster) as client:
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_multiple_clusters(kopf_runner, docker_image, ns):
+def test_multiple_clusters(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with KubeCluster(
-            name="bar", image=docker_image, n_workers=1, namespace=ns
+            name="bar", image=docker_image, n_workers=1, namespace=namespace
         ) as cluster1:
             with Client(cluster1) as client1:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
         with KubeCluster(
-            name="baz", image=docker_image, n_workers=1, namespace=ns
+            name="baz", image=docker_image, n_workers=1, namespace=namespace
         ) as cluster2:
             with Client(cluster2) as client2:
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_clusters_with_custom_port_forward(kopf_runner, docker_image, ns):
+def test_clusters_with_custom_port_forward(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with KubeCluster(
             name="bar",
             image=docker_image,
             n_workers=1,
             scheduler_forward_port=8888,
-            namespace=ns,
+            namespace=namespace,
         ) as cluster1:
             assert cluster1.forwarded_dashboard_port == "8888"
             with Client(cluster1) as client1:
                 assert client1.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_multiple_clusters_simultaneously(kopf_runner, docker_image, ns):
+def test_multiple_clusters_simultaneously(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with (
             KubeCluster(
-                name="fizz", image=docker_image, n_workers=1, namespace=ns
+                name="fizz", image=docker_image, n_workers=1, namespace=namespace
             ) as cluster1,
             KubeCluster(
-                name="buzz", image=docker_image, n_workers=1, namespace=ns
+                name="buzz", image=docker_image, n_workers=1, namespace=namespace
             ) as cluster2,
         ):
             with Client(cluster1) as client1, Client(cluster2) as client2:
@@ -87,18 +87,20 @@ def test_multiple_clusters_simultaneously(kopf_runner, docker_image, ns):
                 assert client2.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image, ns):
+def test_multiple_clusters_simultaneously_same_loop(
+    kopf_runner, docker_image, namespace
+):
     with kopf_runner:
         with (
             KubeCluster(
-                name="fizz", image=docker_image, n_workers=1, namespace=ns
+                name="fizz", image=docker_image, n_workers=1, namespace=namespace
             ) as cluster1,
             KubeCluster(
                 name="buzz",
                 image=docker_image,
                 loop=cluster1.loop,
                 n_workers=1,
-                namespace=ns,
+                namespace=namespace,
             ) as cluster2,
         ):
             with Client(cluster1) as client1, Client(cluster2) as client2:
@@ -108,27 +110,30 @@ def test_multiple_clusters_simultaneously_same_loop(kopf_runner, docker_image, n
 
 
 @pytest.mark.anyio
-async def test_cluster_from_name(kopf_runner, docker_image, ns):
+async def test_cluster_from_name(kopf_runner, docker_image, namespace):
     with kopf_runner:
         async with KubeCluster(
             name="abc",
-            namespace=ns,
+            namespace=namespace,
             image=docker_image,
             n_workers=1,
             asynchronous=True,
         ) as firstcluster:
             async with KubeCluster.from_name(
-                "abc", namespace=ns, asynchronous=True
+                "abc", namespace=namespace, asynchronous=True
             ) as secondcluster:
                 assert firstcluster == secondcluster
                 firstcluster.scale(2)
                 assert firstcluster.scheduler_info == secondcluster.scheduler_info
 
 
-def test_additional_worker_groups(kopf_runner, docker_image, ns):
+def test_additional_worker_groups(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with KubeCluster(
-            name="additionalgroups", n_workers=1, image=docker_image, namespace=ns
+            name="additionalgroups",
+            n_workers=1,
+            image=docker_image,
+            namespace=namespace,
         ) as cluster:
             cluster.add_worker_group(name="more", n_workers=1)
             with Client(cluster) as client:
@@ -137,18 +142,18 @@ def test_additional_worker_groups(kopf_runner, docker_image, ns):
             cluster.delete_worker_group(name="more")
 
 
-def test_cluster_without_operator(docker_image, ns):
+def test_cluster_without_operator(docker_image, namespace):
     with pytest.raises(TimeoutError, match="is the Dask Operator running"):
         KubeCluster(
             name="noop",
             n_workers=1,
             image=docker_image,
             resource_timeout=1,
-            namespace=ns,
+            namespace=namespace,
         )
 
 
-def test_cluster_crashloopbackoff(kopf_runner, docker_image, ns):
+def test_cluster_crashloopbackoff(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with pytest.raises(SchedulerStartupError, match="Scheduler failed to start"):
             spec = make_cluster_spec(name="crashloopbackoff", n_workers=1)
@@ -157,19 +162,19 @@ def test_cluster_crashloopbackoff(kopf_runner, docker_image, ns):
             ] = "dask-schmeduler"
             KubeCluster(
                 custom_cluster_spec=spec,
-                namespace=ns,
+                namespace=namespace,
                 resource_timeout=1,
                 idle_timeout=2,
             )
 
 
-def test_adapt(kopf_runner, docker_image, ns):
+def test_adapt(kopf_runner, docker_image, namespace):
     with kopf_runner:
         with KubeCluster(
             name="adaptive",
             image=docker_image,
             n_workers=0,
-            namespace=ns,
+            namespace=namespace,
         ) as cluster:
             cluster.adapt(minimum=0, maximum=1)
             with Client(cluster) as client:
@@ -181,17 +186,17 @@ def test_adapt(kopf_runner, docker_image, ns):
             cluster.scale(0)
 
 
-def test_custom_spec(kopf_runner, docker_image, ns):
+def test_custom_spec(kopf_runner, docker_image, namespace):
     with kopf_runner:
         spec = make_cluster_spec("customspec", image=docker_image)
         with KubeCluster(
-            custom_cluster_spec=spec, n_workers=1, namespace=ns
+            custom_cluster_spec=spec, n_workers=1, namespace=namespace
         ) as cluster:
             with Client(cluster) as client:
                 assert client.submit(lambda x: x + 1, 10).result() == 11
 
 
-def test_typo_resource_limits(ns):
+def test_typo_resource_limits(namespace):
     with pytest.raises(ValueError):
         KubeCluster(
             name="foo",
@@ -200,7 +205,7 @@ def test_typo_resource_limits(ns):
                     "CPU": "1",
                 },
             },
-            namespace=ns,
+            namespace=namespace,
         )
 
 
@@ -211,11 +216,11 @@ def test_typo_resource_limits(ns):
         "invalid.chars.in.name",
     ],
 )
-def test_invalid_cluster_name_fails(cluster_name, kopf_runner, docker_image, ns):
+def test_invalid_cluster_name_fails(cluster_name, kopf_runner, docker_image, namespace):
     with kopf_runner:
         with pytest.raises(ValidationError):
             KubeCluster(
                 name=cluster_name,
-                namespace=ns,
+                namespace=namespace,
                 image=docker_image,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,11 @@ addopts = "-v --keep-cluster --durations=10"
 timeout = 60
 timeout_func_only = true
 
+[tool.mypy]
+strict = true
+follow_imports = "silent"
+disable_error_code = ["import-untyped", "no-untyped-call"]
+
 [project.entry-points.dask_cluster_discovery]
 helmcluster = "dask_kubernetes.helm:discover"
 kubecluster = "dask_kubernetes.operator:discover"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,5 @@ git+https://github.com/elemental-lf/k8s-crd-resolver@v0.14.0
 jsonschema==4.17.3
 dask[complete]
 anyio
+mypy
+types-PyYAML


### PR DESCRIPTION
General code quality improvements for the controller part of this repository.

- Make sure exported symbols are correctly set in `__init__.py` with `__all__`.
- Renamed pytest fixture for creating a k8s namespace from `ns` to `namespace` since `ns` is a bit overloaded, especially in `test_controller.py`
- Introduce typehints in `controller.py` and `test_controller.py` to massively improve developer experience (previously, one just really had to guess what functions are for and which types are expected)
- Removed unused function parameters
- Made function headers (i.e. parameter [type] defintion) compatible with what `kopf.on.[create/change/...]' expects
- Introduce mypy (and missing stubs of external packages if available)
- Introduce mypy ignores for (still) untyped parts of the codebase for now