### PR TITLE
Fix: Mismatch between declared CRDs and struct for DaskAutoscalers

### DIFF
--- a/dask_kubernetes/operator/go_client/pkg/apis/kubernetes.dask.org/v1/types.go
+++ b/dask_kubernetes/operator/go_client/pkg/apis/kubernetes.dask.org/v1/types.go
@@ -124,9 +124,9 @@ type DaskAutoscalerSpec struct {
 	// Name of the cluster to associate this autoscaler with
 	Cluster string `json:"cluster"`
 	// Minimum number of workers
-	Minimum string `json:"minimum"`
+	Minimum int `json:"minimum"`
 	// Maximum number of workers
-	Maximum string `json:"maximum"`
+	Maximum int `json:"maximum"`
 }
 
 // +genclient


### PR DESCRIPTION
## Description
This pull request addresses a mismatch identified between the declared Custom Resource Definitions (CRDs) for Kubernetes resources and the `DaskAutoscalerSpec` struct in the Go client.

### Problem
The issue lies with the `minimum` and `maximum` attributes in the `DaskAutoscalerSpec` struct, which were initially declared as `string` types but should be `int`, as declared in the CRDs. This disparity causes issues between the Go client and the registered Kubernetes scheme.

### Solution
I have resolved this bug by altering the `DaskAutoscalerSpec` struct to use `int` for the `max` and `min` attributes, ensuring consistency with the CRD. Subsequently, I ran the code autogeneration script to validate that there are no adverse side-effects from these changes.

Thank you for your consideration.