### PR TITLE
Add ability to set additional environment variables on the operator controller

### DIFF
--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
             - name: DASK_KUBERNETES__CONTROLLER__WORKER_ALLOCATION__DELAY
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           args:
             - --liveness=http://0.0.0.0:8080/healthz
           {{- with .Values.kopfArgs }}

--- a/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
+++ b/dask_kubernetes/operator/deployment/helm/dask-kubernetes-operator/values.yaml
@@ -46,6 +46,8 @@ volumes: []  # Volumes for the operator pod
 
 volumeMounts: []  # Volume mounts for the operator container
 
+extraEnv: []  # Extra environment variables for the operator container
+
 nodeSelector: {}  # Node selector
 
 tolerations: []  # Tolerations


### PR DESCRIPTION
Follow on to #946 to enable configuring these options via environment variables too.