### PR TITLE
Update operator Dockerfile to Python 3.12

### DIFF
--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -169,7 +169,7 @@ def test_operator_plugins(kopf_runner: KopfRunner) -> None:
 
     assert runner.exit_code == 0
     assert runner.exception is None
-    assert "Plugin 'noop' running." in runner.stdout
+    assert "Plugin 'noop' running." in runner.output
 
 
 @pytest.mark.timeout(180)
@@ -656,8 +656,8 @@ async def test_job(
             job_status = _get_job_status(k8s_cluster, ns)
             _assert_final_job_status(job, job_status, "Successful")
 
-    assert "A DaskJob has been created" in runner.stdout
-    assert "Job succeeded, deleting Dask cluster." in runner.stdout
+    assert "A DaskJob has been created" in runner.output
+    assert "Job succeeded, deleting Dask cluster." in runner.output
 
 
 @pytest.mark.anyio
@@ -718,8 +718,8 @@ async def test_failed_job(
             job_status = _get_job_status(k8s_cluster, ns)
             _assert_final_job_status(job, job_status, "Failed")
 
-    assert "A DaskJob has been created" in runner.stdout
-    assert "Job failed, deleting Dask cluster." in runner.stdout
+    assert "A DaskJob has been created" in runner.output
+    assert "Job failed, deleting Dask cluster." in runner.output
 
 
 @pytest.mark.anyio

--- a/dask_kubernetes/operator/deployment/Dockerfile
+++ b/dask_kubernetes/operator/deployment/Dockerfile
@@ -1,7 +1,7 @@
 # This images needs to be built from the top level of the project
 # $ docker build -t ghcr.io/dask/dask-kubernetes-operator:latest -f dask_kubernetes/operator/deployment/Dockerfile .
 
-FROM python:3.10 as builder
+FROM python:3.12 as builder
 
 # Copy source
 COPY . /src/dask_kubernetes
@@ -10,7 +10,7 @@ WORKDIR /src/dask_kubernetes
 # Build dask-kubernetes distribution
 RUN pip install hatch && hatch build
 
-FROM python:3.10
+FROM python:3.12
 
 # Copy wheel
 COPY --from=builder /src/dask_kubernetes/dist /src/dask_kubernetes/dist


### PR DESCRIPTION
## Summary
- Bump Python version in operator Dockerfile from 3.10 to 3.12
- Updates both builder and runtime stages

## Motivation
Python 3.12 brings performance improvements and is well-supported by the project (already in CI matrix).

## Test plan
- [ ] CI passes
- [ ] Operator builds successfully with Python 3.12 base image