### PR TITLE
🐛 Fix retire_workers LIFO fallback issue.

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -492,7 +492,7 @@ async def retire_workers(
         namespace=namespace,
         label_selector={"dask.org/workergroup-name": worker_group_name},
     )
-    return [w.name for w in workers[:-n_workers]]
+    return [w.name for w in workers[-n_workers:]]
 
 
 async def check_scheduler_idle(

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -492,6 +492,10 @@ async def retire_workers(
         namespace=namespace,
         label_selector={"dask.org/workergroup-name": worker_group_name},
     )
+    return retire_workers_lifo(workers, n_workers)
+
+
+def retire_workers_lifo(workers, n_workers: int) -> list[str]:
     return [w.name for w in workers[-n_workers:]]
 
 


### PR DESCRIPTION
The `retire_workers` method will call the scheduler api `/api/v1/retire_workers` first, if it fails it will try the rpc counterpart, if it fails it will finally simply retire the most recent worker deployments, last in first out.

When the autoscaler changes the number of worker replicas based on the scheduler need, it will automatically trigger this method:

```
@kopf.on.field("daskworkergroup.kubernetes.dask.org", field="spec.worker.replicas")
async def daskworkergroup_replica_update
```

The workers needed are then computed through:

```
workers_needed = desired_workers - current_workers
```

where `desired_workers` is the number of replicas required and `current_workers` is the number of deployed pods.

Let's say that for instance the desired number of replicas is 18 and the current number of workers is 20. Then `workers_needed` will be -2.

In that case we end up in this if:

```
if workers_needed < 0:
    worker_ids = await retire_workers(
        n_workers=-workers_needed,
        scheduler_service_name=SCHEDULER_NAME_TEMPLATE.format(
            cluster_name=cluster_name
        ),
        worker_group_name=name,
        namespace=namespace,
        logger=logger,
    )
```
we can see that a - sign is applied to `workers_needed` when it is passed to `retire_workers`.

So `retire_workers` will receive 2.

Then `retire_workers` will try to call the scheduler endpoint then rpc endpoint and if both fail, the list of workers returned will be:

`return [w.name for w in workers[:-n_workers]]`

and `workers[:-2]` will return the 18 first workers that will be killed, whereas only two should have been.

We detected the issue because when `/api/v1/retire_workers` would return a 500, due to this [issue](https://github.com/dask/distributed/pull/8996) the whole cluster of workers (minus some) would be dropped by kubernetes.