### PR TITLE
Bump kr8s to 0.17 and Kubernetes supported versions

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -26,14 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        kubernetes-version: ["1.29.2"]
+        kubernetes-version: ["1.30.2"]
         include:
           - python-version: '3.10'
-            kubernetes-version: 1.28.7
+            kubernetes-version: 1.29.4
           - python-version: '3.10'
-            kubernetes-version: 1.27.11
-          - python-version: '3.10'
-            kubernetes-version: 1.26.14
+            kubernetes-version: 1.28.9
 
     env:
       KUBECONFIG: .pytest-kind/pytest-kind/kubeconfig

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Dask Kubernetes
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Python Support
 
-.. image:: https://img.shields.io/badge/Kubernetes%20support-1.26%7C1.27%7C1.28%7C1.29-blue
+.. image:: https://img.shields.io/badge/Kubernetes%20support-1.28%7C1.29%7C1.30-blue
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Kubernetes Support
 

--- a/dask_kubernetes/operator/_objects.py
+++ b/dask_kubernetes/operator/_objects.py
@@ -2,22 +2,15 @@ from __future__ import annotations
 
 from typing import List
 
-from kr8s.asyncio.objects import APIObject, Deployment, Pod, Service
+from kr8s.asyncio.objects import Deployment, Pod, Service, new_class
 
 
-class DaskCluster(APIObject):
-    version = "kubernetes.dask.org/v1"
-    endpoint = "daskclusters"
-    kind = "DaskCluster"
-    plural = "daskclusters"
-    singular = "daskcluster"
-    namespaced = True
+class DaskCluster(new_class("DaskCluster", "kubernetes.dask.org/v1", namespaced=True)):
     scalable = True
     scalable_spec = "worker.replicas"
 
     async def worker_groups(self) -> List[DaskWorkerGroup]:
-        return await self.api.get(
-            DaskWorkerGroup.endpoint,
+        return await DaskWorkerGroup.list(
             label_selector=f"dask.org/cluster-name={self.name}",
             namespace=self.namespace,
         )
@@ -25,8 +18,7 @@ class DaskCluster(APIObject):
     async def scheduler_pod(self) -> Pod:
         pods = []
         while not pods:
-            pods = await self.api.get(
-                Pod.endpoint,
+            pods = await Pod.list(
                 label_selector=",".join(
                     [
                         f"dask.org/cluster-name={self.name}",
@@ -41,8 +33,7 @@ class DaskCluster(APIObject):
     async def scheduler_deployment(self) -> Deployment:
         deployments = []
         while not deployments:
-            deployments = await self.api.get(
-                Deployment.endpoint,
+            deployments = await Deployment.list(
                 label_selector=",".join(
                     [
                         f"dask.org/cluster-name={self.name}",
@@ -57,8 +48,7 @@ class DaskCluster(APIObject):
     async def scheduler_service(self) -> Service:
         services = []
         while not services:
-            services = await self.api.get(
-                Service.endpoint,
+            services = await Service.list(
                 label_selector=",".join(
                     [
                         f"dask.org/cluster-name={self.name}",
@@ -79,7 +69,9 @@ class DaskCluster(APIObject):
         )
 
 
-class DaskWorkerGroup(APIObject):
+class DaskWorkerGroup(
+    new_class("DaskWorkerGroup", "kubernetes.dask.org/v1", namespaced=True)
+):
     version = "kubernetes.dask.org/v1"
     endpoint = "daskworkergroups"
     kind = "DaskWorkerGroup"
@@ -90,8 +82,7 @@ class DaskWorkerGroup(APIObject):
     scalable_spec = "worker.replicas"
 
     async def pods(self) -> List[Pod]:
-        return await self.api.get(
-            Pod.endpoint,
+        return await Pod.list(
             label_selector=",".join(
                 [
                     f"dask.org/cluster-name={self.spec.cluster}",
@@ -103,8 +94,7 @@ class DaskWorkerGroup(APIObject):
         )
 
     async def deployments(self) -> List[Deployment]:
-        return await self.api.get(
-            Deployment.endpoint,
+        return await Deployment.list(
             label_selector=",".join(
                 [
                     f"dask.org/cluster-name={self.spec.cluster}",
@@ -119,7 +109,9 @@ class DaskWorkerGroup(APIObject):
         return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
 
 
-class DaskAutoscaler(APIObject):
+class DaskAutoscaler(
+    new_class("DaskAutoscaler", "kubernetes.dask.org/v1", namespaced=True)
+):
     version = "kubernetes.dask.org/v1"
     endpoint = "daskautoscalers"
     kind = "DaskAutoscaler"
@@ -131,7 +123,7 @@ class DaskAutoscaler(APIObject):
         return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
 
 
-class DaskJob(APIObject):
+class DaskJob(new_class("DaskJob", "kubernetes.dask.org/v1", namespaced=True)):
     version = "kubernetes.dask.org/v1"
     endpoint = "daskjobs"
     kind = "DaskJob"
@@ -145,8 +137,7 @@ class DaskJob(APIObject):
     async def pod(self) -> Pod:
         pods = []
         while not pods:
-            pods = await self.api.get(
-                Pod.endpoint,
+            pods = await Pod.list(
                 label_selector=",".join(
                     [
                         f"dask.org/cluster-name={self.name}",

--- a/dask_kubernetes/operator/_objects.py
+++ b/dask_kubernetes/operator/_objects.py
@@ -5,7 +5,7 @@ from typing import List
 from kr8s.asyncio.objects import Deployment, Pod, Service, new_class
 
 
-class DaskCluster(new_class("DaskCluster", "kubernetes.dask.org/v1", namespaced=True)):
+class DaskCluster(new_class("DaskCluster", "kubernetes.dask.org/v1")):
     scalable = True
     scalable_spec = "worker.replicas"
 
@@ -69,15 +69,7 @@ class DaskCluster(new_class("DaskCluster", "kubernetes.dask.org/v1", namespaced=
         )
 
 
-class DaskWorkerGroup(
-    new_class("DaskWorkerGroup", "kubernetes.dask.org/v1", namespaced=True)
-):
-    version = "kubernetes.dask.org/v1"
-    endpoint = "daskworkergroups"
-    kind = "DaskWorkerGroup"
-    plural = "daskworkergroups"
-    singular = "daskworkergroup"
-    namespaced = True
+class DaskWorkerGroup(new_class("DaskWorkerGroup", "kubernetes.dask.org/v1")):
     scalable = True
     scalable_spec = "worker.replicas"
 
@@ -109,28 +101,12 @@ class DaskWorkerGroup(
         return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
 
 
-class DaskAutoscaler(
-    new_class("DaskAutoscaler", "kubernetes.dask.org/v1", namespaced=True)
-):
-    version = "kubernetes.dask.org/v1"
-    endpoint = "daskautoscalers"
-    kind = "DaskAutoscaler"
-    plural = "daskautoscalers"
-    singular = "daskautoscaler"
-    namespaced = True
-
+class DaskAutoscaler(new_class("DaskAutoscaler", "kubernetes.dask.org/v1")):
     async def cluster(self) -> DaskCluster:
         return await DaskCluster.get(self.spec.cluster, namespace=self.namespace)
 
 
-class DaskJob(new_class("DaskJob", "kubernetes.dask.org/v1", namespaced=True)):
-    version = "kubernetes.dask.org/v1"
-    endpoint = "daskjobs"
-    kind = "DaskJob"
-    plural = "daskjobs"
-    singular = "daskjob"
-    namespaced = True
-
+class DaskJob(new_class("DaskJob", "kubernetes.dask.org/v1")):
     async def cluster(self) -> DaskCluster:
         return await DaskCluster.get(self.name, namespace=self.namespace)
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,7 @@ Dask Kubernetes Operator
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Python Support
 
-.. image:: https://img.shields.io/badge/Kubernetes%20support-1.26%7C1.27%7C1.28%7C1.29-blue
+.. image:: https://img.shields.io/badge/Kubernetes%20support-1.28%7C1.29%7C1.30-blue
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Kubernetes Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "dask>=2022.08.1",
     "distributed>=2022.08.1",
     "kopf>=1.35.3",
-    "kr8s==0.14.*",
+    "kr8s==0.17.*",
     "kubernetes-asyncio>=12.0.1",
     "kubernetes>=12.0.1",
     "pykube-ng>=22.9.0",


### PR DESCRIPTION
In `kr8s==0.17` you can now use `new_class` as part of a class constructor. This avoids the need to manually subclass `APIObject` and should lead to more error free code.

With `kr8s==0.17` only Kubernetes `>=1.28` is supported and I'm noticing some CI failures with Kubernetes `1.26` so taking this opportunity to bump the Kubernetes CI versions.

I've also replaced the use of `api.get(Type.endpoint, ...)` with `Type.list(...)` which is a little more readable.