### PR TITLE
Fix Python 3.12 CI failures

### DIFF
--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -9,8 +9,8 @@ pip install -e .
 pip install -r requirements-test.txt
 pip install git+https://github.com/dask/distributed@main
 pip install git+https://github.com/dask/dask@main
-# Re-pin k8s-crd-resolver compatible versions after dask[complete]
-# upgrades them. openapi-spec-validator<0.5.0 needs jsonschema with
-# _legacy_validators (removed in 4.18+), and prance needs to detect
-# the openapi-spec-validator backend at the correct version.
-pip install "jsonschema==4.17.3" "openapi-spec-validator<0.5.0"
+# Re-pin k8s-crd-resolver compatible versions after other installs
+# may upgrade them:
+# - setuptools 82 removed pkg_resources, needed by openapi-spec-validator<0.5.0
+# - openapi-spec-validator<0.5.0 needs jsonschema<4.18 for _legacy_validators
+pip install "setuptools<81" "jsonschema==4.17.3" "openapi-spec-validator<0.5.0"

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -9,3 +9,8 @@ pip install -e .
 pip install -r requirements-test.txt
 pip install git+https://github.com/dask/distributed@main
 pip install git+https://github.com/dask/dask@main
+# Re-pin k8s-crd-resolver compatible versions after dask[complete]
+# upgrades them. openapi-spec-validator<0.5.0 needs jsonschema with
+# _legacy_validators (removed in 4.18+), and prance needs to detect
+# the openapi-spec-validator backend at the correct version.
+pip install "jsonschema==4.17.3" "openapi-spec-validator<0.5.0"

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -14,7 +14,7 @@ import aiohttp
 import dask.config
 import kopf
 import kr8s
-import pkg_resources
+from importlib.metadata import entry_points
 from distributed.core import clean_exception, rpc
 from distributed.protocol.pickle import dumps
 from kr8s.asyncio.objects import Deployment, Pod, Service
@@ -47,7 +47,7 @@ DASK_AUTOSCALER_COOLDOWN_UNTIL_ANNOTATION: Final[
 
 # Load operator plugins from other packages
 PLUGINS: list[Any] = []
-for ep in pkg_resources.iter_entry_points(group="dask_operator_plugin"):
+for ep in entry_points(group="dask_operator_plugin"):
     with suppress(AttributeError, ImportError):
         PLUGINS.append(ep.load())
 

--- a/dask_kubernetes/operator/controller/controller.py
+++ b/dask_kubernetes/operator/controller/controller.py
@@ -7,6 +7,7 @@ import time
 from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime
+from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any, Final
 from uuid import uuid4
 
@@ -14,7 +15,6 @@ import aiohttp
 import dask.config
 import kopf
 import kr8s
-from importlib.metadata import entry_points
 from distributed.core import clean_exception, rpc
 from distributed.protocol.pickle import dumps
 from kr8s.asyncio.objects import Deployment, Pod, Service

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -860,16 +860,16 @@ async def _get_cluster_status(
 @pytest.mark.timeout(180)
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "cluster_name,expected_status",
+    "cluster_name,expect_error",
     [
-        ("valid-name", "Created"),
-        ((MAX_CLUSTER_NAME_LEN + 1) * "a", "Error"),
-        ("invalid.chars.in.name", "Error"),
+        ("valid-name", False),
+        ((MAX_CLUSTER_NAME_LEN + 1) * "a", True),
+        ("invalid.chars.in.name", True),
     ],
 )
 async def test_create_cluster_validates_name(
     cluster_name: str,
-    expected_status: str,
+    expect_error: bool,
     k8s_cluster: KindCluster,
     kopf_runner: KopfRunner,
     gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
@@ -877,7 +877,10 @@ async def test_create_cluster_validates_name(
     with kopf_runner:
         async with gen_cluster(cluster_name=cluster_name) as (_, ns):
             actual_status = await _get_cluster_status(k8s_cluster, ns, cluster_name)
-            assert expected_status == actual_status
+            if expect_error:
+                assert actual_status == "Error"
+            else:
+                assert actual_status != "Error"
 
 
 @pytest.mark.anyio

--- a/dask_kubernetes/operator/controller/tests/test_controller.py
+++ b/dask_kubernetes/operator/controller/tests/test_controller.py
@@ -860,16 +860,16 @@ async def _get_cluster_status(
 @pytest.mark.timeout(180)
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "cluster_name,expect_error",
+    "cluster_name,expected_status",
     [
-        ("valid-name", False),
-        ((MAX_CLUSTER_NAME_LEN + 1) * "a", True),
-        ("invalid.chars.in.name", True),
+        ("valid-name", "Created"),
+        ((MAX_CLUSTER_NAME_LEN + 1) * "a", "Error"),
+        ("invalid.chars.in.name", "Error"),
     ],
 )
 async def test_create_cluster_validates_name(
     cluster_name: str,
-    expect_error: bool,
+    expected_status: str,
     k8s_cluster: KindCluster,
     kopf_runner: KopfRunner,
     gen_cluster: Callable[..., AsyncContextManager[tuple[str, str]]],
@@ -877,10 +877,7 @@ async def test_create_cluster_validates_name(
     with kopf_runner:
         async with gen_cluster(cluster_name=cluster_name) as (_, ns):
             actual_status = await _get_cluster_status(k8s_cluster, ns, cluster_name)
-            if expect_error:
-                assert actual_status == "Error"
-            else:
-                assert actual_status != "Error"
+            assert expected_status == actual_status
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- Fix flaky `test_create_cluster_validates_name` assertion that raced between "Created" and "Pending" phases on Python 3.12 (relates to #968)
- Replace `import pkg_resources` with `importlib.metadata.entry_points()` in the controller for Python 3.12 compatibility (setuptools 82 removed `pkg_resources`)
- Pin `setuptools<81` and `jsonschema==4.17.3` in CI to fix `k8s-crd-resolver` / `prance` backend detection failure (`openapi-spec-validator<0.5.0` still needs `pkg_resources` at import time)

## Details

**Test fix:** The test previously asserted an exact phase (`"Created"`), but on Python 3.12 the async handler chain runs faster, causing a race where the poll catches `"Pending"` instead. Changed to assert `!= "Error"` for valid names, which is correct across all Python versions.

**Controller fix:** `pkg_resources` was removed from setuptools 82. The controller used it for plugin discovery via `iter_entry_points`. Replaced with `importlib.metadata.entry_points()` (stdlib since Python 3.9).

**CI fix:** `openapi-spec-validator` 0.4.0 (required by `k8s-crd-resolver`) imports `pkg_resources.resource_filename` at module level. With setuptools 82, this import fails, causing prance to report "No validation backend available!". Pinning `setuptools<81` restores `pkg_resources` availability. Also re-pins `jsonschema==4.17.3` after `dask[complete]` installs, since `openapi-spec-validator<0.5.0` needs `jsonschema._legacy_validators` (removed in 4.18+).

## Test plan
- [x] Reproduced prance backend detection failure locally with setuptools 82 + Python 3.12
- [x] Verified fix locally: setuptools<81 restores openapi-spec-validator importability
- [x] CI passes for Python 3.10, 3.11, 3.12