### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         kubernetes-version: ["1.30.2"]
         include:
           - python-version: '3.10'

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Dask Kubernetes
    :target: https://anaconda.org/conda-forge/dask-kubernetes
    :alt: Conda Forge
 
-.. image:: https://img.shields.io/badge/python%20support-3.9%7C3.10%7C3.11%7C3.12-blue
+.. image:: https://img.shields.io/badge/python%20support-3.10%7C3.11%7C3.12-blue
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Python Support
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Dask Kubernetes Operator
    :target: https://anaconda.org/conda-forge/dask-kubernetes
    :alt: Conda Forge
 
-.. image:: https://img.shields.io/badge/python%20support-3.9%7C3.10%7C3.11%7C3.12-blue
+.. image:: https://img.shields.io/badge/python%20support-3.10%7C3.11%7C3.12-blue
    :target: https://kubernetes.dask.org/en/latest/installing.html#supported-versions
    :alt: Python Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Native Kubernetes integration for Dask"
 readme = "README.rst"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 maintainers = [{ name = "Jacob Tomlinson" }]
 keywords = ["dask", "distributed", "kubernetes"]
 dependencies = [
@@ -88,8 +88,7 @@ line-length = 120
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.8
-target-version = "py39"
+target-version = "py310"
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
Dask has ended Python 3.9 support https://github.com/dask/community/issues/373. Removing it from CI and bumping minimum version.