### PR TITLE
Relax kr8s pin to v0.14.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ kubernetes-asyncio>=12.0.1
 kopf>=1.35.3
 pykube-ng>=22.9.0
 rich>=12.5.1
-kr8s==0.14.2
+kr8s==0.14.*


### PR DESCRIPTION
In `kr8s` version `0.14.3` there was a bug fixed that was reported by a `dask-kubernetes` user. It would be nice if we picked that up automatically. I'm still cautious about unpinning `kr8s` completely until we get to `1.0` with more stability guarantees, but relaxing the `mirco` pin seems reasonable.