### PR TITLE
feat: Add configurable liveness probe timeout

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -36,7 +36,7 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity | `{}` |
 | `priorityClassName` | Priority class | `null` |
-| `livenessProbe.timeoutSeconds` |  | `1` |
+| `livenessProbe.timeoutSeconds` |  | `5` |
 | `kopfArgs` | Command line flags to pass to kopf on start up | `["--all-namespaces"]` |
 | `metrics.scheduler.enabled` | Enable scheduler metrics. Pip package [prometheus-client](https://pypi.org/project/prometheus-client/) should be present on scheduler. | `false` |
 | `metrics.scheduler.serviceMonitor.enabled` | Enable scheduler servicemonitor. | `false` |

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/README.md
@@ -36,6 +36,7 @@ The following table lists the configurable parameters of the Dask-kubernetes-ope
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity | `{}` |
 | `priorityClassName` | Priority class | `null` |
+| `livenessProbe.timeoutSeconds` |  | `1` |
 | `kopfArgs` | Command line flags to pass to kopf on start up | `["--all-namespaces"]` |
 | `metrics.scheduler.enabled` | Enable scheduler metrics. Pip package [prometheus-client](https://pypi.org/project/prometheus-client/) should be present on scheduler. | `false` |
 | `metrics.scheduler.serviceMonitor.enabled` | Enable scheduler servicemonitor. | `false` |

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -52,6 +52,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           volumeMounts:
             {{- toYaml .Values.volumeMounts | nindent 12 }}
       volumes:

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -55,7 +55,7 @@ affinity: {}  # Affinity
 priorityClassName: null  # Priority class
 
 livenessProbe:
-  timeoutSeconds: 1
+  timeoutSeconds: 5
 
 kopfArgs: # Command line flags to pass to kopf on start up
   - --all-namespaces

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -54,6 +54,9 @@ affinity: {}  # Affinity
 
 priorityClassName: null  # Priority class
 
+livenessProbe:
+  timeoutSeconds: 1
+
 kopfArgs: # Command line flags to pass to kopf on start up
   - --all-namespaces
 


### PR DESCRIPTION
Fixes #917

Plain helm install:
```
Liveness:      http-get http://:8080/healthz delay=0s timeout=1s period=10s #success=1 #failure=3
```
With `--set livenessProbe.timeoutSeconds=5`:
```
Liveness:      http-get http://:8080/healthz delay=0s timeout=5s period=10s #success=1 #failure=3
```
