### PR TITLE
Fix when scheduler returns a tuple instead of a list

### DIFF
--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -489,6 +489,8 @@ async def retire_workers(
                 attribute="name",
             )
             await scheduler_comm.retire_workers(names=workers_to_close)
+            if isinstance(workers_to_close, tuple):
+                workers_to_close = list(workers_to_close)
             assert isinstance(workers_to_close, list)
             return workers_to_close
 


### PR DESCRIPTION
Closes #950 

Looks like the distributed scheduler has started intermittently returning a tuple instead of a list when calling the `workers_to_close()` RPC method.

There is an assertion in `dask-kubernetes` that was added as part of some type narrowing in #881. This fails when the method returns a tuple. This PR works around this by converting tuples to lists.