### PR TITLE
Experiment with bumping kr8s version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ kubernetes-asyncio>=12.0.1
 kopf>=1.35.3
 pykube-ng>=22.9.0
 rich>=12.5.1
-kr8s==0.9.0
+kr8s==0.9.2


### PR DESCRIPTION
In #880 I've tried bumping to the latest kr8s, but something is causing the test suite to hang. I can reproduce the hang locally too, but when running tests individually they all pass. When running tests with a debugger they all pass. 

In this PR I'm going to try and gradually bump the version forward to see if I can isolate which release causes the issues.