### PR TITLE
Allow configuring the event emit level

### DIFF
--- a/dask_kubernetes/kubernetes.yaml
+++ b/dask_kubernetes/kubernetes.yaml
@@ -37,6 +37,10 @@ kubernetes:
     worker-allocation:
       batch-size: null
       delay: null
+    # Configure whether logs should be emitted as Kubernetes events and minimum level to emit
+    events:
+      enabled: true
+      level: INFO
 
   # Timeout to wait for the scheduler service to be up (in seconds)
   # Set it to 0 to wait indefinitely (not recommended)

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import logging
 import time
 from collections import defaultdict
 from contextlib import suppress
@@ -294,6 +295,15 @@ async def startup(settings: kopf.OperatorSettings, **__: Any) -> None:
     # The default timeout is 300s which is usually to long
     # https://kopf.readthedocs.io/en/latest/configuration/#networking-timeouts
     settings.networking.request_timeout = 10
+
+    # Configure events
+    event_enabled = dask.config.get("kubernetes.controller.events.enabled", True)
+    settings.posting.enabled = event_enabled
+    event_level = dask.config.get("kubernetes.controller.events.level", "INFO")
+    if isinstance(event_level, str) and hasattr(logging, event_level):
+        event_level = getattr(logging, event_level)
+    if isinstance(event_level, int):
+        settings.posting.level = event_level
 
 
 # There may be useful things for us to expose via the liveness probe


### PR DESCRIPTION
Closes #945 

Allows users to set which log messages get emitted as Kubernetes events. Configurable via the Dask config system which allows setting via a `ConfigMap` or environment variables.

```
DASK_KUBERNETES__CONTROLLER__EVENTS__ENABLED=true
DASK_KUBERNETES__CONTROLLER__EVENTS__LEVEL="INFO"
```