### PR TITLE
Reflect that `env` will set on scheduler too

### DIFF
--- a/dask_kubernetes/operator/kubecluster/kubecluster.py
+++ b/dask_kubernetes/operator/kubecluster/kubecluster.py
@@ -75,7 +75,7 @@ class KubeCluster(Cluster):
         Use ``scale`` to change this number in the future
     resources: Dict[str, str]
     env: List[dict] | Dict[str, str]
-        List of environment variables to pass to worker pod.
+        List of environment variables to set on scheduler and workers.
         Can be a list of dicts using the same structure as k8s envs
         or a single dictionary of key/value pairs
     worker_command: List[str] | str


### PR DESCRIPTION
Minor docs change to reflect that the `env` parameter of `KubeCluster` will set the environment variables on the scheduler (in addition to workers).

See that this is the case [here](https://github.com/dask/dask-kubernetes/blob/30cc719850afb6a5d4482e0df867d2368db000e0/dask_kubernetes/operator/kubecluster/kubecluster.py#L877) in `make_cluster_spec(...)`, that function's doc string is correct. But if you are like me you may only look at the doc string on `KubeCluster` in an LSP annotation / [on the docs](https://kubernetes.dask.org/en/latest/operator_kubecluster.html#api)