### PR TITLE
Skip Job cluster creation if already exists

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,4 +11,4 @@ jobs:
           python-version: "3.10"
       - name: Install deps
         run: ./ci/install-deps.sh
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -781,10 +781,11 @@ async def daskjob_create_components(
     )
     kopf.adopt(cluster_spec)
     cluster = await DaskCluster(cluster_spec, namespace=namespace)
-    await cluster.create()
-    logger.info(
-        f"Cluster {cluster_spec['metadata']['name']} for job {name} created in {namespace}."
-    )
+    if not await cluster.exists():
+        await cluster.create()
+        logger.info(
+            f"Cluster {cluster_spec['metadata']['name']} for job {name} created in {namespace}."
+        )
 
     labels = _get_labels(meta)
     annotations = _get_annotations(meta)
@@ -804,7 +805,8 @@ async def daskjob_create_components(
     )
     kopf.adopt(job_pod_spec)
     job_pod = await Pod(job_pod_spec, namespace=namespace)
-    await job_pod.create()
+    if not await job_pod.exists():
+        await job_pod.create()
     patch.status["clusterName"] = cluster_name
     patch.status["jobStatus"] = "ClusterCreated"
     patch.status["jobRunnerPodName"] = get_job_runner_pod_name(name)


### PR DESCRIPTION
All controller event handlers should be idempotent, however as seen in #940 if the controller is restarted while the job creation handler is being run it will get stuck in a failure loop.

This PR adds some quick checks to skip over resources that already exist.

Closes #940