### PR TITLE
Add Release Drafter CI

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,29 @@
+# These will be overridden by the publish workflow and set to the new tag
+name-template: 'Next Release'
+tag-template: 'next'
+
+# Optionally configure your categories and other templates
+exclude-labels:
+  - dependencies
+categories:
+  - title: 'Enhancements'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'bug'
+  - title: 'Documentation'
+    label: 'documentation'
+  - title: 'Project Hygiene'
+    labels:
+      - hygiene
+      - ci
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+template: |
+  ## Changes
+
+  $CHANGES  

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # Write permission is required to create a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,32 @@
+name: Release Publisher
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish_release:
+    permissions:
+      # Write permission is required to publish a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version env
+        # Use a little bit of bash to extract the tag name from the GitHub ref
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+          # Override the Release name/tag/version with the actual tag name
+          name: ${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
+          # Publish the Release
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,7 +3,7 @@ name: Release Publisher
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*.*.*"
 
 permissions:
   contents: read


### PR DESCRIPTION
Adding Release Drafter to automatically create a GitHub Release with a changelog when a new tag is pushed.

See https://jacobtomlinson.dev/posts/2024/creating-github-releases-automatically-on-tags/ for more info