### PR TITLE
Fix section header typo in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -161,7 +161,7 @@ A ``DaskAutoscaler`` resource will communicate with the scheduler periodically a
 .. toctree::
    :maxdepth: 2
    :hidden:
-   :caption: Getting Syarted
+   :caption: Getting Started
 
    Overview <self>
    installing


### PR DESCRIPTION
I hope you don't mind such a small PR—I noticed a minor typo in a section header in the docs, and thought I'd submit a correction.

Thanks for all you do,
Jacob