### PR TITLE
Fix publish permissions for chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on: [push, pull_request]
 jobs:
   build-distribution:
     runs-on: "ubuntu-latest"
-    permissions:
-      id-token: write
+    permissions: write-all
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Add missing permissions for publishing the helm chart. I manually published `2024.5.0`.