### PR TITLE
Improve retire_worker fallback by finding deployments name instead of pod name

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -488,7 +488,7 @@ async def retire_workers(
         "This can result in lost data, see https://kubernetes.dask.org/en/latest/operator_troubleshooting.html."
     )
     workers = await kr8s.asyncio.get(
-        "pods",
+        "deployments",
         namespace=namespace,
         label_selector={"dask.org/workergroup-name": worker_group_name},
     )


### PR DESCRIPTION
Fallback to finding deployments rather than worker for deletion, as otherwise the pod can have the incorrect name, leading to workers not scaling down in adaptive mode.

Believe this was part of the issue on https://github.com/dask/dask-kubernetes/issues/910